### PR TITLE
Added test for the step size limiter

### DIFF
--- a/pySDC/implementations/convergence_controller_classes/step_size_limiter.py
+++ b/pySDC/implementations/convergence_controller_classes/step_size_limiter.py
@@ -25,7 +25,12 @@ class StepSizeLimiter(ConvergenceController):
 
     def get_new_step_size(self, controller, S, **kwargs):
         """
-        Enforce an upper and lower limit to the step size here
+        Enforce an upper and lower limit to the step size here.
+        Be aware that this is only tested when a new step size has been determined. That means if you set an initial
+        value for the step size outside of the limits, and you don't do any further step size control, that value will
+        go through.
+        Also, the final step is adjusted such that we reach Tend as best as possible, which might give step sizes below
+        the lower limit set here.
 
         Args:
             controller (pySDC.Controller): The controller


### PR DESCRIPTION
This is tested in the MPI implementation only, so the coverage might not show up. The implementation of the actual limiter is independent of MPI, however, such that otherwise it doesn't really matter which controller we use.

Closes #221 