### PR TITLE
Added alternative text for logos that can't be dispayed on the website

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,9 +99,12 @@ This project also received funding from the `German Federal Ministry of Educatio
 
 .. image:: docs/source/logo/Time-X.png
    :width: 20%
+   :alt: Time-X
 
 .. image:: docs/source/logo/EU.png
    :width: 15%
+   :alt: EU
 
 .. image:: docs/source/logo/BMBF.jpg
    :width: 20%
+   :alt: BMBF


### PR DESCRIPTION
By writing `:alt: <text>` in an image block in an rst file, you can add an alternative text that will be displayed when the image can't be rendered.
Since the acknowledgements cannot be rendered on the website, I thought we can do this to pretend to be slightly more professional. 

Before:
<img width="843" alt="Screenshot 2022-10-07 at 11 31 39" src="https://user-images.githubusercontent.com/39156931/194522693-7ec05313-4c84-4cab-a92f-b547a40038df.png">

After:
<img width="843" alt="Screenshot 2022-10-07 at 11 31 58" src="https://user-images.githubusercontent.com/39156931/194522799-ffd1c5d8-89dd-4600-a742-972140a4ed77.png">