### PR TITLE
fully implicit 1d advection example; as heat1d, builds a FD matrix of or...

### DIFF
--- a/examples/advection/ProblemClass.py
+++ b/examples/advection/ProblemClass.py
@@ -1,0 +1,129 @@
+from __future__ import division
+import numpy as np
+import scipy.sparse as sp
+import scipy.sparse.linalg as LA
+
+from pySDC.Problem import ptype
+from pySDC.datatype_classes.mesh import mesh, rhs_imex_mesh
+
+from getFDMatrix import getFDMatrix
+
+class advection(ptype):
+    """
+    Example implementing the forced 1D heat equation with Dirichlet-0 BC in [0,1]
+
+    Attributes:
+        A: second-order FD discretization of the 1D laplace operator
+        dx: distance between two spatial nodes
+    """
+
+    def __init__(self, cparams, dtype_u, dtype_f):
+        """
+        Initialization routine
+
+        Args:
+            cparams: custom parameters for the example
+            dtype_u: particle data type (will be passed parent class)
+            dtype_f: acceleration data type (will be passed parent class)
+        """
+
+        # these parameters will be used later, so assert their existence
+        assert 'nvars' in cparams
+        assert 'c' in cparams
+        assert 'order' in cparams
+        
+        # add parameters as attributes for further reference
+        for k,v in cparams.items():
+            setattr(self,k,v)
+
+        # invoke super init, passing number of dofs, dtype_u and dtype_f
+        super(advection,self).__init__(self.nvars,dtype_u,dtype_f)
+
+        # compute dx and get discretization matrix A
+        self.mesh = np.linspace(0, 1, num=self.nvars, endpoint=False)
+        self.dx   = self.mesh[1] - self.mesh[0]
+        self.A    = getFDMatrix(self.nvars, self.order, self.dx)
+    
+    def solve_system(self,rhs,factor,u0):
+        """
+        Simple linear solver for (I-dtA)u = rhs
+
+        Args:
+            rhs: right-hand side for the nonlinear system
+            factor: abbrev. for the node-to-node stepsize (or any other factor required)
+            u0: initial guess for the iterative solver (not used here so far)
+
+        Returns:
+            solution as mesh
+        """
+
+        me = mesh(self.nvars)
+        me.values = LA.spsolve(sp.eye(self.nvars)-factor*self.A,rhs.values)
+        return me
+
+
+    def __eval_fexpl(self,u,t):
+        """
+        Helper routine to evaluate the explicit part of the RHS
+
+        Args:
+            u: current values (not used here)
+            t: current time
+
+        Returns:
+            explicit part of RHS
+        """
+
+        fexpl        = mesh(self.nvars)
+        fexpl.values = 0.0*self.mesh
+        return fexpl
+
+    def __eval_fimpl(self,u,t):
+        """
+        Helper routine to evaluate the implicit part of the RHS
+
+        Args:
+            u: current values
+            t: current time (not used here)
+
+        Returns:
+            implicit part of RHS
+        """
+
+        fimpl        = mesh(self.nvars)
+        fimpl.values = self.A.dot(u.values)
+        return fimpl
+
+
+    def eval_f(self,u,t):
+        """
+        Routine to evaluate both parts of the RHS
+
+        Args:
+            u: current values
+            t: current time
+
+        Returns:
+            the RHS divided into two parts
+        """
+
+        f = rhs_imex_mesh(self.nvars)
+        f.impl = self.__eval_fimpl(u,t)
+        f.expl = self.__eval_fexpl(u,t)
+        return f
+
+
+    def u_exact(self,t):
+        """
+        Routine to compute the exact solution at time t
+
+        Args:
+            t: current time
+
+        Returns:
+            exact solution
+        """
+
+        me = mesh(self.nvars)
+        me.values = np.cos(2.0*np.pi*(self.mesh-self.c*t))
+        return me

