### PR TITLE
Moved variable for extrapolated error estimate from level to convergence controller

### DIFF
--- a/pySDC/core/Level.py
+++ b/pySDC/core/Level.py
@@ -32,7 +32,6 @@ class _Status(FrozenClass):
         self.time = None
         self.dt_new = None
         self.sweep = None
-        self.error_extrapolation_estimate = None
         # freeze class, no further attributes allowed from this point
         self._freeze()
 

--- a/pySDC/helpers/pysdc_helper.py
+++ b/pySDC/helpers/pysdc_helper.py
@@ -27,3 +27,16 @@ class FrozenClass(object):
         Function to freeze the class
         """
         self.__isfrozen = True
+
+    def get(self, key, default=None):
+        """
+        Wrapper for `__dict__.get` to use when reading variables that might not exist, depending on the configuration
+
+        Args:
+            key (str): Name of the variable you wish to read
+            default: Value to be returned if the variable does not exist
+
+        Returns:
+            __dict__.get(key, default)
+        """
+        return self.__dict__.get(key, default)

--- a/pySDC/implementations/convergence_controller_classes/estimate_extrapolation_error.py
+++ b/pySDC/implementations/convergence_controller_classes/estimate_extrapolation_error.py
@@ -71,7 +71,7 @@ class EstimateExtrapolationErrorBase(ConvergenceController):
 
     def setup_status_variables(self, controller, **kwargs):
         """
-        Initialize coefficient variables.
+        Initialize coefficient variables and add variable to the levels for extrapolated error
 
         Args:
             controller (pySDC.controller): The controller
@@ -81,7 +81,30 @@ class EstimateExtrapolationErrorBase(ConvergenceController):
         """
         self.coeff.u = [None] * self.params.n
         self.coeff.f = [0.0] * self.params.n
+
+        self.reset_status_variables(controller, **kwargs)
         return None
+
+    def reset_status_variables(self, controller, **kwargs):
+        """
+        Add variable for extrapolated error
+
+        Args:
+            controller (pySDC.Controller): The controller
+
+        Returns:
+            None
+        """
+        if 'comm' in kwargs.keys():
+            steps = [controller.S]
+        else:
+            if 'active_slots' in kwargs.keys():
+                steps = [controller.MS[i] for i in kwargs['active_slots']]
+            else:
+                steps = controller.MS
+        where = ["levels", "status"]
+        for S in steps:
+            self.add_variable(S, name='error_extrapolation_estimate', where=where, init=None)
 
     def check_parameters(self, controller, params, description, **kwargs):
         """

--- a/pySDC/projects/Resilience/accuracy_check.py
+++ b/pySDC/projects/Resilience/accuracy_check.py
@@ -44,7 +44,7 @@ class log_errors(hooks):
             iter=0,
             sweep=L.status.sweep,
             type='e_extrapolated',
-            value=L.status.error_extrapolation_estimate,
+            value=L.status.__dict__.get('error_extrapolation_estimate', None),
         )
         self.add_to_stats(
             process=step.status.slot,

--- a/pySDC/projects/Resilience/accuracy_check.py
+++ b/pySDC/projects/Resilience/accuracy_check.py
@@ -44,7 +44,7 @@ class log_errors(hooks):
             iter=0,
             sweep=L.status.sweep,
             type='e_extrapolated',
-            value=L.status.__dict__.get('error_extrapolation_estimate', None),
+            value=L.status.get('error_extrapolation_estimate'),
         )
         self.add_to_stats(
             process=step.status.slot,

--- a/pySDC/projects/Resilience/advection.py
+++ b/pySDC/projects/Resilience/advection.py
@@ -70,7 +70,7 @@ class log_data(hooks):
             iter=0,
             sweep=L.status.sweep,
             type='e_embedded',
-            value=L.status.error_embedded_estimate,
+            value=L.status.__dict__.get('error_embedded_estimate', None),
         )
         self.add_to_stats(
             process=step.status.slot,
@@ -79,7 +79,7 @@ class log_data(hooks):
             iter=0,
             sweep=L.status.sweep,
             type='e_extrapolated',
-            value=L.status.error_extrapolation_estimate,
+            value=L.status.__dict__.get('error_extrapolation_estimate', None),
         )
 
 

