### PR TITLE
basic two-level hierarchy for boussinesq now running

### DIFF
--- a/examples/boussinesq_2d_imex/ProblemClass.py
+++ b/examples/boussinesq_2d_imex/ProblemClass.py
@@ -62,6 +62,7 @@ class boussinesq_2d_imex(ptype):
         assert 'Nfreq' in cparams
         assert 'x_bounds' in cparams
         assert 'z_bounds' in cparams
+        assert 'order' in cparams
         
         # add parameters as attributes for further reference
         for k,v in cparams.items():
@@ -77,8 +78,8 @@ class boussinesq_2d_imex(ptype):
 
         self.xx, self.zz, self.h = get2DMesh(self.N, self.x_bounds, self.z_bounds, self.bc_hor[0], self.bc_ver[0])
        
-        self.Id, self.M = getBoussinesq2DMatrix(self.N, self.h, self.bc_hor, self.bc_ver, self.c_s, self.Nfreq)
-        self.D_upwind   = getBoussinesq2DUpwindMatrix( self.N, self.h[0], self.u_adv )
+        self.Id, self.M = getBoussinesq2DMatrix(self.N, self.h, self.bc_hor, self.bc_ver, self.c_s, self.Nfreq, self.order)
+        self.D_upwind   = getBoussinesq2DUpwindMatrix( self.N, self.h[0], self.u_adv , self.order)
     
         self.logger = logging()
     

--- a/examples/boussinesq_2d_imex/buildBoussinesq2DMatrix.py
+++ b/examples/boussinesq_2d_imex/buildBoussinesq2DMatrix.py
@@ -2,7 +2,7 @@ import numpy as np
 import scipy.sparse as sp
 from build2DFDMatrix import get2DMatrix, getBCHorizontal, getBCVertical, get2DUpwindMatrix
 
-def getBoussinesq2DUpwindMatrix(N, dx, u_adv):
+def getBoussinesq2DUpwindMatrix(N, dx, u_adv, order):
 
   Dx   = get2DUpwindMatrix(N, dx)
   
@@ -18,7 +18,7 @@ def getBoussinesq2DUpwindMatrix(N, dx, u_adv):
   
   return sp.csc_matrix(M)
   
-def getBoussinesq2DMatrix(N, h, bc_hor, bc_ver, c_s, Nfreq):
+def getBoussinesq2DMatrix(N, h, bc_hor, bc_ver, c_s, Nfreq, order):
   Dx_u, Dz_u = get2DMatrix(N, h, bc_hor[0], bc_ver[0])
   Dx_w, Dz_w = get2DMatrix(N, h, bc_hor[1], bc_ver[1])
   Dx_b, Dz_b = get2DMatrix(N, h, bc_hor[2], bc_ver[2])

--- a/examples/boussinesq_2d_imex/playground.py
+++ b/examples/boussinesq_2d_imex/playground.py
@@ -4,7 +4,7 @@ from pySDC import CollocationClasses as collclass
 import numpy as np
 
 from ProblemClass import boussinesq_2d_imex
-#from examples.sharpclaw_burgers1d.TransferClass import mesh_to_mesh_1d
+from examples.boussinesq_2d_imex.TransferClass import mesh_to_mesh_2d
 from examples.boussinesq_2d_imex.HookClass import plot_solution
 
 from pySDC.datatype_classes.mesh import mesh, rhs_imex_mesh
@@ -29,28 +29,34 @@ if __name__ == "__main__":
     # This comes as read-in for the level class
     lparams = {}
     lparams['restol'] = 1E-12
+    
+    swparams = {}
+    swparams['collocation_class'] = collclass.CollGaussLobatto
+    swparams['num_nodes'] = 3
+    swparams['do_LU'] = True
 
     sparams = {}
-    sparams['maxiter'] = 1
+    sparams['maxiter'] = 2
 
     # setup parameters "in time"
     t0     = 0
-    Tend   = 30
-    Nsteps =  6
+    Tend   = 3
+    Nsteps =  1
     dt = Tend/float(Nsteps)
 
     # This comes as read-in for the problem class
     pparams = {}
-    pparams['nvars']    = [(4,600,20)]
+    pparams['nvars']    = [(4,300,10)]
     pparams['u_adv']    = 0.02
     pparams['c_s']      = 0.3
     pparams['Nfreq']    = 0.01
     pparams['x_bounds'] = [(-150.0, 150.0)]
     pparams['z_bounds'] = [(   0.0,  10.0)]
+    pparams['order']    = [0, 0] # [fine_level, coarse_level]
 
     # This comes as read-in for the transfer operations
-    #tparams = {}
-    #tparams['finter'] = False
+    tparams = {}
+    tparams['finter'] = False
 
     # Fill description dictionary for easy hierarchy creation
     description = {}
@@ -58,13 +64,12 @@ if __name__ == "__main__":
     description['problem_params']    = pparams
     description['dtype_u']           = mesh
     description['dtype_f']           = rhs_imex_mesh
-    description['collocation_class'] = collclass.CollGaussLobatto
-    description['num_nodes']         = 2
+    description['sweeper_params']    = swparams
     description['sweeper_class']     = imex_1st_order
     description['level_params']      = lparams
     description['hook_class']        = plot_solution
-    #description['transfer_class'] = mesh_to_mesh_1d
-    #description['transfer_params'] = tparams
+    description['transfer_class']    = mesh_to_mesh_2d
+    description['transfer_params']   = tparams
 
     # quickly generate block of steps
     MS = mp.generate_steps(num_procs,sparams,description)


### PR DESCRIPTION
Adds a basic two level hierarchy for the boussinesq example. At the moment, coarse and fine level use the same discretization.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/parallel-in-time/pysdc/25)
<!-- Reviewable:end -->
