### PR TITLE
Feature/switch for coll update

### DIFF
--- a/pySDC/Sweeper.py
+++ b/pySDC/Sweeper.py
@@ -45,7 +45,7 @@ class sweeper(with_metaclass(abc.ABCMeta)):
         coll = params['collocation_class'](params['num_nodes'],0,1)
         assert isinstance(coll, CollBase)
         if not coll.right_is_node:
-          assert params['do_coll_update'], "For nodes where the right end point is not a node, do_coll_update has to be set to True"
+          assert self.params.do_coll_update, "For nodes where the right end point is not a node, do_coll_update has to be set to True"
 
         # This will be set as soon as the sweeper is instantiated at the level
         self.__level = None

--- a/pySDC/Sweeper.py
+++ b/pySDC/Sweeper.py
@@ -31,7 +31,8 @@ class sweeper(with_metaclass(abc.ABCMeta)):
 
                 defaults = dict()
                 defaults['do_LU'] = False
-
+                defaults['do_coll_update'] = True
+                
                 for k,v in defaults.items():
                     setattr(self,k,v)
 
@@ -43,6 +44,8 @@ class sweeper(with_metaclass(abc.ABCMeta)):
 
         coll = params['collocation_class'](params['num_nodes'],0,1)
         assert isinstance(coll, CollBase)
+        if not coll.right_is_node:
+          assert self.params['do_coll_update'], "For nodes where the right end point is not a node, do_coll_update has to be set to True"
 
         # This will be set as soon as the sweeper is instantiated at the level
         self.__level = None

--- a/pySDC/Sweeper.py
+++ b/pySDC/Sweeper.py
@@ -45,7 +45,7 @@ class sweeper(with_metaclass(abc.ABCMeta)):
         coll = params['collocation_class'](params['num_nodes'],0,1)
         assert isinstance(coll, CollBase)
         if not coll.right_is_node:
-          assert self.params['do_coll_update'], "For nodes where the right end point is not a node, do_coll_update has to be set to True"
+          assert params['do_coll_update'], "For nodes where the right end point is not a node, do_coll_update has to be set to True"
 
         # This will be set as soon as the sweeper is instantiated at the level
         self.__level = None

--- a/pySDC/sweeper_classes/generic_LU.py
+++ b/pySDC/sweeper_classes/generic_LU.py
@@ -135,12 +135,17 @@ class generic_LU(sweeper):
         L = self.level
         P = L.prob
 
-        # start with u0 and add integral over the full interval (using coll.weights)
-        L.uend = P.dtype_u(L.u[0])
-        for m in range(self.coll.num_nodes):
-            L.uend += L.dt*self.coll.weights[m]*L.f[m+1]
-        # add up tau correction of the full interval (last entry)
-        if L.tau is not None:
-            L.uend += L.tau[-1]
+-        # check if Mth node is equal to right point and do_coll_update is false, perform a simple copy
+-        if (self.coll.right_is_node and not self.params['do_coll_update']):
+-            # a copy is sufficient
+-            L.uend = P.dtype_u(L.u[-1])
+        else:
+          # start with u0 and add integral over the full interval (using coll.weights)
+          L.uend = P.dtype_u(L.u[0])
+          for m in range(self.coll.num_nodes):
+              L.uend += L.dt*self.coll.weights[m]*L.f[m+1]
+          # add up tau correction of the full interval (last entry)
+          if L.tau is not None:
+              L.uend += L.tau[-1]
 
         return None

--- a/pySDC/sweeper_classes/generic_LU.py
+++ b/pySDC/sweeper_classes/generic_LU.py
@@ -135,10 +135,10 @@ class generic_LU(sweeper):
         L = self.level
         P = L.prob
 
--        # check if Mth node is equal to right point and do_coll_update is false, perform a simple copy
--        if (self.coll.right_is_node and not self.params['do_coll_update']):
--            # a copy is sufficient
--            L.uend = P.dtype_u(L.u[-1])
+         # check if Mth node is equal to right point and do_coll_update is false, perform a simple copy
+        if (self.coll.right_is_node and not self.params.do_coll_update):
+          # a copy is sufficient
+          L.uend = P.dtype_u(L.u[-1])
         else:
           # start with u0 and add integral over the full interval (using coll.weights)
           L.uend = P.dtype_u(L.u[0])

