### PR TITLE
fixed sign of matrix in advection example

### DIFF
--- a/examples/advection/ProblemClass.py
+++ b/examples/advection/ProblemClass.py
@@ -44,7 +44,7 @@ class advection(ptype):
         # compute dx and get discretization matrix A
         self.mesh = np.linspace(0, 1, num=self.nvars, endpoint=False)
         self.dx   = self.mesh[1] - self.mesh[0]
-        self.A    = getFDMatrix(self.nvars, self.order, self.dx)
+        self.A    = -getFDMatrix(self.nvars, self.order, self.dx)
     
     def solve_system(self,rhs,factor,u0):
         """

--- a/examples/advection/playground.py
+++ b/examples/advection/playground.py
@@ -53,8 +53,8 @@ if __name__ == "__main__":
 
     # setup parameters "in time"
     t0 = 0.0
-    dt = 0.125
-    Tend = 4*dt
+    dt = 0.05
+    Tend = 5*dt
 
     # get initial values on finest level
     P = MS[0].levels[0].prob


### PR DESCRIPTION
Changed the sign of the A matrix in the advection example from + to -: The PDE is

u_t + u_x = 0

If A is the approximation of d_x, the semi-discrete version is

u_t + A u = 0

so that the IVP form that SDC is based on reads

u_t = -A u.