--- a/examples/advection/TransferClass.py
+++ b/examples/advection/TransferClass.py
@@ -1,0 +1,118 @@
+from __future__ import division
+import numpy as np
+
+from pySDC.Transfer import transfer
+from pySDC.datatype_classes.mesh import mesh, rhs_imex_mesh
+
+# FIXME: extend this to ndarrays
+class mesh_to_mesh_1d(transfer):
+    """
+    Custon transfer class, implements Transfer.py
+
+    This implementation can restrict and prolong between 1d meshes, using weigthed restriction and 7th-order prologation
+    via matrix-vector multiplication.
+
+    Attributes:
+        fine: reference to the fine level
+        coarse: reference to the coarse level
+        init_f: number of variables on the fine level (whatever init represents there)
+        init_c: number of variables on the coarse level (whatever init represents there)
+        Rspace: spatial restriction matrix, dim. Nf x Nc
+        Pspace: spatial prolongation matrix, dim. Nc x Nf
+    """
+
+    def __init__(self,fine_level,coarse_level):
+        """
+        Initialization routine
+
+        Args:
+            fine_level: fine level connected with the transfer operations (passed to parent)
+            coarse_level: coarse level connected with the transfer operations (passed to parent)
+        """
+
+        # invoke super initialization
+        super(mesh_to_mesh_1d,self).__init__(fine_level,coarse_level)
+
+        # if number of variables is the same on both levels, Rspace and Pspace are identity
+        if self.init_c == self.init_f:
+            self.Rspace = np.eye(self.init_c)
+        # assemble weighted restriction by hand
+        else:
+            self.Rspace = np.zeros((self.init_f,self.init_c))
+            np.fill_diagonal(self.Rspace[1::2,:],1)
+            np.fill_diagonal(self.Rspace[0::2,:],1/2)
+            np.fill_diagonal(self.Rspace[2::2,:],1/2)
+            self.Rspace = 1/2*self.Rspace.T
+
+        # if number of variables is the same on both levels, Rspace and Pspace are identity
+        if self.init_f == self.init_c:
+            self.Pspace = np.eye(self.init_f)
+        # assemble 7th-order prolongation by hand
+        else:
+            self.Pspace = np.zeros((self.init_f,self.init_c))
+
+            np.fill_diagonal(self.Pspace[1::2,:],1)
+
+            np.fill_diagonal(self.Pspace[0::2,:],1/2)
+            np.fill_diagonal(self.Pspace[2::2,:],1/2)
+
+            # this would be 3rd-order accurate
+            # c1 = -0.0625
+            # c2 = 0.5625
+            # c3 = c2
+            # c4 = c1
+            # np.fill_diagonal(self.Pspace[0::2,:],c3)
+            # np.fill_diagonal(self.Pspace[2::2,:],c2)
+            # np.fill_diagonal(self.Pspace[0::2,1:],c4)
+            # np.fill_diagonal(self.Pspace[4::2,:],c1)
+            # self.Pspace[0,0:3] = [0.9375, -0.3125, 0.0625]
+            # self.Pspace[-1,-3:init_c] = [0.0625, -0.3125, 0.9375]
+
+            np.fill_diagonal(self.Pspace[0::2,:],0.5859375)
+            np.fill_diagonal(self.Pspace[2::2,:],0.5859375)
+            np.fill_diagonal(self.Pspace[0::2,1:],-0.09765625)
+            np.fill_diagonal(self.Pspace[4::2,:],-0.09765625)
+            np.fill_diagonal(self.Pspace[0::2,2:],0.01171875)
+            np.fill_diagonal(self.Pspace[6::2,:],0.01171875)
+            self.Pspace[0,0:5] = [1.23046875, -0.8203125, 0.4921875, -0.17578125, 0.02734375]
+            self.Pspace[2,0:5] = [0.41015625, 0.8203125, -0.2734375, 0.08203125, -0.01171875]
+            self.Pspace[-1,-5:self.init_c] = [0.02734375,  -0.17578125, 0.4921875, -0.8203125, 1.23046875]
+            self.Pspace[-3,-5:self.init_c] = [-0.01171875, 0.08203125, -0.2734375, 0.8203125, 0.41015625]
+
+        pass
+
+    def restrict_space(self,F):
+        """
+        Restriction implementation
+
+        Args:
+            F: the fine level data (easier to access than via the fine attribute)
+        """
+
+        if isinstance(F,mesh):
+            u_coarse = mesh(self.init_c,val=0)
+            u_coarse.values = np.dot(self.Rspace,F.values)
+        elif isinstance(F,rhs_imex_mesh):
+            u_coarse = rhs_imex_mesh(self.init_c)
+            u_coarse.impl.values = np.dot(self.Rspace,F.impl.values)
+            u_coarse.expl.values = np.dot(self.Rspace,F.expl.values)
+
+        return u_coarse
+
+    def prolong_space(self,G):
+        """
+        Prolongation implementation
+
+        Args:
+            G: the coarse level data (easier to access than via the coarse attribute)
+        """
+
+        if isinstance(G,mesh):
+            u_fine = mesh(self.init_c,val=0)
+            u_fine.values = np.dot(self.Pspace,G.values)
+        elif isinstance(G,rhs_imex_mesh):
+            u_fine = rhs_imex_mesh(self.init_c)
+            u_fine.impl.values = np.dot(self.Pspace,G.impl.values)
+            u_fine.expl.values = np.dot(self.Pspace,G.expl.values)
+
+        return u_fine

