### PR TITLE
Changed imports a bit

### DIFF
--- a/pySDC/core/Controller.py
+++ b/pySDC/core/Controller.py
@@ -275,7 +275,7 @@ class controller(object):
 
     def add_convergence_controller(self, convergence_controller, description, params=None, allow_double=False):
         '''
-        Add an individual convergence controller to the list of convergence controllers and instiate it.
+        Add an individual convergence controller to the list of convergence controllers and instantiate it.
         Afterwards, the order of the convergence controllers is updated.
 
         Args:

--- a/pySDC/implementations/controller_classes/controller_MPI.py
+++ b/pySDC/implementations/controller_classes/controller_MPI.py
@@ -4,7 +4,7 @@ from mpi4py import MPI
 from pySDC.core.Controller import controller
 from pySDC.core.Errors import ControllerError
 from pySDC.core.Step import step
-from pySDC.implementations.convergence_controller_classes.basic_restarting import BasicRestartingMPI
+from pySDC.implementations.convergence_controller_classes.basic_restarting import BasicRestarting
 
 
 class controller_MPI(controller):
@@ -61,7 +61,7 @@ class controller_MPI(controller):
                 'you have specified a predictor type but only a single level.. ' 'predictor will be ignored'
             )
 
-        self.add_convergence_controller(BasicRestartingMPI, description)
+        self.add_convergence_controller(BasicRestarting.get_implementation('MPI'), description)
 
         for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
             C.setup_status_variables(self, comm=comm)

--- a/pySDC/implementations/controller_classes/controller_nonMPI.py
+++ b/pySDC/implementations/controller_classes/controller_nonMPI.py
@@ -6,7 +6,7 @@ import dill
 from pySDC.core.Controller import controller
 from pySDC.core import Step as stepclass
 from pySDC.core.Errors import ControllerError, CommunicationError
-from pySDC.implementations.convergence_controller_classes.basic_restarting import BasicRestartingNonMPI
+from pySDC.implementations.convergence_controller_classes.basic_restarting import BasicRestarting
 
 
 class controller_nonMPI(controller):
@@ -75,7 +75,7 @@ class controller_nonMPI(controller):
                 'you have specified a predictor type but only a single level.. ' 'predictor will be ignored'
             )
 
-        self.add_convergence_controller(BasicRestartingNonMPI, description)
+        self.add_convergence_controller(BasicRestarting.get_implementation("nonMPI"), description)
 
         for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
             C.reset_buffers_nonMPI(self)

--- a/pySDC/implementations/convergence_controller_classes/adaptivity.py
+++ b/pySDC/implementations/convergence_controller_classes/adaptivity.py
@@ -143,19 +143,15 @@ class Adaptivity(AdaptivityBase):
         Returns:
             None
         """
+        from pySDC.implementations.convergence_controller_classes.estimate_embedded_error import EstimateEmbeddedError
+
         super(Adaptivity, self).dependencies(controller, description)
-        if type(controller) == controller_nonMPI:
-            from pySDC.implementations.convergence_controller_classes.estimate_embedded_error import (
-                EstimateEmbeddedErrorNonMPI,
-            )
 
-            controller.add_convergence_controller(EstimateEmbeddedErrorNonMPI, description=description)
-        else:
-            from pySDC.implementations.convergence_controller_classes.estimate_embedded_error import (
-                EstimateEmbeddedErrorMPI,
-            )
+        controller.add_convergence_controller(
+            EstimateEmbeddedError.get_implementation("nonMPI" if type(controller) == controller_nonMPI else "MPI"),
+            description=description,
+        )
 
-            controller.add_convergence_controller(EstimateEmbeddedErrorMPI, description=description)
         return None
 
     def check_parameters(self, controller, params, description, **kwargs):

--- a/pySDC/implementations/convergence_controller_classes/basic_restarting.py
+++ b/pySDC/implementations/convergence_controller_classes/basic_restarting.py
@@ -5,7 +5,7 @@ from pySDC.implementations.convergence_controller_classes.spread_step_sizes impo
 )
 
 
-class BasicRestartingBase(ConvergenceController):
+class BasicRestarting(ConvergenceController):
     """
     Class with some utilities for restarting. The specific functions are:
      - Telling each step after one that requested a restart to get restarted as well
@@ -13,6 +13,24 @@ class BasicRestartingBase(ConvergenceController):
 
     Default control order is 95.
     """
+
+    @classmethod
+    def get_implementation(cls, flavor):
+        """
+        Retrieve the implementation for a specific flavor of this class.
+
+        Args:
+            flavor (str): The implementation that you want
+
+        Returns:
+            cls: The child class that implements the desired flavor
+        """
+        if flavor == 'MPI':
+            return BasicRestartingMPI
+        elif flavor == 'nonMPI':
+            return BasicRestartingNonMPI
+        else:
+            raise NotImplementedError(f'Flavor {flavor} of BasicRestarting is not implemented!')
 
     def __init__(self, controller, params, description, **kwargs):
         """
@@ -23,7 +41,7 @@ class BasicRestartingBase(ConvergenceController):
             params (dict): Parameters for the convergence controller
             description (dict): The description object used to instantiate the controller
         """
-        super(BasicRestartingBase, self).__init__(controller, params, description)
+        super(BasicRestarting, self).__init__(controller, params, description)
         self.buffers = Pars({"restart": False, "max_restart_reached": False})
 
     def setup(self, controller, params, description, **kwargs):
@@ -129,7 +147,7 @@ class BasicRestartingBase(ConvergenceController):
         return None
 
 
-class BasicRestartingNonMPI(BasicRestartingBase):
+class BasicRestartingNonMPI(BasicRestarting):
     """
     Non-MPI specific version of basic restarting
     """
@@ -205,7 +223,7 @@ on...",
         return None
 
 
-class BasicRestartingMPI(BasicRestartingBase):
+class BasicRestartingMPI(BasicRestarting):
     """
     MPI specific version of basic restarting
     """

--- a/pySDC/implementations/convergence_controller_classes/basic_restarting.py
+++ b/pySDC/implementations/convergence_controller_classes/basic_restarting.py
@@ -67,6 +67,9 @@ class BasicRestarting(ConvergenceController):
             "control_order": 95,
         }
 
+        if 'max_restarts' in description.keys():
+            defaults['max_restarts'] = description['max_restarts']
+
         return {**defaults, **params}
 
     def setup_status_variables(self, controller, **kwargs):

--- a/pySDC/implementations/convergence_controller_classes/estimate_embedded_error.py
+++ b/pySDC/implementations/convergence_controller_classes/estimate_embedded_error.py
@@ -14,6 +14,24 @@ class EstimateEmbeddedError(ConvergenceController):
     you make sure your preconditioner is compatible, which you have to just try out...
     """
 
+    @classmethod
+    def get_implementation(cls, flavor):
+        """
+        Retrieve the implementation for a specific flavor of this class.
+
+        Args:
+            flavor (str): The implementation that you want
+
+        Returns:
+            cls: The child class that implements the desired flavor
+        """
+        if flavor == 'MPI':
+            return EstimateEmbeddedErrorMPI
+        elif flavor == 'nonMPI':
+            return EstimateEmbeddedErrorNonMPI
+        else:
+            raise NotImplementedError(f'Flavor {flavor} of EmstimateEmbeddedError is not implemented!')
+
     def setup(self, controller, params, description, **kwargs):
         """
         Add a default value for control order to the parameters and check if we are using a Runge-Kutta sweeper


### PR DESCRIPTION
to reduce the mess of nonMPI and MPI versions a bit, I implemented these classmethods to get the correct implementation from the parent class of the two implementations for some convergence controllers.

Also, you can set a custom amount of max. restarts in the description now. This is needed because the restart convergence controller is loaded by default and this seemed the easiest way to pass parameters to it.