### PR TITLE
equidistant nodes

### DIFF
--- a/pySDC/CollocationClasses.py
+++ b/pySDC/CollocationClasses.py
@@ -215,3 +215,60 @@ class CollGaussRadau_Left(CollBase):
         print('WARNING: GaussRadau_Left not fully tested, use at own risk!')
 
         return nodes
+
+
+class EquidistantInner(CollBase):
+    """
+    Implements equidistant nodes with both boundary points excluded by deriving from CollBase
+    """
+    def __init__(self, num_nodes, tleft, tright):
+        super(EquidistantInner, self).__init__(num_nodes, tleft, tright)
+        assert num_nodes > 1, "Number of nodes should be at least 1 for EquidistantInner, but is %d" % num_nodes
+        self.order = self.num_nodes
+        self.nodes = self._getNodes
+        self.weights = self._getWeights(tleft,tright)
+        self.Qmat = self._gen_Qmatrix
+        self.Smat = self._gen_Smatrix
+        self.delta_m = self._gen_deltas
+        self.left_is_node = False
+        self.right_is_node = False
+
+    @property
+    def _getNodes(self):
+        """
+        Computes integration nodes with both boundaries excluded
+        """
+        M = self.num_nodes
+        a = self.tleft
+        b = self.tright
+        nodes = np.linspace(a, b, M+1, endpoint=False)
+        nodes = nodes[1:]
+        return nodes
+
+class EquidistantNoLeft(CollBase):
+    """
+    Implements equidistant nodes with left boundary point excluded
+    """
+    def __init__(self, num_nodes, tleft, tright):
+        super(EquidistantNoLeft, self).__init__(num_nodes, tleft, tright)
+        assert num_nodes > 1, "Number of nodes should be at least 1 for EquidistantInner, but is %d" % num_nodes
+        self.order = self.num_nodes
+        self.nodes = self._getNodes
+        self.weights = self._getWeights(tleft,tright)
+        self.Qmat = self._gen_Qmatrix
+        self.Smat = self._gen_Smatrix
+        self.delta_m = self._gen_deltas
+        self.left_is_node = False
+        self.right_is_node = False
+
+    @property
+    def _getNodes(self):
+        """
+        Computes integration nodes with both boundaries excluded
+        """
+        M = self.num_nodes
+        a = self.tleft
+        b = self.tright
+        nodes = np.linspace(a, b, M+1)
+        nodes = nodes[1:]
+        return nodes

--- a/pySDC/CollocationClasses.py
+++ b/pySDC/CollocationClasses.py
@@ -259,7 +259,7 @@ class EquidistantNoLeft(CollBase):
         self.Smat = self._gen_Smatrix
         self.delta_m = self._gen_deltas
         self.left_is_node = False
-        self.right_is_node = False
+        self.right_is_node = True
 
     @property
     def _getNodes(self):

--- a/tests/test_collocation.py
+++ b/tests/test_collocation.py
@@ -8,7 +8,7 @@ import numpy as np
 t_start  = np.random.rand(1)*0.2
 t_end    = 0.8 + np.random.rand(1)*0.2
 
-classes  = [ ["CollGaussLegendre", 2, 12], ["CollGaussLobatto", 2, 12], ["CollGaussRadau_Right", 2, 12], ["CollGaussRadau_Left", 2, 12], ["EquidistantInner", 2, 15], ["EquidistantNoLeft", 2, 15] ]
+classes  = [ ["CollGaussLegendre", 2, 12], ["CollGaussLobatto", 2, 12], ["CollGaussRadau_Right", 2, 12], ["CollGaussRadau_Left", 2, 12], ["EquidistantInner", 2, 12], ["EquidistantNoLeft", 2, 12] ]
 
 class TestCollocation:
 

--- a/tests/test_collocation.py
+++ b/tests/test_collocation.py
@@ -8,7 +8,7 @@ import numpy as np
 t_start  = np.random.rand(1)*0.2
 t_end    = 0.8 + np.random.rand(1)*0.2
 
-classes  = [ ["CollGaussLegendre", 2, 12], ["CollGaussLobatto", 2, 12], ["CollGaussRadau_Right", 2, 12], ["CollGaussRadau_Left", 2, 12] ]
+classes  = [ ["CollGaussLegendre", 2, 12], ["CollGaussLobatto", 2, 12], ["CollGaussRadau_Right", 2, 12], ["CollGaussRadau_Left", 2, 12], ["EquidistantInner", 2, 15], ["EquidistantNoLeft", 2, 15] ]
 
 class TestCollocation:
 
@@ -23,7 +23,6 @@ class TestCollocation:
         # some basic consistency tests
         assert np.size(coll.nodes)==np.size(coll.weights), "For node type " + type[0] + ", number of entries in nodes and weights is different"
         assert np.size(coll.nodes)==M, "For node type " + type[0] + ", requesting M nodes did not produce M entries in nodes and weights"
-
 
         # generate random set of polynomial coefficients
         poly_coeff = np.random.rand(coll.order-1)


### PR DESCRIPTION
Extends `CollocationClasses.py` to provide two new classes for equidistant nodes, one where both endpoints are excluded, one where only the left endpoint is excluded.