### PR TITLE
Adaptivity Tend fix

### DIFF
--- a/pySDC/core/Hooks.py
+++ b/pySDC/core/Hooks.py
@@ -265,10 +265,12 @@ class hooks(object):
                           sweep=L.status.sweep, type='niter', value=step.status.iter)
         self.add_to_stats(process=step.status.slot, time=L.time, level=L.level_index, iter=-1,
                           sweep=L.status.sweep, type='residual_post_step', value=L.status.residual)
-        self.add_to_stats(process=step.status.slot, time=L.time + L.dt, level=L.level_index, iter=step.status.iter,
-                          sweep=L.status.sweep, type='recomputed', value=step.status.restart)
-        self.add_to_stats(process=step.status.slot, time=L.time, level=L.level_index, iter=step.status.iter,
-                          sweep=L.status.sweep, type='recomputed', value=step.status.restart)
+
+        # record the recomputed quantities at weird positions to make sure there is only one value for each step
+        self.add_to_stats(process=-1, time=L.time + L.dt, level=-1, iter=-1,
+                          sweep=-1, type='recomputed', value=step.status.restart)
+        self.add_to_stats(process=-1, time=L.time, level=-1, iter=-1,
+                          sweep=-1, type='recomputed', value=step.status.restart)
 
     def post_predict(self, step, level_number):
         """

--- a/pySDC/core/Hooks.py
+++ b/pySDC/core/Hooks.py
@@ -265,6 +265,8 @@ class hooks(object):
                           sweep=L.status.sweep, type='niter', value=step.status.iter)
         self.add_to_stats(process=step.status.slot, time=L.time, level=L.level_index, iter=-1,
                           sweep=L.status.sweep, type='residual_post_step', value=L.status.residual)
+        self.add_to_stats(process=step.status.slot, time=L.time + L.dt, level=L.level_index, iter=step.status.iter,
+                          sweep=L.status.sweep, type='recomputed', value=step.status.restart)
         self.add_to_stats(process=step.status.slot, time=L.time, level=L.level_index, iter=step.status.iter,
                           sweep=L.status.sweep, type='recomputed', value=step.status.restart)
 

--- a/pySDC/core/Level.py
+++ b/pySDC/core/Level.py
@@ -5,6 +5,7 @@ from pySDC.helpers.pysdc_helper import FrozenClass
 class _Pars(FrozenClass):
     def __init__(self, params):
         self.dt = None
+        self.dt_initial = None
         self.restol = 0.0
         self.nsweeps = 1
         self.residual_type = 'full_abs'
@@ -12,6 +13,8 @@ class _Pars(FrozenClass):
             setattr(self, k, v)
         # freeze class, no further attributes allowed from this point
         self._freeze()
+
+        self.dt_initial = self.dt * 1.
 
 
 # short helper class to bundle all status variables

--- a/pySDC/helpers/stats_helper.py
+++ b/pySDC/helpers/stats_helper.py
@@ -90,4 +90,5 @@ def get_list_of_types(stats):
 
 
 def get_sorted(stats, process=None, time=None, level=None, iter=None, type=None, recomputed=None, sortby='time'):
-    return sort_stats(filter_stats(stats, process=process, time=time, level=level, iter=iter, type=type), sortby=sortby)
+    return sort_stats(filter_stats(stats, process=process, time=time, level=level, iter=iter, type=type,
+                      recomputed=recomputed), sortby=sortby)

--- a/pySDC/implementations/controller_classes/controller_nonMPI.py
+++ b/pySDC/implementations/controller_classes/controller_nonMPI.py
@@ -834,9 +834,8 @@ ing adaptivity!'
         else:
             restart_at = len(restarts) - 1
 
-        # Compute the maximum allowed step size based on Tend. The final step will be computed with the original
-        # step size to reach the same final time regardless of step size control
-        dt_max = (Tend-self.MS[restart_at].levels[0].params.dt_initial - time[0]) / len(active_slots)
+        # Compute the maximum allowed step size based on Tend.
+        dt_max = (Tend - time[0]) / len(active_slots)
 
         # record the step sizes to restart with from all the levels of the step
         new_steps = [None] * len(self.MS[restart_at].levels)

--- a/pySDC/implementations/controller_classes/controller_nonMPI.py
+++ b/pySDC/implementations/controller_classes/controller_nonMPI.py
@@ -202,7 +202,7 @@ s to have a constant order in time for adaptivity. Setting restol=0')
                 uend = self.MS[active_slots[-1]].levels[0].uend
                 time[active_slots[0]] = time[active_slots[-1]] + self.MS[active_slots[-1]].dt
 
-            self.adaptivity_update_step_sizes(active_slots)
+            self.update_step_sizes(active_slots)
 
             # setup the times of the steps for the next block
             for i in range(1, len(active_slots)):
@@ -823,9 +823,9 @@ ing adaptivity!'
             if L.status.error_embedded_estimate >= L.params.e_tol:
                 S.status.restart = True
 
-    def adaptivity_update_step_sizes(self, active_slots):
+    def update_step_sizes(self, active_slots):
         """
