### PR TITLE
Moved scipy reference solution function to core problem module

### DIFF
--- a/pySDC/core/Problem.py
+++ b/pySDC/core/Problem.py
@@ -57,3 +57,25 @@ class ptype(object):
         Abstract interface to apply mass matrix (only needed for FEM)
         """
         raise NotImplementedError('ERROR: if you want a mass matrix, implement apply_mass_matrix(u)')
+
+    def generate_scipy_reference_solution(self, eval_rhs, t, u_init=None, t_init=None):
+        """
+        Compute a reference solution using `scipy.solve_ivp` with very small tolerances.
+
+        Args:
+            eval_rhs (function): Function evaluate the full right hand side. Must have signature `eval_rhs(float: t, numpy.ndarray: u)`
+            t (float): current time
+            u_init (pySDC.implementations.problem_classes.Lorenz.dtype_u): initial conditions for getting the exact solution
+            t_init (float): the starting time
+
+        Returns:
+            numpy.ndarray: exact solution
+        """
+        import numpy as np
+        from scipy.integrate import solve_ivp
+
+        tol = 100 * np.finfo(float).eps
+        u_init = self.u_exact(t=0) if u_init is None else u_init
+        t_init = 0 if t_init is None else t_init
+
+        return solve_ivp(eval_rhs, (t_init, t), u_init, rtol=tol, atol=tol).y[:, -1]

--- a/pySDC/core/Problem.py
+++ b/pySDC/core/Problem.py
@@ -61,9 +61,12 @@ class ptype(object):
     def generate_scipy_reference_solution(self, eval_rhs, t, u_init=None, t_init=None):
         """
         Compute a reference solution using `scipy.solve_ivp` with very small tolerances.
+        Keep in mind that scipy needs the solution to be a one dimensional array. If you are solving something higher
+        dimensional, you need to make sure the function `eval_rhs` takes a flattened one-dimensional version as an input
+        and output, but reshapes to whatever the problem needs for evaluation.
 
         Args:
-            eval_rhs (function): Function evaluate the full right hand side. Must have signature `eval_rhs(float: t, numpy.ndarray: u)`
+            eval_rhs (function): Function evaluate the full right hand side. Must have signature `eval_rhs(float: t, numpy.1darray: u)`
             t (float): current time
             u_init (pySDC.implementations.problem_classes.Lorenz.dtype_u): initial conditions for getting the exact solution
             t_init (float): the starting time
@@ -78,4 +81,5 @@ class ptype(object):
         u_init = self.u_exact(t=0) if u_init is None else u_init
         t_init = 0 if t_init is None else t_init
 
-        return solve_ivp(eval_rhs, (t_init, t), u_init, rtol=tol, atol=tol).y[:, -1]
+        u_shape = u_init.shape
+        return solve_ivp(eval_rhs, (t_init, t), u_init.flatten(), rtol=tol, atol=tol).y[:, -1].reshape(u_shape)

--- a/pySDC/implementations/problem_classes/AllenCahn_2D_FFT.py
+++ b/pySDC/implementations/problem_classes/AllenCahn_2D_FFT.py
@@ -142,7 +142,7 @@ class allencahn2d_imex(ptype):
 
             def eval_rhs(t, u):
                 f = self.eval_f(u.reshape(self.init[0]), t)
-                return f.impl.flatten() + f.expl.flatten()
+                return (f.impl + f.expl).flatten()
 
             me[:, :] = self.generate_scipy_reference_solution(eval_rhs, t, u_init, t_init)
 

--- a/pySDC/implementations/problem_classes/AllenCahn_2D_FFT.py
+++ b/pySDC/implementations/problem_classes/AllenCahn_2D_FFT.py
@@ -112,29 +112,39 @@ class allencahn2d_imex(ptype):
 
         return me
 
-    def u_exact(self, t):
+    def u_exact(self, t, u_init=None, t_init=None):
         """
         Routine to compute the exact solution at time t
 
         Args:
             t (float): current time
+            u_init (pySDC.implementations.problem_classes.allencahn2d_imex.dtype_u): initial conditions for getting the exact solution
+            t_init (float): the starting time
 
         Returns:
             dtype_u: exact solution
         """
 
-        assert t == 0, 'ERROR: u_exact only valid for t=0'
         me = self.dtype_u(self.init, val=0.0)
