### PR TITLE
Wait for gitlab only when doing post processing

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -124,6 +124,8 @@ jobs:
   wait_for_gitlab:
     runs-on: ubuntu-latest
 
+    if: ${{ github.repository_owner == 'Parallel-in-Time'}}
+
     needs:
       - mirror_to_gitlab
 


### PR DESCRIPTION
I don't really know what's happening in the wait for gitlab step, but I assume it is used only in the post processing and I guess non-owners are not supposed to have access to something. Anyways, this step [fails](https://github.com/brownbaerchen/pySDC/actions/runs/3892243512/jobs/6643450451) for me in my fork, so I added the same if statement that I found in the post processing step, such that it is only run if the owner of the repository is Parallel-in-Time, which is not the case for forks, I guess.

I could not test this because Jakob's fix for the mirror to gitlab step on forks is not merged yet, but it seemed simple enough.