--- a/pySDC/projects/Resilience/advection.py
+++ b/pySDC/projects/Resilience/advection.py
@@ -70,7 +70,7 @@ class log_data(hooks):
             iter=0,
             sweep=L.status.sweep,
             type='e_embedded',
-            value=L.status.__dict__.get('error_embedded_estimate', None),
+            value=L.status.get('error_embedded_estimate'),
         )
         self.add_to_stats(
             process=step.status.slot,
@@ -79,7 +79,7 @@ class log_data(hooks):
             iter=0,
             sweep=L.status.sweep,
             type='e_extrapolated',
-            value=L.status.__dict__.get('error_extrapolation_estimate', None),
+            value=L.status.get('error_extrapolation_estimate'),
         )
 
 

--- a/pySDC/projects/Resilience/fault_stats.py
+++ b/pySDC/projects/Resilience/fault_stats.py
@@ -60,7 +60,7 @@ class log_fault_stats_data(FaultInjector):
             iter=-1,
             sweep=L.status.sweep,
             type='e_em',
-            value=L.status.error_embedded_estimate,
+            value=L.status.__dict__.get('error_embedded_estimate', None),
         )
         self.increment_stats(
             process=step.status.slot,
@@ -137,7 +137,7 @@ class log_all_iterates(log_fault_stats_data):
             iter=iter,
             sweep=L.status.sweep,
             type='e_ex',
-            value=L.status.error_extrapolation_estimate,
+            value=L.status.__dict__.get('error_extrapolation_estimate', None),
         )
 
 

--- a/pySDC/projects/Resilience/fault_stats.py
+++ b/pySDC/projects/Resilience/fault_stats.py
@@ -60,7 +60,7 @@ class log_fault_stats_data(FaultInjector):
             iter=-1,
             sweep=L.status.sweep,
             type='e_em',
-            value=L.status.__dict__.get('error_embedded_estimate', None),
+            value=L.status.get('error_embedded_estimate'),
         )
         self.increment_stats(
             process=step.status.slot,
@@ -137,7 +137,7 @@ class log_all_iterates(log_fault_stats_data):
             iter=iter,
             sweep=L.status.sweep,
             type='e_ex',
-            value=L.status.__dict__.get('error_extrapolation_estimate', None),
+            value=L.status.get('error_extrapolation_estimate'),
         )
 
 

--- a/pySDC/projects/Resilience/piline.py
+++ b/pySDC/projects/Resilience/piline.py
@@ -72,7 +72,7 @@ class log_data(hooks):
             iter=0,
             sweep=L.status.sweep,
             type='e_extrapolated',
-            value=L.status.__dict__.get('error_extrapolation_estimate', None),
+            value=L.status.get('error_extrapolation_estimate'),
         )
         self.increment_stats(
             process=step.status.slot,

--- a/pySDC/projects/Resilience/piline.py
+++ b/pySDC/projects/Resilience/piline.py
@@ -72,7 +72,7 @@ class log_data(hooks):
             iter=0,
             sweep=L.status.sweep,
             type='e_extrapolated',
-            value=L.status.error_extrapolation_estimate,
+            value=L.status.__dict__.get('error_extrapolation_estimate', None),
         )
         self.increment_stats(
             process=step.status.slot,

--- a/pySDC/projects/Resilience/vdp.py
+++ b/pySDC/projects/Resilience/vdp.py
@@ -95,7 +95,7 @@ class log_data(hooks):
             iter=0,
             sweep=L.status.sweep,
             type='e_ex',
-            value=L.status.error_extrapolation_estimate,
+            value=L.status.__dict__.get('error_extrapolation_estimate', None),
         )
         self.increment_stats(
             process=step.status.slot,

--- a/pySDC/projects/Resilience/vdp.py
+++ b/pySDC/projects/Resilience/vdp.py
@@ -95,7 +95,7 @@ class log_data(hooks):
             iter=0,
             sweep=L.status.sweep,
             type='e_ex',
-            value=L.status.__dict__.get('error_extrapolation_estimate', None),
+            value=L.status.get('error_extrapolation_estimate'),
         )
         self.increment_stats(
             process=step.status.slot,


### PR DESCRIPTION
The hooks become slightly more convoluted because I use the same hook class for different configurations of convergence controllers, such that the values I want to record don't necessarily exist.

I could implement a `get` function in the frozen class, which wraps `__dict__.get` in order to streamline this a bit. What do you think?