### PR TITLE
Replaced your email in plain text as mailto link in the code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement 
-[here](mailto:speck@fz-juelich.de).
+[here](mailto:r.speck@fz-juelich.de).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
I don't know if this actually helps against spam since your email is probably still written in plain text in the source code. If you think it makes no difference, just close the PR without merging.