-        if self.params.init_type == 'circle':
-            xv, yv = np.meshgrid(self.xvalues, self.xvalues, indexing='ij')
-            me[:, :] = np.tanh((self.params.radius - np.sqrt(xv**2 + yv**2)) / (np.sqrt(2) * self.params.eps))
-        elif self.params.init_type == 'checkerboard':
-            xv, yv = np.meshgrid(self.xvalues, self.xvalues)
-            me[:, :] = np.sin(2.0 * np.pi * xv) * np.sin(2.0 * np.pi * yv)
-        elif self.params.init_type == 'random':
-            me[:, :] = np.random.uniform(-1, 1, self.init)
+
+        if t == 0:
+            if self.params.init_type == 'circle':
+                xv, yv = np.meshgrid(self.xvalues, self.xvalues, indexing='ij')
+                me[:, :] = np.tanh((self.params.radius - np.sqrt(xv**2 + yv**2)) / (np.sqrt(2) * self.params.eps))
+            elif self.params.init_type == 'checkerboard':
+                xv, yv = np.meshgrid(self.xvalues, self.xvalues)
+                me[:, :] = np.sin(2.0 * np.pi * xv) * np.sin(2.0 * np.pi * yv)
+            elif self.params.init_type == 'random':
+                me[:, :] = np.random.uniform(-1, 1, self.init)
+            else:
+                raise NotImplementedError('type of initial value not implemented, got %s' % self.params.init_type)
         else:
-            raise NotImplementedError('type of initial value not implemented, got %s' % self.params.init_type)
+
+            def eval_rhs(t, u):
+                f = self.eval_f(u.reshape(self.init[0]), t)
+                return f.impl.flatten() + f.expl.flatten()
+
+            me[:, :] = self.generate_scipy_reference_solution(eval_rhs, t, u_init, t_init)
 
         return me
 

--- a/pySDC/implementations/problem_classes/Lorenz.py
+++ b/pySDC/implementations/problem_classes/Lorenz.py
@@ -141,6 +141,7 @@ class LorenzAttractor(ptype):
         me = self.dtype_u(self.init)
 
         if t > 0:
+
             def eval_rhs(t, u):
                 """
                 Evaluate the right hand side, but switch the arguments for scipy.

--- a/pySDC/implementations/problem_classes/Lorenz.py
+++ b/pySDC/implementations/problem_classes/Lorenz.py
@@ -141,9 +141,7 @@ class LorenzAttractor(ptype):
         me = self.dtype_u(self.init)
 
         if t > 0:
-            from scipy.integrate import solve_ivp
-
-            def rhs(t, u):
+            def eval_rhs(t, u):
                 """
                 Evaluate the right hand side, but switch the arguments for scipy.
 
@@ -156,11 +154,7 @@ class LorenzAttractor(ptype):
                 """
                 return self.eval_f(u, t)
 
-            tol = 100 * np.finfo(float).eps
-            u_init = self.u_exact(t=0) if u_init is None else u_init
-            t_init = 0 if t_init is None else t_init
-
-            me[:] = solve_ivp(rhs, (t_init, t), u_init, rtol=tol, atol=tol).y[:, -1]
+            me[:] = self.generate_scipy_reference_solution(eval_rhs, t, u_init, t_init)
         else:
             me[:] = 1.0
         return me

--- a/pySDC/implementations/problem_classes/Van_der_Pol_implicit.py
+++ b/pySDC/implementations/problem_classes/Van_der_Pol_implicit.py
@@ -57,22 +57,10 @@ class vanderpol(ptype):
 
         if t > 0.0:
 
-            def rhs(t, u):
+            def eval_rhs(t, u):
                 return self.eval_f(u, t)
 
-            tol = 100 * np.finfo(float).eps
-
-            if u_init is not None:
-                if t_init is None:
-                    raise ValueError(
-                        'Please supply `t_init` when you want to get the exact solution from a point that \
-is not 0!'
-                    )
-                me = u_init.copy()
-            else:
-                u_init = self.params.u0.copy()
-                t_init = 0.0
-            me[:] = solve_ivp(rhs, (t_init, t), u_init, rtol=tol, atol=tol).y[:, -1]
+            me[:] = self.generate_scipy_reference_solution(eval_rhs, t, u_init, t_init)
         else:
             me[:] = self.params.u0[:]
         return me

--- a/pySDC/tests/test_problem.py
+++ b/pySDC/tests/test_problem.py
@@ -3,7 +3,7 @@ import pytest
 
 
 @pytest.mark.base
-@pytest.mark.parametrize("init", [[(2, 3)], [(1,)]])
+@pytest.mark.parametrize("init", [[(2, 3, 4)], [(2, 3)], [(1,)]])
 def test_scipy_reference(init):
     """
     Test the generation of reference solutions with scipy.

