### PR TITLE
test_imexsweeper

### DIFF
--- a/examples/SWFW/ProblemClass.py
+++ b/examples/SWFW/ProblemClass.py
@@ -59,7 +59,7 @@ class swfw_scalar(ptype):
         me = mesh(self.nvars)
         for i in range(self.lambda_s.size):
             for j in range(self.lambda_f.size):
-               me.values[i,j] = rhs.values[i,j]/(1-factor*self.lambda_f[j])
+               me.values[i,j] = rhs.values[i,j]/(1.0-factor*self.lambda_f[j])
 
         return me
 
@@ -130,7 +130,7 @@ class swfw_scalar(ptype):
         Returns:
             exact solution
         """
-
+        
         me = mesh(self.nvars)
         for i in range(self.lambda_s.size):
             for j in range(self.lambda_f.size):

--- a/tests/test_imexsweeper.py
+++ b/tests/test_imexsweeper.py
@@ -135,7 +135,7 @@ class TestImexSweeper(unittest.TestCase):
     level.sweep.compute_end_point()
     uend_sweep = level.uend.values
     # Compute end value from matrix formulation
-    uend_mat   = u0.values + step.status.dt*level.sweep.coll.weights.dot(ustages*(problem.lambda_s[0] + problem.lambda_f[0]))
+    uend_mat   = self.pparams['u0'] + step.status.dt*level.sweep.coll.weights.dot(ustages*(problem.lambda_s[0] + problem.lambda_f[0]))
     assert np.linalg.norm(uend_sweep - uend_mat, np.infty)<1e-14, "Update formula in sweeper gives different result than matrix update formula"
 
   #

--- a/tests/test_imexsweeper.py
+++ b/tests/test_imexsweeper.py
@@ -14,7 +14,38 @@ import numpy as np
 class TestImexSweeper(unittest.TestCase):
 
   #
+  # Some auxiliary functions which are not tests themselves
   #
+  def setupLevelStepProblem(self):
+    step = stepclass.step(params={})
+    L = lvl.level(problem_class=swfw_scalar, problem_params=self.pparams, dtype_u=mesh, dtype_f=rhs_imex_mesh, sweeper_class=imex, sweeper_params=self.swparams, level_params={}, hook_class=hookclass.hooks, id="imextest")
+    step.register_level(L)
+    step.status.dt   = 1.0
+    step.status.time = 0.0
+    u0 = step.levels[0].prob.u_exact(step.status.time)
+    step.init_step(u0)
+    nnodes  = step.levels[0].sweep.coll.num_nodes
+    level   = step.levels[0]
+    problem = level.prob
+    return step, level, problem, nnodes
+  
+  def setupQMatrices(self, level):
+    QE = level.sweep.QE[1:,1:]
+    QI = level.sweep.QI[1:,1:]
+    Q  = level.sweep.coll.Qmat[1:,1:]
+    return QE, QI, Q
+
+  def setupSweeperMatrices(self, step, level, problem):
+    nnodes  = step.levels[0].sweep.coll.num_nodes
+    # Build SDC sweep matrix
+    QE, QI, Q = self.setupQMatrices(level)
+    dt = step.status.dt
+    LHS = np.eye(nnodes) - step.status.dt*( problem.lambda_f[0]*QI + problem.lambda_s[0]*QE )
+    RHS = step.status.dt*( (problem.lambda_f[0]+problem.lambda_s[0])*Q - (problem.lambda_f[0]*QI + problem.lambda_s[0]*QE) )
+    return LHS, RHS
+
+  #
+  # General setUp function used by all tests
   #
   def setUp(self):
     self.pparams = {}
@@ -25,104 +56,86 @@ class TestImexSweeper(unittest.TestCase):
     self.swparams['collocation_class'] = collclass.CollGaussLobatto
     self.swparams['num_nodes'] = 2
 
+  # ***************
+  # **** TESTS ****
+  # ***************
+
+
   #
-  #
+  # Check that a level object can be instantiated
   #
   def test_caninstantiate(self):
     L = lvl.level(problem_class=swfw_scalar, problem_params=self.pparams, dtype_u=mesh, dtype_f=rhs_imex_mesh, sweeper_class=imex, sweeper_params=self.swparams, level_params={}, hook_class=hookclass.hooks, id="imextest")
+    assert isinstance(L.sweep, imex), "sweeper in generated level is not an object of type imex"
 
   #
-  #
+  # Check that a level object can be registered in a step object (needed as prerequiste to execute update_nodes
   #
   def test_canregisterlevel(self):
     step = stepclass.step(params={})
     L = lvl.level(problem_class=swfw_scalar, problem_params=self.pparams, dtype_u=mesh, dtype_f=rhs_imex_mesh, sweeper_class=imex, sweeper_params=self.swparams, level_params={}, hook_class=hookclass.hooks, id="imextest")
     step.register_level(L)
+    # At this point, it should not be possible to actually execute functions of the sweeper because the parameters set in setupLevelStepProblem are not yet initialised
+    with self.assertRaises(Exception):
+      step.sweep.predict()
+    with self.assertRaises(Exception):
+      step.sweep.update_nodes()
+    with self.assertRaises(Exception):
+      step.sweep.compute_end_point()
 
   #
-  #
+  # Check that the sweeper functions update_nodes and compute_end_point can be executed
   #
   def test_canrunsweep(self):
 
-    step = stepclass.step(params={})
-    L = lvl.level(problem_class=swfw_scalar, problem_params=self.pparams, dtype_u=mesh, dtype_f=rhs_imex_mesh, sweeper_class=imex, sweeper_params=self.swparams, level_params={}, hook_class=hookclass.hooks, id="imextest")
-    step.register_level(L)
-    step.status.dt   = 1.0
-    step.status.time = 0.0
-    nnodes  = step.levels[0].sweep.coll.num_nodes
-    u0 = step.levels[0].prob.u_exact(step.status.time)
-    step.init_step(u0)
-    step.levels[0].sweep.predict()
-    u0full = np.array([ step.levels[0].u[l].values.flatten() for l in range(1,nnodes+1) ])
-
-    step.levels[0].sweep.update_nodes()
-    assert step.levels[0].uend is None, "uend should be None previous to running compute_end_point"
-    step.levels[0].sweep.compute_end_point()
-    #print "Sweep: %s" % step.levels[0].uend.values
+    # After running setupLevelStepProblem, the functions predict, update_nodes and compute_end_point should run
+    step, level, problem, nnodes = self.setupLevelStepProblem()   
+    assert level.u[0] is not None, "After init_step, level.u[0] should no longer be of type None" 
+    assert level.u[1] is None, "Before predict, level.u[1] and following should be of type None"
+    level.sweep.predict()
+    # Should now be able to run update nodes
+    level.sweep.update_nodes()
+    assert level.uend is None, "uend should be None previous to running compute_end_point"
+    level.sweep.compute_end_point()
+    assert level.uend is not None, "uend still None after running compute_end_point"
 
   #
   # Make sure a sweep in matrix form is equal to a sweep in node-to-node form
   #
   def test_sweepequalmatrix(self):
 
-    step = stepclass.step(params={})
-    L = lvl.level(problem_class=swfw_scalar, problem_params=self.pparams, dtype_u=mesh, dtype_f=rhs_imex_mesh, sweeper_class=imex, sweeper_params=self.swparams, level_params={}, hook_class=hookclass.hooks, id="imextest")
-    step.register_level(L)
-    step.status.dt   = 1.0
-    step.status.time = 0.0
-    nnodes  = step.levels[0].sweep.coll.num_nodes
-    u0 = step.levels[0].prob.u_exact(step.status.time)
-    step.init_step(u0)
+    step, level, problem, nnodes = self.setupLevelStepProblem()
     step.levels[0].sweep.predict()
-    u0full = np.array([ step.levels[0].u[l].values.flatten() for l in range(1,nnodes+1) ])
+    u0full = np.array([ level.u[l].values.flatten() for l in range(1,nnodes+1) ])
 
     # Perform node-to-node SDC sweep
-    step.levels[0].sweep.update_nodes()
+    level.sweep.update_nodes()
 
-    # Build SDC sweep matrix
-    level   = step.levels[0]
-    problem = level.prob
-    QE = level.sweep.QE[1:,1:]
-    QI = level.sweep.QI[1:,1:]
-    Q  = level.sweep.coll.Qmat[1:,1:]
-    dt = step.status.dt
-    LHS = np.eye(nnodes) - step.status.dt*( problem.lambda_f[0]*QI + problem.lambda_s[0]*QE )
-    RHS = step.status.dt*( (problem.lambda_f[0]+problem.lambda_s[0])*Q - (problem.lambda_f[0]*QI + problem.lambda_s[0]*QE) )
+    LHS, RHS = self.setupSweeperMatrices(step, level, problem)
+
     unew = np.linalg.inv(LHS).dot( u0full + RHS.dot(u0full) )
     usweep = np.array([ level.u[l].values.flatten() for l in range(1,nnodes+1) ])
     assert np.linalg.norm(unew - usweep, np.infty)<1e-14, "Single SDC sweeps in matrix and node-to-node formulation yield different results"        
 
   #
-  #
+  # Make sure the implemented update formula matches the matrix update formula
   #
   @unittest.skip("Needs fix of isse #52 before passing")
   def test_updateformula(self):
 
-    step = stepclass.step(params={})
-    L = lvl.level(problem_class=swfw_scalar, problem_params=self.pparams, dtype_u=mesh, dtype_f=rhs_imex_mesh, sweeper_class=imex, sweeper_params=self.swparams, level_params={}, hook_class=hookclass.hooks, id="imextest")
-    step.register_level(L)
-    step.status.dt   = 1.0
-    step.status.time = 0.0
-    nnodes  = step.levels[0].sweep.coll.num_nodes
-    u0 = step.levels[0].prob.u_exact(step.status.time)
-    step.init_step(u0)
-    step.levels[0].sweep.predict()
-    u0full = np.array([ step.levels[0].u[l].values.flatten() for l in range(1,nnodes+1) ])
-
-    # Build SDC sweep matrix
-    level   = step.levels[0]
-    problem = level.prob
-    QE = level.sweep.QE[1:,1:]
-    QI = level.sweep.QI[1:,1:]
-    Q  = level.sweep.coll.Qmat[1:,1:]
+    step, level, problem, nnodes = self.setupLevelStepProblem()
+    level.sweep.predict()
+    u0full = np.array([ level.u[l].values.flatten() for l in range(1,nnodes+1) ])
 
     # Perform update step in sweeper
-    step.levels[0].sweep.update_nodes()
-    ustages = np.array([ step.levels[0].u[l].values.flatten() for l in range(1,nnodes+1) ])
+    level.sweep.update_nodes()
+    ustages = np.array([ level.u[l].values.flatten() for l in range(1,nnodes+1) ])
 
-    step.levels[0].sweep.compute_end_point()
-    uend_sweep = step.levels[0].uend.values
-    uend_mat   = u0.values + step.status.dt*step.levels[0].sweep.coll.weights.dot(ustages*(problem.lambda_s[0] + problem.lambda_f[0]))
+    # Compute end value through provided function
+    level.sweep.compute_end_point()
+    uend_sweep = level.uend.values
+    # Compute end value from matrix formulation
+    uend_mat   = u0.values + step.status.dt*level.sweep.coll.weights.dot(ustages*(problem.lambda_s[0] + problem.lambda_f[0]))
     assert np.linalg.norm(uend_sweep - uend_mat, np.infty)<1e-14, "Update formula in sweeper gives different result than matrix update formula"
 
   #
@@ -130,55 +143,42 @@ class TestImexSweeper(unittest.TestCase):
   #
   def test_collocationinvariant(self):
 
-    step = stepclass.step(params={})
-    L = lvl.level(problem_class=swfw_scalar, problem_params=self.pparams, dtype_u=mesh, dtype_f=rhs_imex_mesh, sweeper_class=imex, sweeper_params=self.swparams, level_params={}, hook_class=hookclass.hooks, id="imextest")
-    step.register_level(L)
-    step.status.dt   = 1.0
-    step.status.time = 0.0
-    nnodes  = step.levels[0].sweep.coll.num_nodes
-    u0 = step.levels[0].prob.u_exact(step.status.time)
-    step.init_step(u0)
-    step.levels[0].sweep.predict()
-    u0full = np.array([ step.levels[0].u[l].values.flatten() for l in range(1,nnodes+1) ])
-
-    # Build SDC sweep matrix
-    level   = step.levels[0]
-    problem = level.prob
-    QE = level.sweep.QE[1:,1:]
-    QI = level.sweep.QI[1:,1:]
-    Q  = level.sweep.coll.Qmat[1:,1:]
+    step, level, problem, nnodes = self.setupLevelStepProblem()
+    level.sweep.predict()
+    u0full = np.array([ level.u[l].values.flatten() for l in range(1,nnodes+1) ])
     
+    QE, QI, Q = self.setupQMatrices(level)
+
+    # Build collocation matrix
     Mcoll = np.eye(nnodes) - step.status.dt*Q*(problem.lambda_s[0] + problem.lambda_f[0])
+
+    # Solve collocation problem directly
     ucoll = np.linalg.inv(Mcoll).dot(u0full)
+    
+    # Put stages of collocation solution into level
     for l in range(0,nnodes):
-      step.levels[0].u[l+1].values = ucoll[l]
-      step.levels[0].f[l+1].impl.values = problem.lambda_f[0]*ucoll[l]
-      step.levels[0].f[l+1].expl.values = problem.lambda_s[0]*ucoll[l]
+      level.u[l+1].values = ucoll[l]
+      level.f[l+1].impl.values = problem.lambda_f[0]*ucoll[l]
+      level.f[l+1].expl.values = problem.lambda_s[0]*ucoll[l]
 
     # Perform node-to-node SDC sweep
-    step.levels[0].sweep.update_nodes()
+    level.sweep.update_nodes()
 
+    # Build matrices for matrix formulation of sweep
     LHS = np.eye(nnodes) - step.status.dt*( problem.lambda_f[0]*QI + problem.lambda_s[0]*QE )
     RHS = step.status.dt*( (problem.lambda_f[0]+problem.lambda_s[0])*Q - (problem.lambda_f[0]*QI + problem.lambda_s[0]*QE) )
+    # Make sure both matrix and node-to-node sweep leave collocation unaltered
     unew = np.linalg.inv(LHS).dot( u0full + RHS.dot(ucoll) )
     assert np.linalg.norm( unew - ucoll, np.infty )<1e-14, "Collocation solution not invariant under matrix SDC sweep"
-    unew_sweep = np.array([ step.levels[0].u[l].values.flatten() for l in range(1,nnodes+1) ])
+    unew_sweep = np.array([ level.u[l].values.flatten() for l in range(1,nnodes+1) ])
     assert np.linalg.norm( unew_sweep - ucoll, np.infty )<1e-14, "Collocation solution not invariant under node-to-node sweep"
 
   #
   #
   #
   def test_canrunmatrixsweep(self):
-    step = stepclass.step(params={})
-    L = lvl.level(problem_class=swfw_scalar, problem_params=self.pparams, dtype_u=mesh, dtype_f=rhs_imex_mesh, sweeper_class=imex, sweeper_params=self.swparams, level_params={}, hook_class=hookclass.hooks, id="imextest")
-    step.register_level(L)
-    step.status.dt   = 1.0
-    step.status.time = 0.0
-    u0 = step.levels[0].prob.u_exact(step.status.time)
-    step.init_step(u0)
-    nnodes  = step.levels[0].sweep.coll.num_nodes
-    level   = step.levels[0]
-    problem = level.prob
+    step, level, problem, nnodes = self.setupLevelStepProblem()
+
     QE = level.sweep.QE[1:,1:]
     QI = level.sweep.QI[1:,1:]
     Q  = level.sweep.coll.Qmat[1:,1:]
@@ -204,3 +204,5 @@ class TestImexSweeper(unittest.TestCase):
     #print ufull
     #uend   = u0.values + step.status.dt*level.sweep.coll.weights.dot( (problem.lambda_f[0]+problem.lambda_s[0])*ufull )
     #print "Matrix: %s" % uend
+
+

--- a/tests/test_imexsweeper.py
+++ b/tests/test_imexsweeper.py
@@ -54,7 +54,7 @@ class TestImexSweeper(unittest.TestCase):
     self.pparams['u0'] = np.random.rand()
     self.swparams = {}
     self.swparams['collocation_class'] = collclass.CollGaussLobatto
-    self.swparams['num_nodes'] = 2
+    self.swparams['num_nodes'] = 2+np.random.randint(5)
 
   # ***************
   # **** TESTS ****

--- a/tests/test_imexsweeper.py
+++ b/tests/test_imexsweeper.py
@@ -95,6 +95,7 @@ class TestImexSweeper(unittest.TestCase):
   #
   #
   #
+  @unittest.skip("Needs fix of isse #52 before passing")
   def test_updateformula(self):
 
     step = stepclass.step(params={})

--- a/tests/test_imexsweeper.py
+++ b/tests/test_imexsweeper.py
@@ -217,7 +217,7 @@ class TestImexSweeper(unittest.TestCase):
     u0full = np.array([ level.u[l].values.flatten() for l in range(1,nnodes+1) ])
 
     # Perform K node-to-node SDC sweep
-    K = 1 + np.random.randint(4)
+    K = 1 + np.random.randint(6)
     for i in range(0,K):
       level.sweep.update_nodes()
     # Fetch final value
@@ -232,5 +232,6 @@ class TestImexSweeper(unittest.TestCase):
       Mat_sweep = Mat_sweep + np.linalg.matrix_power(Pinv.dot(RHS),i).dot(Pinv)
     # Now build update function
     update = 1.0 + (problem.lambda_s[0] + problem.lambda_f[0])*level.sweep.coll.weights.dot(Mat_sweep.dot(np.ones(nnodes)))
+    # Multiply u0 by value of update function to get end value directly
     uend_matrix = update*self.pparams['u0']
     assert abs(uend_matrix - uend_sweep)<1e-14, "Node-to-node sweep plus update yields different result than update function computed through K-sweep matrix"

--- a/tests/test_imexsweeper.py
+++ b/tests/test_imexsweeper.py
@@ -51,7 +51,7 @@ class TestImexSweeper(unittest.TestCase):
     self.pparams = {}
     self.pparams['lambda_s'] = np.array([-0.1*1j], dtype='complex')
     self.pparams['lambda_f'] = np.array([-1.0*1j], dtype='complex')
-    self.pparams['u0'] = 1.0
+    self.pparams['u0'] = np.random.rand()
     self.swparams = {}
     self.swparams['collocation_class'] = collclass.CollGaussLobatto
     self.swparams['num_nodes'] = 2
@@ -120,7 +120,7 @@ class TestImexSweeper(unittest.TestCase):
   #
   # Make sure the implemented update formula matches the matrix update formula
   #
-  @unittest.skip("Needs fix of isse #52 before passing")
+  @unittest.skip("Needs fix of issue #52 before passing")
   def test_updateformula(self):
 
     step, level, problem, nnodes = self.setupLevelStepProblem()
@@ -206,7 +206,7 @@ class TestImexSweeper(unittest.TestCase):
   #
   # Make sure that update function for K sweeps computed from K-sweep matrix gives same result as K sweeps in node-to-node form plus compute_end_point
   #
-  @unittest.skip("Needs fix of isse #52 before passing")
+  @unittest.skip("Needs fix of issue #52 before passing")
   def test_maysweepupdate(self):
     step, level, problem, nnodes = self.setupLevelStepProblem()
     step.levels[0].sweep.predict()

--- a/tests/test_imexsweeper.py
+++ b/tests/test_imexsweeper.py
@@ -60,7 +60,6 @@ class TestImexSweeper(unittest.TestCase):
   # **** TESTS ****
   # ***************
 
-
   #
   # Check that a level object can be instantiated
   #
@@ -120,8 +119,10 @@ class TestImexSweeper(unittest.TestCase):
   #
   # Make sure the implemented update formula matches the matrix update formula
   #
-  @unittest.skip("Needs fix of issue #52 before passing")
   def test_updateformula(self):
+
+    if (self.swparams['collocation_class']==collclass.CollGaussLobatto):
+      raise unittest.SkipTest("Needs fix of issue #52 before passing for Gauss Lobatto nodes")
 
     step, level, problem, nnodes = self.setupLevelStepProblem()
     level.sweep.predict()
@@ -206,8 +207,11 @@ class TestImexSweeper(unittest.TestCase):
   #
   # Make sure that update function for K sweeps computed from K-sweep matrix gives same result as K sweeps in node-to-node form plus compute_end_point
   #
-  @unittest.skip("Needs fix of issue #52 before passing")
   def test_maysweepupdate(self):
+
+    if (self.swparams['collocation_class']==collclass.CollGaussLobatto):
+      raise unittest.SkipTest("Needs fix of issue #52 before passing for Gauss Lobatto nodes")
+
     step, level, problem, nnodes = self.setupLevelStepProblem()
     step.levels[0].sweep.predict()
     u0full = np.array([ level.u[l].values.flatten() for l in range(1,nnodes+1) ])

--- a/tests/test_imexsweeper.py
+++ b/tests/test_imexsweeper.py
@@ -1,0 +1,205 @@
+from pySDC import Level as lvl
+from pySDC import Hooks as hookclass
+from pySDC import CollocationClasses as collclass
+from pySDC import Step as stepclass
+
+from pySDC.datatype_classes.complex_mesh import mesh, rhs_imex_mesh
+from pySDC.sweeper_classes.imex_1st_order import imex_1st_order as imex
+from examples.SWFW.ProblemClass import swfw_scalar 
+
+from nose.tools import *
+import unittest
+import numpy as np
+
+class TestImexSweeper(unittest.TestCase):
+
+  #
+  #
+  #
+  def setUp(self):
+    self.pparams = {}
+    self.pparams['lambda_s'] = np.array([-0.1*1j], dtype='complex')
+    self.pparams['lambda_f'] = np.array([-1.0*1j], dtype='complex')
+    self.pparams['u0'] = 1.0
+    self.swparams = {}
+    self.swparams['collocation_class'] = collclass.CollGaussLobatto
+    self.swparams['num_nodes'] = 2
+
+  #
+  #
+  #
+  def test_caninstantiate(self):
+    L = lvl.level(problem_class=swfw_scalar, problem_params=self.pparams, dtype_u=mesh, dtype_f=rhs_imex_mesh, sweeper_class=imex, sweeper_params=self.swparams, level_params={}, hook_class=hookclass.hooks, id="imextest")
+
+  #
+  #
+  #
+  def test_canregisterlevel(self):
+    step = stepclass.step(params={})
+    L = lvl.level(problem_class=swfw_scalar, problem_params=self.pparams, dtype_u=mesh, dtype_f=rhs_imex_mesh, sweeper_class=imex, sweeper_params=self.swparams, level_params={}, hook_class=hookclass.hooks, id="imextest")
+    step.register_level(L)
+
+  #
+  #
+  #
+  def test_canrunsweep(self):
+
+    step = stepclass.step(params={})
+    L = lvl.level(problem_class=swfw_scalar, problem_params=self.pparams, dtype_u=mesh, dtype_f=rhs_imex_mesh, sweeper_class=imex, sweeper_params=self.swparams, level_params={}, hook_class=hookclass.hooks, id="imextest")
+    step.register_level(L)
+    step.status.dt   = 1.0
+    step.status.time = 0.0
+    nnodes  = step.levels[0].sweep.coll.num_nodes
+    u0 = step.levels[0].prob.u_exact(step.status.time)
+    step.init_step(u0)
+    step.levels[0].sweep.predict()
+    u0full = np.array([ step.levels[0].u[l].values.flatten() for l in range(1,nnodes+1) ])
+
+    step.levels[0].sweep.update_nodes()
+    assert step.levels[0].uend is None, "uend should be None previous to running compute_end_point"
+    step.levels[0].sweep.compute_end_point()
+    #print "Sweep: %s" % step.levels[0].uend.values
+
+  #
+  # Make sure a sweep in matrix form is equal to a sweep in node-to-node form
+  #
+  def test_sweepequalmatrix(self):
+
+    step = stepclass.step(params={})
+    L = lvl.level(problem_class=swfw_scalar, problem_params=self.pparams, dtype_u=mesh, dtype_f=rhs_imex_mesh, sweeper_class=imex, sweeper_params=self.swparams, level_params={}, hook_class=hookclass.hooks, id="imextest")
+    step.register_level(L)
+    step.status.dt   = 1.0
+    step.status.time = 0.0
+    nnodes  = step.levels[0].sweep.coll.num_nodes
+    u0 = step.levels[0].prob.u_exact(step.status.time)
+    step.init_step(u0)
+    step.levels[0].sweep.predict()
+    u0full = np.array([ step.levels[0].u[l].values.flatten() for l in range(1,nnodes+1) ])
+
+    # Perform node-to-node SDC sweep
+    step.levels[0].sweep.update_nodes()
+
+    # Build SDC sweep matrix
+    level   = step.levels[0]
+    problem = level.prob
+    QE = level.sweep.QE[1:,1:]
+    QI = level.sweep.QI[1:,1:]
+    Q  = level.sweep.coll.Qmat[1:,1:]
+    dt = step.status.dt
+    LHS = np.eye(nnodes) - step.status.dt*( problem.lambda_f[0]*QI + problem.lambda_s[0]*QE )
+    RHS = step.status.dt*( (problem.lambda_f[0]+problem.lambda_s[0])*Q - (problem.lambda_f[0]*QI + problem.lambda_s[0]*QE) )
+    unew = np.linalg.inv(LHS).dot( u0full + RHS.dot(u0full) )
+    usweep = np.array([ level.u[l].values.flatten() for l in range(1,nnodes+1) ])
+    assert np.linalg.norm(unew - usweep, np.infty)<1e-14, "Single SDC sweeps in matrix and node-to-node formulation yield different results"        
+
+  #
+  #
+  #
+  def test_updateformula(self):
+
+    step = stepclass.step(params={})
+    L = lvl.level(problem_class=swfw_scalar, problem_params=self.pparams, dtype_u=mesh, dtype_f=rhs_imex_mesh, sweeper_class=imex, sweeper_params=self.swparams, level_params={}, hook_class=hookclass.hooks, id="imextest")
+    step.register_level(L)
+    step.status.dt   = 1.0
+    step.status.time = 0.0
+    nnodes  = step.levels[0].sweep.coll.num_nodes
+    u0 = step.levels[0].prob.u_exact(step.status.time)
+    step.init_step(u0)
+    step.levels[0].sweep.predict()
+    u0full = np.array([ step.levels[0].u[l].values.flatten() for l in range(1,nnodes+1) ])
+
+    # Build SDC sweep matrix
+    level   = step.levels[0]
+    problem = level.prob
+    QE = level.sweep.QE[1:,1:]
+    QI = level.sweep.QI[1:,1:]
+    Q  = level.sweep.coll.Qmat[1:,1:]
+
+    # Perform update step in sweeper
+    step.levels[0].sweep.update_nodes()
+    ustages = np.array([ step.levels[0].u[l].values.flatten() for l in range(1,nnodes+1) ])
+
+    step.levels[0].sweep.compute_end_point()
+    uend_sweep = step.levels[0].uend.values
+    uend_mat   = u0.values + step.status.dt*step.levels[0].sweep.coll.weights.dot(ustages*(problem.lambda_s[0] + problem.lambda_f[0]))
+    assert np.linalg.norm(uend_sweep - uend_mat, np.infty)<1e-14, "Update formula in sweeper gives different result than matrix update formula"
+
+  #
+  # Compute the exact collocation solution by matrix inversion and make sure it is a fixed point
+  #
+  def test_collocationinvariant(self):
+
+    step = stepclass.step(params={})
+    L = lvl.level(problem_class=swfw_scalar, problem_params=self.pparams, dtype_u=mesh, dtype_f=rhs_imex_mesh, sweeper_class=imex, sweeper_params=self.swparams, level_params={}, hook_class=hookclass.hooks, id="imextest")
+    step.register_level(L)
+    step.status.dt   = 1.0
+    step.status.time = 0.0
+    nnodes  = step.levels[0].sweep.coll.num_nodes
+    u0 = step.levels[0].prob.u_exact(step.status.time)
+    step.init_step(u0)
+    step.levels[0].sweep.predict()
+    u0full = np.array([ step.levels[0].u[l].values.flatten() for l in range(1,nnodes+1) ])
+
+    # Build SDC sweep matrix
+    level   = step.levels[0]
+    problem = level.prob
+    QE = level.sweep.QE[1:,1:]
+    QI = level.sweep.QI[1:,1:]
+    Q  = level.sweep.coll.Qmat[1:,1:]
+    
+    Mcoll = np.eye(nnodes) - step.status.dt*Q*(problem.lambda_s[0] + problem.lambda_f[0])
+    ucoll = np.linalg.inv(Mcoll).dot(u0full)
+    for l in range(0,nnodes):
+      step.levels[0].u[l+1].values = ucoll[l]
+      step.levels[0].f[l+1].impl.values = problem.lambda_f[0]*ucoll[l]
+      step.levels[0].f[l+1].expl.values = problem.lambda_s[0]*ucoll[l]
+
+    # Perform node-to-node SDC sweep
+    step.levels[0].sweep.update_nodes()
+
+    LHS = np.eye(nnodes) - step.status.dt*( problem.lambda_f[0]*QI + problem.lambda_s[0]*QE )
+    RHS = step.status.dt*( (problem.lambda_f[0]+problem.lambda_s[0])*Q - (problem.lambda_f[0]*QI + problem.lambda_s[0]*QE) )
+    unew = np.linalg.inv(LHS).dot( u0full + RHS.dot(ucoll) )
+    assert np.linalg.norm( unew - ucoll, np.infty )<1e-14, "Collocation solution not invariant under matrix SDC sweep"
+    unew_sweep = np.array([ step.levels[0].u[l].values.flatten() for l in range(1,nnodes+1) ])
+    assert np.linalg.norm( unew_sweep - ucoll, np.infty )<1e-14, "Collocation solution not invariant under node-to-node sweep"
+
+  #
+  #
+  #
+  def test_canrunmatrixsweep(self):
+    step = stepclass.step(params={})
+    L = lvl.level(problem_class=swfw_scalar, problem_params=self.pparams, dtype_u=mesh, dtype_f=rhs_imex_mesh, sweeper_class=imex, sweeper_params=self.swparams, level_params={}, hook_class=hookclass.hooks, id="imextest")
+    step.register_level(L)
+    step.status.dt   = 1.0
+    step.status.time = 0.0
+    u0 = step.levels[0].prob.u_exact(step.status.time)
+    step.init_step(u0)
+    nnodes  = step.levels[0].sweep.coll.num_nodes
+    level   = step.levels[0]
+    problem = level.prob
+    QE = level.sweep.QE[1:,1:]
+    QI = level.sweep.QI[1:,1:]
+    Q  = level.sweep.coll.Qmat[1:,1:]
+    
+    P  = np.eye(nnodes) - step.status.dt*problem.lambda_s[0]*QE - step.status.dt*problem.lambda_f[0]*QI
+
+    Pinv = np.linalg.inv(P)
+    M  = np.eye(nnodes) - step.status.dt*( problem.lambda_s[0] + problem.lambda_f[0] )*Q
+    #M = step.status.dt*( (problem.lambda_s[0]+problem.lambda_f[0])*Q - problem.lambda_f[0]*QI - problem.lambda_s[0]*QE )
+    #print QI
+    #print P    
+    #print Pinv
+    #print M
+    #level.sweep.predict()
+    #u0full = np.array([ level.u[l].values.flatten() for l in range(1,nnodes+1) ])
+    #ufull  = u0full + Pinv.dot( u0full ) - Pinv.dot( M.dot(u0full) )
+    #print u0.values
+    #print Pinv.dot(u0full)
+    #print Pinv.dot(M)
+    #print Pinv.dot(M.dot(u0full))
+    #ufull = Pinv.dot(M.dot(u0full)) + Pinv.dot(u0full)
+    #ufull  = np.linalg.inv(M).dot(u0full)
+    #print ufull
+    #uend   = u0.values + step.status.dt*level.sweep.coll.weights.dot( (problem.lambda_f[0]+problem.lambda_s[0])*ufull )
+    #print "Matrix: %s" % uend

--- a/tests/test_imexsweeper.py
+++ b/tests/test_imexsweeper.py
@@ -234,36 +234,3 @@ class TestImexSweeper(unittest.TestCase):
     update = 1.0 + (problem.lambda_s[0] + problem.lambda_f[0])*level.sweep.coll.weights.dot(Mat_sweep.dot(np.ones(nnodes)))
     uend_matrix = update*self.pparams['u0']
     assert abs(uend_matrix - uend_sweep)<1e-14, "Node-to-node sweep plus update yields different result than update function computed through K-sweep matrix"
-  #
-  #
-  #
-  def test_canrunmatrixsweep(self):
-    step, level, problem, nnodes = self.setupLevelStepProblem()
-
-    QE = level.sweep.QE[1:,1:]
-    QI = level.sweep.QI[1:,1:]
-    Q  = level.sweep.coll.Qmat[1:,1:]
-    
-    P  = np.eye(nnodes) - step.status.dt*problem.lambda_s[0]*QE - step.status.dt*problem.lambda_f[0]*QI
-
-    Pinv = np.linalg.inv(P)
-    M  = np.eye(nnodes) - step.status.dt*( problem.lambda_s[0] + problem.lambda_f[0] )*Q
-    #M = step.status.dt*( (problem.lambda_s[0]+problem.lambda_f[0])*Q - problem.lambda_f[0]*QI - problem.lambda_s[0]*QE )
-    #print QI
-    #print P    
-    #print Pinv
-    #print M
-    #level.sweep.predict()
-    #u0full = np.array([ level.u[l].values.flatten() for l in range(1,nnodes+1) ])
-    #ufull  = u0full + Pinv.dot( u0full ) - Pinv.dot( M.dot(u0full) )
-    #print u0.values
-    #print Pinv.dot(u0full)
-    #print Pinv.dot(M)
-    #print Pinv.dot(M.dot(u0full))
-    #ufull = Pinv.dot(M.dot(u0full)) + Pinv.dot(u0full)
-    #ufull  = np.linalg.inv(M).dot(u0full)
-    #print ufull
-    #uend   = u0.values + step.status.dt*level.sweep.coll.weights.dot( (problem.lambda_f[0]+problem.lambda_s[0])*ufull )
-    #print "Matrix: %s" % uend
-
-


### PR DESCRIPTION
Introduces a number of tests for the IMEX sweeper.
 - checks that matrix formulation of sweep is equivalent to node-to-node sweep
 - checks that update function matches node-to-node sweeps plus update (for Lobatto nodes, need to fix #52 to pass)
 - other tests making sure the IMEX sweeper does what is expected.