-        Update the step sizes computed in adaptivity here, since this can get arbitrarily elaborate
+        Update the step sizes computed in adaptivity or wherever here, since this can get arbitrarily elaborate
         """
         # figure out where the block is restarted
         restarts = [self.MS[p].status.restart for p in active_slots]

--- a/pySDC/projects/error_estimation/piline_hotrod_adaptivity.py
+++ b/pySDC/projects/error_estimation/piline_hotrod_adaptivity.py
@@ -126,61 +126,69 @@ def plot(stats, use_adaptivity, num_procs, generate_reference=False):
     if use_adaptivity and num_procs == 1:
         error_msg = 'Error when using adaptivity in serial:'
         expected = {
-            'v1': 83.88240785649039,
-            'v2': 80.62744370831926,
-            'p3': 16.137248067563256,
-            'e_em': 6.236525251779312e-08,
-            'e_ex': 6.33675177461887e-08,
-            'dt': 0.09607389421085785,
+            'v1': 83.88400120208927,
+            'v2': 80.62656174446846,
+            'p3': 16.134850636244856,
+            'e_em': 9.535710887575988e-09,
+            'e_ex': 5.203249735635934e-08,
+            'dt': 0.0587195170595578,
             'restarts': 1.0,
             'sweeps': 2416.0,
+            't': 19.95,
         }
+
     elif use_adaptivity and num_procs == 4:
         error_msg = 'Error when using adaptivity in parallel:'
         expected = {
-            'v1': 83.88317481237193,
-            'v2': 80.62700122995363,
-            'p3': 16.136136147445036,
-            'e_em': 2.9095385656319195e-08,
-            'e_ex': 5.666752074991754e-08,
-            'dt': 0.09347348421862582,
+            'v1': 83.88400085600999,
+            'v2': 80.62656228348706,
+            'p3': 16.134850343534808,
+            'e_em': 1.5352657811718018e-08,
+            'e_ex': 5.685289098759357e-08,
+            'dt': 0.07015581329617149,
             'restarts': 8.0,
-            'sweeps': 2400.0,
+            'sweeps': 2404.0,
+            't': 19.95,
         }
+
     elif not use_adaptivity and num_procs == 4:
         error_msg = 'Error with fixed step size in parallel:'
         expected = {
-            'v1': 83.88400149770143,
-            'v2': 80.62656173487008,
-            'p3': 16.134849851184736,
-            'e_em': 4.977994905175365e-09,
-            'e_ex': 5.048084913047097e-09,
+            'v1': 83.88400128006428,
+            'v2': 80.62656202423844,
+            'p3': 16.134849781053525,
+            'e_em': 4.7536339309317555e-09,
+            'e_ex': 5.372188915941894e-09,
             'dt': 0.05,
             'restarts': 0.0,
             'sweeps': 1600.0,
+            't': 19.95000000000015,
         }
+
     elif not use_adaptivity and num_procs == 1:
         error_msg = 'Error with fixed step size in serial:'
         expected = {
             'v1': 83.88400149770143,
             'v2': 80.62656173487008,
             'p3': 16.134849851184736,
-            'e_em': 4.977994905175365e-09,
-            'e_ex': 5.048084913047097e-09,
+            'e_em': 5.034856087604567e-09,
+            'e_ex': 5.114154137212804e-09,
             'dt': 0.05,
             'restarts': 0.0,
             'sweeps': 1600.0,
+            't': 19.95000000000015,
         }
 
     got = {
         'v1': v1[-1],
         'v2': v2[-1],
         'p3': p3[-1],
-        'e_em': e_em[-1],
-        'e_ex': e_ex[e_ex != [None]][-1],
-        'dt': dt[-1],
+        'e_em': e_em[-2],
+        'e_ex': e_ex[e_ex != [None]][-2],
+        'dt': dt[-2],
         'restarts': restarts.sum(),
         'sweeps': sweeps.sum(),
+        't': t[-1],
     }
 
     if generate_reference:

--- a/pySDC/projects/error_estimation/piline_hotrod_adaptivity.py
+++ b/pySDC/projects/error_estimation/piline_hotrod_adaptivity.py
@@ -22,17 +22,17 @@ class log_data(hooks):
 
         L.sweep.compute_end_point()
 
-        self.add_to_stats(process=step.status.slot, time=L.time, level=L.level_index, iter=0,
+        self.add_to_stats(process=step.status.slot, time=L.time + L.dt, level=L.level_index, iter=0,
                           sweep=L.status.sweep, type='v1', value=L.uend[0])
-        self.add_to_stats(process=step.status.slot, time=L.time, level=L.level_index, iter=0,
+        self.add_to_stats(process=step.status.slot, time=L.time + L.dt, level=L.level_index, iter=0,
                           sweep=L.status.sweep, type='v2', value=L.uend[1])
-        self.add_to_stats(process=step.status.slot, time=L.time, level=L.level_index, iter=0,
+        self.add_to_stats(process=step.status.slot, time=L.time + L.dt, level=L.level_index, iter=0,
                           sweep=L.status.sweep, type='p3', value=L.uend[2])
         self.add_to_stats(process=step.status.slot, time=L.time, level=L.level_index, iter=0,
                           sweep=L.status.sweep, type='dt', value=L.dt)
-        self.add_to_stats(process=step.status.slot, time=L.time, level=L.level_index, iter=0,
+        self.add_to_stats(process=step.status.slot, time=L.time + L.dt, level=L.level_index, iter=0,
                           sweep=L.status.sweep, type='e_embedded', value=L.status.error_embedded_estimate)
-        self.add_to_stats(process=step.status.slot, time=L.time, level=L.level_index, iter=0,
+        self.add_to_stats(process=step.status.slot, time=L.time + L.dt, level=L.level_index, iter=0,
                           sweep=L.status.sweep, type='e_extrapolated', value=L.status.error_extrapolation_estimate)
         self.increment_stats(process=step.status.slot, time=L.time, level=L.level_index, iter=0,
                              sweep=L.status.sweep, type='restart', value=1, initialize=0)
@@ -115,7 +115,7 @@ def plot(stats, use_adaptivity, num_procs, generate_reference=False):
     v2 = np.array(sort_stats(filter_stats(stats, type='v2', recomputed=recomputed), sortby='time'))[:, 1]
     p3 = np.array(sort_stats(filter_stats(stats, type='p3', recomputed=recomputed), sortby='time'))[:, 1]
     t = np.array(sort_stats(filter_stats(stats, type='p3', recomputed=recomputed), sortby='time'))[:, 0]
-    dt = np.array(sort_stats(filter_stats(stats, type='dt', recomputed=recomputed), sortby='time'))[:, 1]
+    dt = np.array(sort_stats(filter_stats(stats, type='dt', recomputed=recomputed), sortby='time'))
     e_em = np.array(sort_stats(filter_stats(stats, type='e_embedded', recomputed=recomputed), sortby='time'))[:, 1]
     e_ex = np.array(sort_stats(filter_stats(stats, type='e_extrapolated', recomputed=recomputed), sortby='time'))[:, 1]
     restarts = np.array(sort_stats(filter_stats(stats, type='restart', recomputed=recomputed), sortby='time'))[:, 1]
@@ -126,29 +126,29 @@ def plot(stats, use_adaptivity, num_procs, generate_reference=False):
     if use_adaptivity and num_procs == 1:
         error_msg = 'Error when using adaptivity in serial:'
         expected = {
-            'v1': 83.88400120208927,
-            'v2': 80.62656174446846,
-            'p3': 16.134850636244856,
-            'e_em': 9.535710887575988e-09,
-            'e_ex': 5.203249735635934e-08,
-            'dt': 0.0587195170595578,
+            'v1': 83.88330442715265,
+            'v2': 80.62692930055763,
+            'p3': 16.13594155613822,
+            'e_em': 4.922608098922865e-09,
+            'e_ex': 4.4120077421613226e-08,
+            'dt': 0.05,
             'restarts': 1.0,
             'sweeps': 2416.0,
-            't': 19.95,
+            't': 20.03656747407325,
         }
 
     elif use_adaptivity and num_procs == 4:
         error_msg = 'Error when using adaptivity in parallel:'
         expected = {
-            'v1': 83.88400085600999,
-            'v2': 80.62656228348706,
-            'p3': 16.134850343534808,
-            'e_em': 1.5352657811718018e-08,
-            'e_ex': 5.685289098759357e-08,
-            'dt': 0.07015581329617149,
+            'v1': 83.88400082289273,
+            'v2': 80.62656229801286,
+            'p3': 16.134850400599763,
+            'e_em': 2.3681899108396465e-08,
+            'e_ex': 3.6491178375304526e-08,
+            'dt': 0.08265581329617167,
             'restarts': 8.0,
-            'sweeps': 2404.0,
-            't': 19.95,
+            'sweeps': 2432.0,
+            't': 19.999999999999996,
         }
 
     elif not use_adaptivity and num_procs == 4:
@@ -157,12 +157,12 @@ def plot(stats, use_adaptivity, num_procs, generate_reference=False):
             'v1': 83.88400128006428,
             'v2': 80.62656202423844,
             'p3': 16.134849781053525,
-            'e_em': 4.7536339309317555e-09,
-            'e_ex': 5.372188915941894e-09,
+            'e_em': 4.277040943634347e-09,
+            'e_ex': 4.9707053288253756e-09,
             'dt': 0.05,
             'restarts': 0.0,
             'sweeps': 1600.0,
-            't': 19.95000000000015,
+            't': 20.00000000000015,
         }
 
     elif not use_adaptivity and num_procs == 1:
@@ -171,21 +171,21 @@ def plot(stats, use_adaptivity, num_procs, generate_reference=False):
             'v1': 83.88400149770143,
             'v2': 80.62656173487008,
             'p3': 16.134849851184736,
-            'e_em': 5.034856087604567e-09,
-            'e_ex': 5.114154137212804e-09,
+            'e_em': 4.977994905175365e-09,
+            'e_ex': 5.048084913047097e-09,
             'dt': 0.05,
             'restarts': 0.0,
             'sweeps': 1600.0,
-            't': 19.95000000000015,
+            't': 20.00000000000015,
         }
 
     got = {
         'v1': v1[-1],
         'v2': v2[-1],
         'p3': p3[-1],
-        'e_em': e_em[-2],
-        'e_ex': e_ex[e_ex != [None]][-2],
-        'dt': dt[-2],
+        'e_em': e_em[-1],
+        'e_ex': e_ex[e_ex != [None]][-1],
+        'dt': dt[-1][1],
         'restarts': restarts.sum(),
         'sweeps': sweeps.sum(),
         't': t[-1],
@@ -197,9 +197,9 @@ def plot(stats, use_adaptivity, num_procs, generate_reference=False):
         for k in got.keys():
             v = got[k]
             if type(v) in [list, np.ndarray]:
-                print(f'\t\'{k}\': {v[v!=[None]][-1]},')
+                print(f'    \'{k}\': {v[v!=[None]][-1]},')
             else:
-                print(f'\t\'{k}\': {v},')
+                print(f'    \'{k}\': {v},')
         print('}')
 
     if use_adaptivity and num_procs == 4:
@@ -212,7 +212,7 @@ def plot(stats, use_adaptivity, num_procs, generate_reference=False):
         fig.savefig('data/piline_solution_adaptive.png', bbox_inches='tight', dpi=300)
 
     fig, ax = plt.subplots(1, 1, figsize=(3.5, 3))
-    ax.plot(t, dt, color='black')
+    ax.plot(dt[:, 0], dt[:, 1], color='black')
     e_ax = ax.twinx()
     e_ax.plot(t, e_em, label=r'$\epsilon_\mathrm{embedded}$')
     e_ax.plot(t, e_ex, label=r'$\epsilon_\mathrm{extrapolated}$', ls='--')


### PR DESCRIPTION
Not just the last step, but the steps of the last block are shortened to go to Tend. I find this more consistent with the current state of adaptivity. It is set in the function that sets the new steps from whatever is stored in level.status.dt_new, so this can be made problem specific.