### PR TITLE
Update for stats_helper.py

### DIFF
--- a/pySDC/helpers/stats_helper.py
+++ b/pySDC/helpers/stats_helper.py
@@ -34,7 +34,7 @@ def filter_stats(stats, process=None, time=None, level=None, iter=None, type=Non
     return result
 
 
-def sort_stats(stats, sortby, sorting, comm=None):
+def sort_stats(stats, sortby, comm=None):
     """
     Helper function to transform stats dictionary to sorted list of tuples
 
@@ -58,10 +58,7 @@ def sort_stats(stats, sortby, sorting, comm=None):
         result = [item for sub_result in comm.allgather(result) for item in sub_result]
 
     # sort by first element of the tuple (which is the sortby key) and return
-    if sorting:
-        sorted_data = sorted(result, key=lambda tup: tup[0])
-    else:
-        sorted_data = result
+    sorted_data = sorted(result, key=lambda tup: tup[0])
 
     return sorted_data
 
@@ -111,7 +108,7 @@ def get_list_of_types(stats):
     return type_list
 
 
-def get_sorted(stats, sortby='time', sorting=True, comm=None, **kwargs):
+def get_sorted(stats, sortby='time', comm=None, **kwargs):
     """
     Utility for filtering and sorting stats in a single call. Pass a communicatior if using MPI.
     Keyword arguments are passed to `filter_stats` for filtering.
@@ -127,6 +124,5 @@ def get_sorted(stats, sortby='time', sorting=True, comm=None, **kwargs):
     return sort_stats(
         filter_stats(stats, **kwargs),
         sortby=sortby,
-        sorting=sorting,
         comm=comm,
     )

--- a/pySDC/helpers/stats_helper.py
+++ b/pySDC/helpers/stats_helper.py
@@ -34,7 +34,7 @@ def filter_stats(stats, process=None, time=None, level=None, iter=None, type=Non
     return result
 
 
-def sort_stats(stats, sortby, comm=None):
+def sort_stats(stats, sortby, sorting, comm=None):
     """
     Helper function to transform stats dictionary to sorted list of tuples
 
@@ -58,7 +58,10 @@ def sort_stats(stats, sortby, comm=None):
         result = [item for sub_result in comm.allgather(result) for item in sub_result]
 
     # sort by first element of the tuple (which is the sortby key) and return
-    sorted_data = sorted(result, key=lambda tup: tup[0])
+    if sorting:
+        sorted_data = sorted(result, key=lambda tup: tup[0])
+    else:
+        sorted_data = result
 
     return sorted_data
 
@@ -108,7 +111,7 @@ def get_list_of_types(stats):
     return type_list
 
 
-def get_sorted(stats, sortby='time', comm=None, **kwargs):
+def get_sorted(stats, sortby='time', sorting=True, comm=None, **kwargs):
     """
     Utility for filtering and sorting stats in a single call. Pass a communicatior if using MPI.
     Keyword arguments are passed to `filter_stats` for filtering.
@@ -124,5 +127,6 @@ def get_sorted(stats, sortby='time', comm=None, **kwargs):
     return sort_stats(
         filter_stats(stats, **kwargs),
         sortby=sortby,
+        sorting=sorting,
         comm=comm,
     )

--- a/pySDC/projects/PinTSimE/battery_model.py
+++ b/pySDC/projects/PinTSimE/battery_model.py
@@ -97,7 +97,7 @@ def main(problem=battery, restol=1e-12, sweeper=imex_1st_order, use_switch_estim
 
     # initialize step parameters
     step_params = dict()
-    step_params['maxiter'] = 20
+    step_params['maxiter'] = 10
 
     # initialize controller parameters
     controller_params = dict()
@@ -161,7 +161,7 @@ def main(problem=battery, restol=1e-12, sweeper=imex_1st_order, use_switch_estim
         min_iter = min(min_iter, item[1])
         max_iter = max(max_iter, item[1])
 
-    assert np.mean(niters) <= 5, "Mean number of iterations is too high, got %s" % np.mean(niters)
+    assert np.mean(niters) <= 5.0, "Mean number of iterations is too high, got %s" % np.mean(niters)
     f.close()
 
     return description
@@ -206,8 +206,8 @@ def plot_voltages(description, problem, sweeper, use_switch_estimator, cwd='./')
     ax.plot(times, [v[1] for v in vC], label=r'$v_C$')
 
     if use_switch_estimator:
-        val_switch = get_sorted(stats, type='switch1', sortby='time', sorting=False)
-        t_switch = [v[0] for v in val_switch]
+        val_switch = get_sorted(stats, type='switch1', sortby='time')
+        t_switch = [v[1] for v in val_switch]
         ax.axvline(x=t_switch[-1], linestyle='--', color='k', label='Switch')
 
     ax.legend(frameon=False, fontsize=12, loc='upper right')

--- a/pySDC/projects/PinTSimE/battery_model.py
+++ b/pySDC/projects/PinTSimE/battery_model.py
@@ -206,9 +206,9 @@ def plot_voltages(description, problem, sweeper, use_switch_estimator, cwd='./')
     ax.plot(times, [v[1] for v in vC], label=r'$v_C$')
 
     if use_switch_estimator:
-        val_switch = get_sorted(stats, type='switch1', sortby='time')
+        val_switch = get_sorted(stats, type='switch1', sortby='time', sorting=False)
         t_switch = [v[0] for v in val_switch]
-        ax.axvline(x=t_switch[0], linestyle='--', color='k', label='Switch')
+        ax.axvline(x=t_switch[-1], linestyle='--', color='k', label='Switch')
 
     ax.legend(frameon=False, fontsize=12, loc='upper right')
 

--- a/pySDC/projects/PinTSimE/estimation_check.py
+++ b/pySDC/projects/PinTSimE/estimation_check.py
@@ -112,7 +112,7 @@ def check(cwd='./'):
     """
 
     V_ref = 1.0
-    dt_list = [1e-1, 1e-2]  # [4e-1, 4e-2, 4e-3]
+    dt_list = [4e-1, 4e-2, 4e-3]
     use_switch_estimator = [True, False]
     restarts = []
 
@@ -172,8 +172,8 @@ def differences_around_switch(dt_list, restarts, sweeper, V_ref, cwd='./'):
         stats_false = dill.load(f2)
         f2.close()
 
-        val_switch = get_sorted(stats_true, type='switch1', sortby='time', sorting=False)
-        t_switch = [v[0] for v in val_switch]
+        val_switch = get_sorted(stats_true, type='switch1', sortby='time')
+        t_switch = [v[1] for v in val_switch]
         t_switch = t_switch[-1]  # battery has only one single switch
 
         vC_true = get_sorted(stats_true, type='voltage C', recomputed=False, sortby='time')
@@ -235,8 +235,8 @@ def differences_over_time(dt_list, sweeper, V_ref, cwd='./'):
         stats_false = dill.load(f2)
         f2.close()
 
-        val_switch = get_sorted(stats_true, type='switch1', sortby='time', sorting=False)
-        t_switch = [v[0] for v in val_switch]
+        val_switch = get_sorted(stats_true, type='switch1', sortby='time')
+        t_switch = [v[1] for v in val_switch]
         t_switch = t_switch[-1]  # battery has only one single switch
 
         vC_true = get_sorted(stats_true, type='voltage C', recomputed=False, sortby='time')
@@ -299,8 +299,8 @@ def iterations_over_time(dt_list, maxiter, sweeper, cwd='./'):
         times_true.append([v[0] for v in iter_counts_true_val])
         times_false.append([v[0] for v in iter_counts_false_val])
 
-        val_switch = get_sorted(stats_true, type='switch1', sortby='time', sorting=False)
-        t_switch = [v[0] for v in val_switch]
+        val_switch = get_sorted(stats_true, type='switch1', sortby='time')
+        t_switch = [v[1] for v in val_switch]
         t_switches.append(t_switch[-1])
 
     setup_mpl()

--- a/pySDC/projects/PinTSimE/estimation_check.py
+++ b/pySDC/projects/PinTSimE/estimation_check.py
@@ -172,9 +172,9 @@ def differences_around_switch(dt_list, restarts, sweeper, V_ref, cwd='./'):
         stats_false = dill.load(f2)
         f2.close()
 
-        val_switch = get_sorted(stats_true, type='switch1', sortby='time')
+        val_switch = get_sorted(stats_true, type='switch1', sortby='time', sorting=False)
         t_switch = [v[0] for v in val_switch]
-        t_switch = t_switch[0]  # battery has only one single switch
+        t_switch = t_switch[-1]  # battery has only one single switch
 
         vC_true = get_sorted(stats_true, type='voltage C', recomputed=False, sortby='time')
         vC_false = get_sorted(stats_false, type='voltage C', sortby='time')
@@ -235,9 +235,9 @@ def differences_over_time(dt_list, sweeper, V_ref, cwd='./'):
         stats_false = dill.load(f2)
         f2.close()
 
-        val_switch = get_sorted(stats_true, type='switch1', sortby='time')
+        val_switch = get_sorted(stats_true, type='switch1', sortby='time', sorting=False)
         t_switch = [v[0] for v in val_switch]
-        t_switch = t_switch[0]  # battery has only one single switch
+        t_switch = t_switch[-1]  # battery has only one single switch
 
         vC_true = get_sorted(stats_true, type='voltage C', recomputed=False, sortby='time')
         vC_false = get_sorted(stats_false, type='voltage C', sortby='time')
@@ -299,9 +299,9 @@ def iterations_over_time(dt_list, maxiter, sweeper, cwd='./'):
         times_true.append([v[0] for v in iter_counts_true_val])
         times_false.append([v[0] for v in iter_counts_false_val])
 
-        val_switch = get_sorted(stats_true, type='switch1', sortby='time')
+        val_switch = get_sorted(stats_true, type='switch1', sortby='time', sorting=False)
         t_switch = [v[0] for v in val_switch]
-        t_switches.append(t_switch[0])
+        t_switches.append(t_switch[-1])
 
     setup_mpl()
     fig_iter_all, ax_iter_all = plt_helper.plt.subplots(

--- a/pySDC/projects/PinTSimE/estimation_check_extended.py
+++ b/pySDC/projects/PinTSimE/estimation_check_extended.py
@@ -161,13 +161,13 @@ def check(cwd='./'):
         stats_false = dill.load(f2)
         f2.close()
 
-        val_switch1 = get_sorted(stats_true, type='switch1', sortby='time')
-        val_switch2 = get_sorted(stats_true, type='switch2', sortby='time')
+        val_switch1 = get_sorted(stats_true, type='switch1', sortby='time', sorting=False)
+        val_switch2 = get_sorted(stats_true, type='switch2', sortby='time', sorting=False)
         t_switch1 = [v[0] for v in val_switch1]
         t_switch2 = [v[0] for v in val_switch2]
 
-        t_switch1 = t_switch1[0]
-        t_switch2 = t_switch2[0]
+        t_switch1 = t_switch1[-1]
+        t_switch2 = t_switch2[-1]
 
         val_switch_all.append([t_switch1, t_switch2])
 

--- a/pySDC/projects/PinTSimE/estimation_check_extended.py
+++ b/pySDC/projects/PinTSimE/estimation_check_extended.py
@@ -161,10 +161,10 @@ def check(cwd='./'):
         stats_false = dill.load(f2)
         f2.close()
 
-        val_switch1 = get_sorted(stats_true, type='switch1', sortby='time', sorting=False)
-        val_switch2 = get_sorted(stats_true, type='switch2', sortby='time', sorting=False)
-        t_switch1 = [v[0] for v in val_switch1]
-        t_switch2 = [v[0] for v in val_switch2]
+        val_switch1 = get_sorted(stats_true, type='switch1', sortby='time')
+        val_switch2 = get_sorted(stats_true, type='switch2', sortby='time')
+        t_switch1 = [v[1] for v in val_switch1]
+        t_switch2 = [v[1] for v in val_switch2]
 
         t_switch1 = t_switch1[-1]
         t_switch2 = t_switch2[-1]

--- a/pySDC/projects/PinTSimE/switch_estimator.py
+++ b/pySDC/projects/PinTSimE/switch_estimator.py
@@ -114,12 +114,12 @@ class SwitchEstimator(ConvergenceController):
                             L.prob.params.t_switch[self.count_switches] = self.t_switch
                             controller.hooks.add_to_stats(
                                 process=S.status.slot,
-                                time=self.t_switch,
+                                time=L.time,
                                 level=L.level_index,
                                 iter=0,
                                 sweep=L.status.sweep,
                                 type='switch{}'.format(self.count_switches + 1),
-                                value=p(self.t_switch),
+                                value=self.t_switch,
                             )
                             # self.switch_detected_step = self.switch_detected
                             self.switch_detected_step = True


### PR DESCRIPTION
This is a small PR for an update of stats_helper.py. I add the possibility to get stats back, but unsorted. This is needed, because there are some cases in which the switch estimator find more than one switch (if the first estimation is not accurate yet) and the last founded switch is needed in the end. Shortly: We need the switch which is lastly founded, not the switch which is the last (or the first) in the order sorted by time.