### PR TITLE
Added a table of convergence controllers to the setup dump

### DIFF
--- a/pySDC/core/Controller.py
+++ b/pySDC/core/Controller.py
@@ -54,7 +54,7 @@ class controller(object):
         if self.params.use_iteration_estimator and self.params.all_to_done:
             self.logger.warning('all_to_done and use_iteration_estimator set, will ignore all_to_done')
 
-        self.base_convergence_controllers = []  # use this to mark user added convergence controllers in the log file
+        self.base_convergence_controllers = [CheckConvergence]
         self.setup_convergence_controllers(description)
 
     @staticmethod
@@ -247,7 +247,6 @@ class controller(object):
         self.convergence_controllers = []
         self.convergence_controller_order = []
         conv_classes = description.get('convergence_controllers', {})
-        conv_classes[CheckConvergence] = {}  # don't need special params for this, hence the {}
 
         # instantiate the convergence controllers
         for conv_class, params in conv_classes.items():
@@ -282,7 +281,7 @@ class controller(object):
 
         return None
 
-    def get_convergence_controllers_as_table(self, description=None):
+    def get_convergence_controllers_as_table(self, description):
         '''
         This function is for debugging purposes to keep track of the different convergence controllers and their order.
 
@@ -292,9 +291,6 @@ class controller(object):
         Returns:
             str: Table of convergence controllers as a string
         '''
-        if description is None:
-            description = {'convergence_controllers': {}}
-
         out = 'Active convergence controllers:'
         out += '\n    |  # | order | convergence controller'
         out += '\n----+----+-------+---------------------------------------------------------------------------------------'
@@ -302,7 +298,7 @@ class controller(object):
             C = self.convergence_controllers[self.convergence_controller_order[i]]
 
             # figure out how the convergence controller was added
-            if type(C) in description['convergence_controllers']:  # added by user
+            if type(C) in description.get('convergence_controllers', {}).keys():  # added by user
                 user_added = '--> '
             elif type(C) in self.base_convergence_controllers:  # added by default
                 user_added = '    '

--- a/pySDC/implementations/controller_classes/controller_MPI.py
+++ b/pySDC/implementations/controller_classes/controller_MPI.py
@@ -39,6 +39,10 @@ class controller_MPI(controller):
         # insert data on time communicator to the steps (helpful here and there)
         self.S.status.time_size = num_procs
 
+        self.base_convergence_controllers += [BasicRestarting.get_implementation("MPI")]
+        for convergence_controller in self.base_convergence_controllers:
+            self.add_convergence_controller(convergence_controller, description)
+
         if self.params.dump_setup and rank == 0:
             self.dump_setup(step=self.S, controller_params=controller_params, description=description)
 
@@ -60,8 +64,6 @@ class controller_MPI(controller):
             self.logger.warning(
                 'you have specified a predictor type but only a single level.. ' 'predictor will be ignored'
             )
-
-        self.add_convergence_controller(BasicRestarting.get_implementation('MPI'), description)
 
         for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
             C.setup_status_variables(self, comm=comm)

--- a/pySDC/implementations/controller_classes/controller_nonMPI.py
+++ b/pySDC/implementations/controller_classes/controller_nonMPI.py
@@ -44,6 +44,10 @@ class controller_nonMPI(controller):
             for _ in range(num_procs - 1):
                 self.MS.append(stepclass.step(description))
 
+        self.base_convergence_controllers += [BasicRestarting.get_implementation("nonMPI")]
+        for convergence_controller in self.base_convergence_controllers:
+            self.add_convergence_controller(convergence_controller, description)
+
         if self.params.dump_setup:
             self.dump_setup(step=self.MS[0], controller_params=controller_params, description=description)
 
@@ -74,8 +78,6 @@ class controller_nonMPI(controller):
             self.logger.warning(
                 'you have specified a predictor type but only a single level.. ' 'predictor will be ignored'
             )
-
-        self.add_convergence_controller(BasicRestarting.get_implementation("nonMPI"), description)
 
         for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
             C.reset_buffers_nonMPI(self)


### PR DESCRIPTION
For convergence controllers there are three modes of adding them, default ones are not marked with an arrow like other parameters, user added ones get '--> ' in front of them, just like other parameters. The third way a convergence controller can be added is as a dependence from another convergence controller. These get ' -> '.

Since convergence controllers are now an integral part of the controllers, I think they should be displayed in the log files for debug purposes.