### PR TITLE
added counter for required GMRES iterations in boussinesq example

### DIFF
--- a/examples/boussinesq_2d_imex/ProblemClass.py
+++ b/examples/boussinesq_2d_imex/ProblemClass.py
@@ -8,6 +8,32 @@ from build2DFDMatrix import get2DMesh
 from buildBoussinesq2DMatrix import getBoussinesq2DMatrix, getBoussinesqBCHorizontal, getBoussinesqBCVertical, getBoussinesq2DUpwindMatrix
 from unflatten import unflatten
 
+class logging(object):
+
+  def __init__(self):
+    self.solver_calls = 0
+    self.iterations   = 0
+    
+  def add(self, iterations):
+    self.solver_calls += 1
+    self.iterations   += iterations
+    
+class Callback(object):
+
+    def getresidual(self):
+      return self.residual
+      
+    def getcounter(self):
+      return self.counter
+      
+    def __init__(self):
+      self.counter=0
+      self.residual=0.0
+      
+    def __call__(self, residuals):
+      self.counter+=1
+      self.residual=residuals
+
 
 class boussinesq_2d_imex(ptype):
     """
@@ -54,6 +80,8 @@ class boussinesq_2d_imex(ptype):
         self.Id, self.M = getBoussinesq2DMatrix(self.N, self.h, self.bc_hor, self.bc_ver, self.c_s, self.Nfreq)
         self.D_upwind   = getBoussinesq2DUpwindMatrix( self.N, self.h[0], self.u_adv )
     
+        self.logger = logging()
+    
     def solve_system(self,rhs,factor,u0,t):
         """
         Simple linear solver for (I-dtA)u = rhs
@@ -69,7 +97,10 @@ class boussinesq_2d_imex(ptype):
         """
 
         b         = rhs.values.flatten()
-        sol, info =  LA.gmres( self.Id - factor*self.M, b, x0=u0.values.flatten(), tol=1e-13, restart=10, maxiter=20)
+        cb        = Callback()
+        sol, info = LA.gmres( self.Id - factor*self.M, b, x0=u0.values.flatten(), tol=1e-13, restart=10, maxiter=500, callback=cb)
+        print "Number of GMRES iterations: %3i --- Final residual: %6.3e" % ( cb.getcounter(), cb.getresidual() )
+        self.logger.add(cb.getcounter())
         me        = mesh(self.nvars)
         me.values = unflatten(sol, 4, self.N[0], self.N[1])
 
@@ -159,3 +190,8 @@ class boussinesq_2d_imex(ptype):
         me.values[2,:,:] = dtheta*np.sin( np.pi*self.zz/H )/( 1.0 + np.square(self.xx - x_c)/(a*a))
         me.values[3,:,:] = 0.0*self.xx
         return me
+        
+    def report_log(self):
+      print "Number of calls to implicit solver: %5i" % self.logger.solver_calls
+      print "Total number of iterations: %5i" % self.logger.iterations
+      print "Average number of iterations per call: %6.3f" % (float(self.logger.iterations)/float(self.logger.solver_calls))

--- a/examples/boussinesq_2d_imex/ProblemClass.py
+++ b/examples/boussinesq_2d_imex/ProblemClass.py
@@ -99,8 +99,10 @@ class boussinesq_2d_imex(ptype):
         b         = rhs.values.flatten()
         cb        = Callback()
         sol, info = LA.gmres( self.Id - factor*self.M, b, x0=u0.values.flatten(), tol=1e-13, restart=10, maxiter=500, callback=cb)
-        print "Number of GMRES iterations: %3i --- Final residual: %6.3e" % ( cb.getcounter(), cb.getresidual() )
-        self.logger.add(cb.getcounter())
+        # If this is a dummy call with factor==0.0, do not log because it should not be counted as a solver call
+        if factor!=0.0:
+          print "Number of GMRES iterations: %3i --- Final residual: %6.3e" % ( cb.getcounter(), cb.getresidual() )
+          self.logger.add(cb.getcounter())
         me        = mesh(self.nvars)
         me.values = unflatten(sol, 4, self.N[0], self.N[1])
 

--- a/examples/boussinesq_2d_imex/playground.py
+++ b/examples/boussinesq_2d_imex/playground.py
@@ -28,15 +28,15 @@ if __name__ == "__main__":
 
     # This comes as read-in for the level class
     lparams = {}
-    lparams['restol'] = 3E-11
+    lparams['restol'] = 1E-12
 
     sparams = {}
-    sparams['maxiter'] = 8
+    sparams['maxiter'] = 1
 
     # setup parameters "in time"
     t0     = 0
-    Tend   = 3000
-    Nsteps =  600
+    Tend   = 30
+    Nsteps =  6
     dt = Tend/float(Nsteps)
 
     # This comes as read-in for the problem class
@@ -81,6 +81,8 @@ if __name__ == "__main__":
 
     print('error at time %s: %9.5e' %(Tend,np.linalg.norm(uex.values[2,:,:].flatten()-uend.values[2,:,:].flatten(),np.inf)/np.linalg.norm(
         uex.values.flatten(),np.inf)))
+    
+    P.report_log()
 
     plt.show()
 


### PR DESCRIPTION
- adds a logging and callback object definition to the ProblemClass of the boussinesq example
- the callback object is used in SciPy GMRES to track the number of required iterations and the residual
- the logging object tracks the total number of iterations over the whole integration

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/parallel-in-time/pysdc/24)
<!-- Reviewable:end -->
