### PR TITLE
Added utility function for listing all available variables in stats

### DIFF
--- a/pySDC/helpers/stats_helper.py
+++ b/pySDC/helpers/stats_helper.py
@@ -92,3 +92,17 @@ def get_list_of_types(stats):
 def get_sorted(stats, process=None, time=None, level=None, iter=None, type=None, recomputed=None, sortby='time'):
     return sort_stats(filter_stats(stats, process=process, time=time, level=level, iter=iter, type=type,
                       recomputed=recomputed), sortby=sortby)
+
+
+def get_available_types(stats):
+    '''
+    Get the names of all available variables that are stored during a pySDC run.
+    All values returned by this function are valid entries for `type` when filtering stats.
+
+    Args:
+        stats (dict): raw statistics from a controller run
+
+    Returns:
+        list: Available variable names
+    '''
+    return list(dict.fromkeys([me.type for me in stats]))


### PR DESCRIPTION
Added a function that prints all available values for `type` when filtering stats produced during a pySDC run.
This is useful when using a hook that somebody else wrote or if you forgot what you did yourself.