--- a/examples/advection/getFDMatrix.py
+++ b/examples/advection/getFDMatrix.py
@@ -1,0 +1,46 @@
+import numpy as np
+import scipy.sparse as sp
+import scipy.sparse.linalg as LA
+
+def getFDMatrix(N, p, dx):
+
+  if (p==2):
+    stencil = [-0.5, 0.0, 0.5]
+    range   = [-1,0,1]
+  elif (p==4):
+    stencil = [1.0/12.0, -2.0/3.0, 0.0, 2.0/3.0, -1.0/12.0]
+    range  = [-2,-1,0,1,2]
+  elif (p==6):
+    stencil = [-1.0/60.0, 3.0/20.0, -3.0/4.0, 0.0, 3.0/4.0, -3.0/20.0, 1.0/60.0]
+    range = [-3,-2,-1,0,1,2,3]
+  else:
+    print ("Do not have order %1i implemented." % p)
+
+  A = sp.diags(stencil, range, shape=(N,N))
+  A = sp.lil_matrix(A)
+  # Now insert periodic BC manually.. I am sure there is a cleverer way to do this ... but meh, can't be bothered to find out
+  if (p==2):
+    A[0,N-1] = stencil[0]
+    A[N-1,0] = stencil[2]
+  elif (p==4):
+    A[0,N-2] = stencil[0]
+    A[0,N-1] = stencil[1]
+    A[1,N-1] = stencil[0]
+    A[N-2,0] = stencil[4]
+    A[N-1,0] = stencil[3]
+    A[N-1,1] = stencil[4]
+  elif (p==6):
+    A[0,N-3] = stencil[0]
+    A[0,N-2] = stencil[1]
+    A[0,N-1] = stencil[2]
+    A[1,N-2] = stencil[0]
+    A[1,N-1] = stencil[1]
+    A[2,N-1] = stencil[0]
+    A[N-3,0] = stencil[6]
+    A[N-2,0] = stencil[5]
+    A[N-2,1] = stencil[6]
+    A[N-1,0] = stencil[4]
+    A[N-1,1] = stencil[5]
+    A[N-1,2] = stencil[6]
+  A *= (1.0/dx)
+  return sp.csr_matrix(A)

