### PR TITLE
Added random generator to the Sweeper

### DIFF
--- a/pySDC/core/Sweeper.py
+++ b/pySDC/core/Sweeper.py
@@ -3,7 +3,6 @@ import logging
 import numpy as np
 import scipy.linalg
 import scipy.optimize as opt
-from scipy.special import factorial
 
 from pySDC.core.Errors import ParameterError
 from pySDC.core.Level import level


### PR DESCRIPTION
This allows to set a local random seed for the sweeper which makes sure the initial guesses are reproducible.

As far as I can tell there are no tests that depend on a specific random seed inside the sweeper, but be aware that this will change the behaviour compared to previously, where there was either none or a global random seed specified.

Global random seeds are outdated because you may set a different random seed for a completely independent different random process somewhere else, which would impact the reproducibility of the other random processes.

Computing contraction factors for preconditioners, anyways, seems to work much better with random initial guess.
If you would don't like these small PRs because they produce so many emails, please let me know.