--- a/pySDC/sweeper_classes/imex_1st_order.py
+++ b/pySDC/sweeper_classes/imex_1st_order.py
@@ -134,19 +134,24 @@ class imex_1st_order(sweeper):
         """
         Compute u at the right point of the interval
 
-        The value uend computed here is a full evaluation of the Picard formulation (always!)
+        The value uend computed here is a full evaluation of the Picard formulation unless do_full_update==False
         """
 
         # get current level and problem description
         L = self.level
         P = L.prob
 
-        # start with u0 and add integral over the full interval (using coll.weights)
-        L.uend = P.dtype_u(L.u[0])
-        for m in range(self.coll.num_nodes):
-            L.uend += L.dt*self.coll.weights[m]*(L.f[m+1].impl + L.f[m+1].expl)
-        # add up tau correction of the full interval (last entry)
-        if L.tau is not None:
-            L.uend += L.tau[-1]
+        # check if Mth node is equal to right point and do_coll_update is false, perform a simple copy
+        if (self.coll.right_is_node and not self.params.do_coll_update):
+           # a copy is sufficient
+           L.uend = P.dtype_u(L.u[-1])
+        else:
+          # start with u0 and add integral over the full interval (using coll.weights)
+          L.uend = P.dtype_u(L.u[0])
+          for m in range(self.coll.num_nodes):
+              L.uend += L.dt*self.coll.weights[m]*(L.f[m+1].impl + L.f[m+1].expl)
+          # add up tau correction of the full interval (last entry)
+          if L.tau is not None:
+              L.uend += L.tau[-1]
 
         return None

--- a/tests/test_imexsweeper.py
+++ b/tests/test_imexsweeper.py
@@ -272,8 +272,5 @@ class TestImexSweeper(unittest.TestCase):
     # Compute end value from matrix formulation
     q = np.zeros(nnodes)
     q[nnodes-1] = 1.0
-    print q
     uend_mat   = q.dot(ustages)
-    print uend_sweep
-    print uend_mat
     assert np.linalg.norm(uend_sweep - uend_mat, np.infty)<1e-14, "For do_coll_update=False, update formula in sweeper gives different result than matrix update formula with q=(0,..,0,1)"

--- a/tests/test_imexsweeper.py
+++ b/tests/test_imexsweeper.py
@@ -204,7 +204,7 @@ class TestImexSweeper(unittest.TestCase):
   #
   # Make sure that update function for K sweeps computed from K-sweep matrix gives same result as K sweeps in node-to-node form plus compute_end_point
   #
-  def test_maysweepupdate(self):
+  def test_manysweepupdate(self):
 
     step, level, problem, nnodes = self.setupLevelStepProblem()
     step.levels[0].sweep.predict()
@@ -229,3 +229,13 @@ class TestImexSweeper(unittest.TestCase):
     # Multiply u0 by value of update function to get end value directly
     uend_matrix = update*self.pparams['u0']
     assert abs(uend_matrix - uend_sweep)<1e-14, "Node-to-node sweep plus update yields different result than update function computed through K-sweep matrix"
+
+  #
+  # Make sure that creating a sweeper object with a collocation object with right_is_node=False and do_coll_update=False throws an exception
+  #
+  def test_norightnode_collupdate_fails(self):
+    self.swparams['collocation_class'] = collclass.CollGaussLegendre
+    self.swparams['do_coll_update'] = False
+    # Has to throw an exception
+    with self.assertRaises(AssertionError):
+      step, level, problem, nnodes = self.setupLevelStepProblem()   


### PR DESCRIPTION
Since it seems that for some reason copying the last stage instead of performing a full update improves stability, this introduces a flag `do_coll_update` as a sweeper parameter which can be set to `False` to do a simple copy of the last stage in `compute_end_value`.

The default is `True`, that is to perform a proper update. An exception is raised if `do_coll_update=False` for a set of nodes where the right endpoint is not a quadrature node.

Tests verify that (a) the exception is raised as expected and (b) that the update is identical to `q*U` with `q=(0,...,0,1)`.