--- a/examples/advection/playground.py
+++ b/examples/advection/playground.py
@@ -1,0 +1,74 @@
+
+from pySDC import CollocationClasses as collclass
+
+import numpy as np
+
+from examples.advection.ProblemClass import advection
+from examples.advection.TransferClass import mesh_to_mesh_1d
+from pySDC.datatype_classes.mesh import mesh, rhs_imex_mesh
+from pySDC.sweeper_classes.imex_1st_order import imex_1st_order
+import pySDC.Methods as mp
+from pySDC import Log
+from pySDC.Stats import grep_stats, sort_stats
+
+if __name__ == "__main__":
+
+    # set global logger (remove this if you do not want the output at all)
+    logger = Log.setup_custom_logger('root')
+
+    num_procs = 1
+
+    # This comes as read-in for the level class
+    lparams = {}
+    lparams['restol'] = 1E-15
+
+    sparams = {}
+    sparams['maxiter'] = 25
+
+    # This comes as read-in for the problem class
+    pparams = {}
+    pparams['c'] = 1.0
+    pparams['nvars'] = [511]
+    pparams['order'] = 6
+
+    # This comes as read-in for the transfer operations
+    tparams = {}
+    tparams['finter'] = True
+
+    # Fill description dictionary for easy hierarchy creation
+    description = {}
+    description['problem_class'] = advection
+    description['problem_params'] = pparams
+    description['dtype_u'] = mesh
+    description['dtype_f'] = rhs_imex_mesh
+    description['collocation_class'] = collclass.CollGaussLegendre
+    description['num_nodes'] = 5
+    description['sweeper_class'] = imex_1st_order
+    description['level_params'] = lparams
+    #description['transfer_class'] = mesh_to_mesh_1d
+    #description['transfer_params'] = tparams
+
+    # quickly generate block of steps
+    MS = mp.generate_steps(num_procs,sparams,description)
+
+    # setup parameters "in time"
+    t0 = 0
+    dt = 0.125
+    Tend = 4*dt
+
+    # get initial values on finest level
+    P = MS[0].levels[0].prob
+    uinit = P.u_exact(t0)
+
+    # call main function to get things done...
+    uend,stats = mp.run_pfasst_serial(MS,u0=uinit,t0=t0,dt=dt,Tend=Tend)
+
+    # compute exact solution and compare
+    uex = P.u_exact(Tend)
+
+    print('error at time %s: %s' %(Tend,np.linalg.norm(uex.values-uend.values,np.inf)/np.linalg.norm(
+        uex.values,np.inf)))
+
+    extract_stats = grep_stats(stats,iter=-1,type='residual')
+    sortedlist_stats = sort_stats(extract_stats,sortby='step')
+    print(extract_stats,sortedlist_stats)

--- a/examples/advection/testFDOrder.py
+++ b/examples/advection/testFDOrder.py
@@ -1,0 +1,47 @@
+import numpy as np
+from getFDMatrix import getFDMatrix
+import numpy.linalg as LA
+import math
+from matplotlib import pyplot as plt
+
+def u_function(x):
+  u = np.zeros(np.size(x))
+  for i in range(0,np.size(x)):
+    u[i] = math.cos(2.0*math.pi*x[i])
+  return u
+
+def u_x_function(x):
+  u = np.zeros(np.size(x))
+  for i in range(0,np.size(x)):
+    u[i] = -2.0*math.pi*math.sin(2.0*math.pi*x[i])
+  return u
+
+p = [2, 4, 6]
+Nv = [10, 25, 50, 75, 100, 125, 150]
+
+error = np.zeros([np.size(p),np.size(Nv)])
+orderline = np.zeros([np.size(p),np.size(Nv)])
+
+for j in range(0,np.size(Nv)):
+  x = np.linspace(0, 1, num=Nv[j], endpoint=False)
+  dx = x[1]-x[0]
+  for i in range(0,np.size(p)):
+    A = getFDMatrix(Nv[j],p[i], dx)
+    u = u_function(x)
+    u_x_fd = A.dot(u)
+    u_x_ex = u_x_function(x)
+    error[i,j] = LA.norm(u_x_fd - u_x_ex, np.inf)/LA.norm(u_x_ex, np.inf)
+    orderline[i,j] = (float(Nv[0])/float(Nv[j]))**p[i]*error[i,0]
+
+fig = plt.figure(figsize=(8,8))
+plt.loglog(Nv, error[0,:], 'o', label='p=2', markersize=12, color='b')
+plt.loglog(Nv, orderline[0,:], color='b')
+plt.loglog(Nv, error[1,:], 'o', label='p=4', markersize=12, color='r')
+plt.loglog(Nv, orderline[1,:], color='r')
+plt.loglog(Nv, error[2,:], 'o', label='p=6', markersize=12, color='g')
+plt.loglog(Nv, orderline[2,:], color='g')
+plt.legend()
+plt.xlim([Nv[0], Nv[np.size(Nv)-1]])
+plt.xlabel(r'$N_x$')
+plt.ylabel('Relative error')
+plt.show()


### PR DESCRIPTION
Adds a new example: Fully implicit 1D advection based on a sparse FD matrix of order p=2,4,6. These matrices will later provide the implicit part of the FWSW examples, but at the moment work as standalone.