--- a/pySDC/tests/test_problem.py
+++ b/pySDC/tests/test_problem.py
@@ -23,18 +23,17 @@ def test_scipy_reference(init):
     # instantiate a dummy problem
     problem = ptype(init, None, None, {})
 
-    # setup initial conditions
-    u = np.ones(init[0])
-    u[-1] += 2
-    lamdt = np.random.rand(*u.shape)
+    # setup random initial conditions
+    u0 = np.random.rand(*init[0])
+    lamdt = np.random.rand(*u0.shape)
 
     # define function to evaluate the right hand side
     def eval_rhs(t, u):
         return (u.reshape(init[0]) * -lamdt).flatten()
 
     # compute two solutions: One with scipy and one analytic exact solution
-    u_ref = problem.generate_scipy_reference_solution(eval_rhs, 1.0, u_init=u.copy(), t_init=0)
-    u_exact = u * np.exp(-lamdt)
+    u_ref = problem.generate_scipy_reference_solution(eval_rhs, 1.0, u_init=u0.copy(), t_init=0)
+    u_exact = u0 * np.exp(-lamdt)
 
     # check that the two solutions are the same to high degree
     assert (

--- a/pySDC/tests/test_problem.py
+++ b/pySDC/tests/test_problem.py
@@ -1,0 +1,47 @@
+# Test some functionality of the core problem module
+import pytest
+
+
+@pytest.mark.base
+@pytest.mark.parametrize("init", [[(2, 3)], [(1,)]])
+def test_scipy_reference(init):
+    """
+    Test the generation of reference solutions with scipy.
+    A Dahlquist problem is solved using scipy and exactly. Depending on the shape that is passed in `init`, this can
+    emulate a PDE. What is really tested in terms of PDEs is that the changes in shape of the solution object is handled
+    correctly.
+
+    Args:
+        init (list): Object similar to the `init` that you use for the problem class
+
+    Returns:
+        None
+    """
+    import numpy as np
+    from pySDC.core.Problem import ptype
+
+    # instantiate a dummy problem
+    problem = ptype(init, None, None, {})
+
+    # setup initial conditions
+    u = np.ones(init[0])
+    u[-1] += 2
+    lamdt = -1.0
+
+    # define function to evaluate the right hand side
+    def eval_rhs(t, u):
+        return (u.reshape(init[0]) * -lamdt).flatten()
+
+    # compute two solutions: One with scipy and one analytic exact solution
+    u_ref = problem.generate_scipy_reference_solution(eval_rhs, 1.0, u_init=u.copy(), t_init=0)
+    u_exact = u * np.exp(-lamdt)
+
+    # check that the two solutions are the same to high degree
+    assert (
+        u_ref.shape == u_exact.shape
+    ), f"The shape of the scipy reference solution does not match the shape of the actual solution"
+    assert np.allclose(u_ref, u_exact, atol=1e-12), f"The scipy solution deviates significantly from the exact solution"
+
+
+if __name__ == '__main__':
+    test_scipy_reference([(2, 3)])

--- a/pySDC/tests/test_problem.py
+++ b/pySDC/tests/test_problem.py
@@ -26,7 +26,7 @@ def test_scipy_reference(init):
     # setup initial conditions
     u = np.ones(init[0])
     u[-1] += 2
-    lamdt = -1.0
+    lamdt = np.random.rand(*u.shape)
 
     # define function to evaluate the right hand side
     def eval_rhs(t, u):


### PR DESCRIPTION
This is tested for Lorenz and van der Pol equations, but not for the Allen-Cahn equation. Instead, I actually wrote a unit test that creates a dummy instance of the problem class and let's it solve a series of randomised Dahlquist problems that look like a PDE. This makes sure that the reshaping that is required to solve PDEs with scipy works.
I test 3D, 2D and 0D problems this way.
Since the code specific to Allen-Cahn is not very much and complicated, I chose to forgo this test to not make the tests overly long.
Let me now if you disagree with my choices.