### PR TITLE
Small performance boost for QMatrix computation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+### Spyder ###
+.spyproject

--- a/pySDC/core/Collocation.py
+++ b/pySDC/core/Collocation.py
@@ -111,15 +111,13 @@ class CollBase(object):
     @property
     def _gen_Qmatrix(self):
         """
-        Compute tleft-to-node integration matrix for later use in collocation
-        formulation
+        Compute tleft-to-node integration matrix for later use in collocation formulation
 
         Returns:
             numpy.ndarray: matrix containing the weights for tleft to node
         """
         if self.nodes is None:
-            raise CollocationError(
-                f"Need nodes before computing weights, got {self.nodes}")
+            raise CollocationError(f"Need nodes before computing weights, got {self.nodes}")
         M = self.num_nodes
         Q = np.zeros([M + 1, M + 1])
 
@@ -128,19 +126,16 @@ class CollBase(object):
         circ_one[0] = 1.0
         tcks = []
         for i in range(M):
-            tcks.append(BarycentricInterpolator(
-                self.nodes, np.roll(circ_one, i)))
+            tcks.append(BarycentricInterpolator(self.nodes, np.roll(circ_one, i)))
 
         # Generate evaluation points for quadrature
         a, b = self.tleft, self.nodes[:, None]
         tau, omega = roots_legendre(self.num_nodes)
         tau, omega = tau[None, :], omega[None, :]
-        phi = (b-a)/2*tau + (b+a)/2
+        phi = (b - a) / 2 * tau + (b + a) / 2
 
         # Compute quadrature
-        intQ = np.array([
-            np.sum((b-a)/2 * omega * p(phi), axis=-1)
-            for p in tcks])
+        intQ = np.array([np.sum((b - a) / 2 * omega * p(phi), axis=-1) for p in tcks])
 
         # Store into Q matrix
         Q[1:, 1:] = intQ.T


### PR DESCRIPTION
Hi Robert,

the original implementation of the QMatrix computation was suffering from 2 main downsides
1. each time _get_weights was called, it need to re-compute the same Barycentric interpolation polynomials that were already computed for the previous node => redundancy
2.  the use of quad is very expensive, and probably not needed since the integrand function is a polynomial of order M.

So I put the computation of the Barycentric polynomials directly in the _gen_QMatrix function, and changed the quad interpolation with an order M interpolation using Legendre nodes and weights. This does not change the dependencies of pySDC (nodes and weights come from scipy, quadrature use vectorized numpy operations). It improves a little bit the computation for large number of nodes (for M=100, requires only 6 sec. on my laptop, compared to 300 sec. for the previous version). From what I've compared, results are similar to machine precision (maybe if you have some regression test I could additionally check it).
Here is a comparison with the pythag package in terms of similarity, up to 150 nodes :

![image](https://user-images.githubusercontent.com/12183839/113423779-5d6efc00-93cf-11eb-84bb-c0aa167bf197.png)

I did not remove the _get_weights method, since I'm not sure it is not used in an other function (did not modify it either ...).
So in case you're interested, feel free to take this merge request ;)

Best,
Thibaut