### PR TITLE
Matrix functions in sweeper

### DIFF
--- a/pySDC/sweeper_classes/imex_1st_order.py
+++ b/pySDC/sweeper_classes/imex_1st_order.py
@@ -129,7 +129,6 @@ class imex_1st_order(sweeper):
 
         return None
 
-
     def compute_end_point(self):
         """
         Compute u at the right point of the interval
@@ -155,3 +154,9 @@ class imex_1st_order(sweeper):
               L.uend += L.tau[-1]
 
         return None
+
+    def get_sweeper_mats(self):
+      QE = self.QE[1:,1:]
+      QI = self.QI[1:,1:]
+      Q  = self.coll.Qmat[1:,1:]
+      return QE, QI, Q

--- a/pySDC/sweeper_classes/imex_1st_order.py
+++ b/pySDC/sweeper_classes/imex_1st_order.py
@@ -160,3 +160,15 @@ class imex_1st_order(sweeper):
       QI = self.QI[1:,1:]
       Q  = self.coll.Qmat[1:,1:]
       return QE, QI, Q
+
+    def get_scalar_problems_sweeper_mats(self, lambdas=[None, None]):
+      QE, QI, Q = self.get_sweeper_mats()
+      if lambdas==[None,None]:
+        pass
+        # should use lambdas from attached problem and make sure it is a scalar IMEX 
+        raise NotImplementedError("At the moment, the values for lambda have to be provided")
+      else:
+        lambda_fast = lambdas[0]
+        lambda_slow = lambdas[1]
+      assert abs(lambda_slow)<=abs(lambda_fast), "First entry in parameter lambdas (lambda_fast) has to be greater than second entry (lambda_slow)"
+      return QE, QI, Q

--- a/tests/test_imexsweeper.py
+++ b/tests/test_imexsweeper.py
@@ -33,9 +33,7 @@ class TestImexSweeper(unittest.TestCase):
     return step, level, problem, nnodes
   
   def setupQMatrices(self, level):
-    QE = level.sweep.QE[1:,1:]
-    QI = level.sweep.QI[1:,1:]
-    Q  = level.sweep.coll.Qmat[1:,1:]
+    QE, QI, Q = level.sweep.get_sweeper_mats()
     return QE, QI, Q
 
   def setupSweeperMatrices(self, step, level, problem):

--- a/tests/test_imexsweeper.py
+++ b/tests/test_imexsweeper.py
@@ -32,14 +32,10 @@ class TestImexSweeper(unittest.TestCase):
     problem = level.prob
     return step, level, problem, nnodes
   
-  def setupQMatrices(self, level):
-    QE, QI, Q = level.sweep.get_sweeper_mats()
-    return QE, QI, Q
-
   def setupSweeperMatrices(self, step, level, problem):
     nnodes  = step.levels[0].sweep.coll.num_nodes
     # Build SDC sweep matrix
-    QE, QI, Q = self.setupQMatrices(level)
+    QE, QI, Q = level.sweep.get_sweeper_mats()
     dt = step.status.dt
     LHS = np.eye(nnodes) - step.status.dt*( problem.lambda_f[0]*QI + problem.lambda_s[0]*QE )
     RHS = step.status.dt*( (problem.lambda_f[0]+problem.lambda_s[0])*Q - (problem.lambda_f[0]*QI + problem.lambda_s[0]*QE) )
@@ -149,11 +145,12 @@ class TestImexSweeper(unittest.TestCase):
   def test_collocationinvariant(self):
     for type in classes:
       self.swparams['collocation_class'] = getattr(pySDC.CollocationClasses, type)
+
       step, level, problem, nnodes = self.setupLevelStepProblem()
       level.sweep.predict()
       u0full = np.array([ level.u[l].values.flatten() for l in range(1,nnodes+1) ])
       
-      QE, QI, Q = self.setupQMatrices(level)
+      QE, QI, Q = level.sweep.get_sweeper_mats()
 
       # Build collocation matrix
       Mcoll = np.eye(nnodes) - step.status.dt*Q*(problem.lambda_s[0] + problem.lambda_f[0])

--- a/tests/test_imexsweeper.py
+++ b/tests/test_imexsweeper.py
@@ -116,7 +116,6 @@ class TestImexSweeper(unittest.TestCase):
   def test_updateformula(self):
     for type in classes:
       self.swparams['collocation_class'] = getattr(pySDC.CollocationClasses, type)
-
       step, level, problem, nnodes = self.setupLevelStepProblem()
       level.sweep.predict()
       u0full = np.array([ level.u[l].values.flatten() for l in range(1,nnodes+1) ])
@@ -197,7 +196,6 @@ class TestImexSweeper(unittest.TestCase):
       Mat_sweep = level.sweep.get_scalar_problems_manysweep_mat( nsweeps = K, lambdas = lambdas )
       usweep_onematrix = Mat_sweep.dot(u0full)
       assert np.linalg.norm( usweep_onematrix - usweep, np.infty )<1e-14, "Single-matrix multiple sweep formulation yields different result than multiple sweeps in node-to-node or matrix form form"
-
     
   #
   # Make sure that update function for K sweeps computed from K-sweep matrix gives same result as K sweeps in node-to-node form plus compute_end_point
@@ -205,7 +203,6 @@ class TestImexSweeper(unittest.TestCase):
   def test_manysweepupdate(self):
     for type in classes:
       self.swparams['collocation_class'] = getattr(pySDC.CollocationClasses, type)
-
       step, level, problem, nnodes = self.setupLevelStepProblem()
       step.levels[0].sweep.predict()
       u0full = np.array([ level.u[l].values.flatten() for l in range(1,nnodes+1) ])
@@ -228,7 +225,6 @@ class TestImexSweeper(unittest.TestCase):
       # Multiply u0 by value of update function to get end value directly
       uend_matrix = update*self.pparams['u0']
       assert abs(uend_matrix - uend_sweep)<1e-14, "Node-to-node sweep plus update yields different result than update function computed through K-sweep matrix"
-
 
   #
   # Make sure that creating a sweeper object with a collocation object with right_is_node=False and do_coll_update=False throws an exception


### PR DESCRIPTION
Augments the IMEX sweeper with a range of functions to generate the matrices representing one or multiple sweeps in matrix form. Having those functions all in one place allows to automate their testing.

Modifies test_imexsweeper to verify that matrix sweeps and normal sweeps are equivalent.

Fixes #57 