### PR TITLE
Interpolate after restarts

### DIFF
--- a/pySDC/core/Controller.py
+++ b/pySDC/core/Controller.py
@@ -32,13 +32,14 @@ class controller(object):
     Base abstract controller class
     """
 
-    def __init__(self, controller_params, description):
+    def __init__(self, controller_params, description, useMPI=None):
         """
         Initialization routine for the base controller
 
         Args:
             controller_params (dict): parameter set for the controller and the steps
         """
+        self.useMPI = useMPI
 
         # check if we have a hook on this list. If not, use default class.
         self.__hooks = []
@@ -288,7 +289,7 @@ class controller(object):
             None
         '''
         # check if we passed any sort of special params
-        params = {} if params is None else params
+        params = {**({} if params is None else params), 'useMPI': self.useMPI}
 
         # check if we already have the convergence controller or if we want to have it multiple times
         if convergence_controller not in [type(me) for me in self.convergence_controllers] or allow_double:

--- a/pySDC/core/ConvergenceController.py
+++ b/pySDC/core/ConvergenceController.py
@@ -6,6 +6,7 @@ from pySDC.helpers.pysdc_helper import FrozenClass
 class Pars(FrozenClass):
     def __init__(self, params):
         self.control_order = 0  # integer that determines the order in which the convergence controllers are called
+        self.useMPI = None  # depends on the controller
 
         for k, v in params.items():
             setattr(self, k, v)

--- a/pySDC/core/Sweeper.py
+++ b/pySDC/core/Sweeper.py
@@ -321,17 +321,6 @@ class sweeper(object):
             elif self.params.initial_guess == 'random':
                 L.u[m] = P.dtype_u(init=P.init, val=self.rng.rand(1)[0])
                 L.f[m] = P.dtype_f(init=P.init, val=self.rng.rand(1)[0])
-            elif self.params.initial_guess == 'interpolate':
-                """
-                This relies on the convergence controller "InterpolateBetweenRestarts", which will take care that the
-                solution and right hand sides are interpolated and stored in the respective variables in the sweeper.
-                Here, the interpolated values are only distributed.
-                """
-                L.u[m] = P.dtype_u(P.init)
-                L.u[m][:] = self.u_inter[m][:]
-
-                L.f[m] = P.dtype_f(P.init)
-                L.f[m][:] = self.f_inter[m][:]
             else:
                 raise ParameterError(f'initial_guess option {self.params.initial_guess} not implemented')
 

--- a/pySDC/core/Sweeper.py
+++ b/pySDC/core/Sweeper.py
@@ -321,6 +321,17 @@ class sweeper(object):
             elif self.params.initial_guess == 'random':
                 L.u[m] = P.dtype_u(init=P.init, val=self.rng.rand(1)[0])
                 L.f[m] = P.dtype_f(init=P.init, val=self.rng.rand(1)[0])
+            elif self.params.initial_guess == 'interpolate':
+                """
+                This relies on the convergence controller "InterpolateBetweenRestarts", which will take care that the
+                solution and right hand sides are interpolated and stored in the respective variables in the sweeper.
+                Here, the interpolated values are only distributed.
+                """
+                L.u[m] = P.dtype_u(P.init)
+                L.u[m][:] = self.u_inter[m][:]
+
+                L.f[m] = P.dtype_f(P.init)
+                L.f[m][:] = self.f_inter[m][:]
             else:
                 raise ParameterError(f'initial_guess option {self.params.initial_guess} not implemented')
 

--- a/pySDC/helpers/plot_helper.py
+++ b/pySDC/helpers/plot_helper.py
@@ -25,7 +25,7 @@ def figsize(textwidth, scale, ratio):
     return fig_size
 
 
-def figsize_by_journal(journal, scale, ratio):  # pragma no cover
+def figsize_by_journal(journal, scale, ratio):  # pragma: no cover
     """
     Get figsize for specific journal. If you supply a text height, we will rescale the figure to fit on the page instead
     of the parameters supplied.

--- a/pySDC/implementations/controller_classes/controller_MPI.py
+++ b/pySDC/implementations/controller_classes/controller_MPI.py
@@ -25,7 +25,7 @@ class controller_MPI(controller):
         """
 
         # call parent's initialization routine
-        super(controller_MPI, self).__init__(controller_params, description)
+        super(controller_MPI, self).__init__(controller_params, description, useMPI=True)
 
         # create single step per processor
         self.S = step(description)

--- a/pySDC/implementations/controller_classes/controller_MPI.py
+++ b/pySDC/implementations/controller_classes/controller_MPI.py
@@ -25,7 +25,7 @@ class controller_MPI(controller):
         """
 
         # call parent's initialization routine
-        super(controller_MPI, self).__init__(controller_params, description, useMPI=True)
+        super().__init__(controller_params, description, useMPI=True)
 
         # create single step per processor
         self.S = step(description)

--- a/pySDC/implementations/controller_classes/controller_nonMPI.py
+++ b/pySDC/implementations/controller_classes/controller_nonMPI.py
@@ -30,7 +30,7 @@ class controller_nonMPI(controller):
             raise ControllerError('predict flag is ignored, use predict_type instead')
 
         # call parent's initialization routine
-        super(controller_nonMPI, self).__init__(controller_params, description)
+        super(controller_nonMPI, self).__init__(controller_params, description, useMPI=False)
 
         self.MS = [stepclass.step(description)]
 

--- a/pySDC/implementations/controller_classes/controller_nonMPI.py
+++ b/pySDC/implementations/controller_classes/controller_nonMPI.py
@@ -30,7 +30,7 @@ class controller_nonMPI(controller):
             raise ControllerError('predict flag is ignored, use predict_type instead')
 
         # call parent's initialization routine
-        super(controller_nonMPI, self).__init__(controller_params, description, useMPI=False)
+        super().__init__(controller_params, description, useMPI=False)
 
         self.MS = [stepclass.step(description)]
 

--- a/pySDC/implementations/convergence_controller_classes/adaptivity.py
+++ b/pySDC/implementations/convergence_controller_classes/adaptivity.py
@@ -6,7 +6,6 @@ from pySDC.implementations.convergence_controller_classes.step_size_limiter impo
 from pySDC.implementations.convergence_controller_classes.basic_restarting import (
     BasicRestartingNonMPI,
 )
-from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
 from pySDC.implementations.hooks.log_step_size import LogStepSize
 
 
@@ -175,7 +174,7 @@ class Adaptivity(AdaptivityBase):
         super(Adaptivity, self).dependencies(controller, description)
 
         controller.add_convergence_controller(
-            EstimateEmbeddedError.get_implementation("nonMPI" if type(controller) == controller_nonMPI else "MPI"),
+            EstimateEmbeddedError.get_implementation("nonMPI" if not self.params.useMPI else "MPI"),
             description=description,
         )
 

--- a/pySDC/implementations/convergence_controller_classes/check_convergence.py
+++ b/pySDC/implementations/convergence_controller_classes/check_convergence.py
@@ -45,10 +45,9 @@ class CheckConvergence(ConvergenceController):
             from pySDC.implementations.convergence_controller_classes.estimate_embedded_error import (
                 EstimateEmbeddedError,
             )
-            from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
 
             controller.add_convergence_controller(
-                EstimateEmbeddedError.get_implementation("nonMPI" if type(controller) == controller_nonMPI else "MPI"),
+                EstimateEmbeddedError.get_implementation("nonMPI" if not self.params.useMPI else "MPI"),
                 description=description,
             )
 

--- a/pySDC/implementations/convergence_controller_classes/estimate_contraction_factor.py
+++ b/pySDC/implementations/convergence_controller_classes/estimate_contraction_factor.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 from pySDC.core.ConvergenceController import ConvergenceController
-from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
 from pySDC.implementations.convergence_controller_classes.estimate_embedded_error import EstimateEmbeddedError
 
 
@@ -36,7 +35,7 @@ class EstimateContractionFactor(ConvergenceController):
             None
         """
         controller.add_convergence_controller(
-            EstimateEmbeddedError.get_implementation("nonMPI" if type(controller) == controller_nonMPI else "MPI"),
+            EstimateEmbeddedError.get_implementation("nonMPI" if not self.params.useMPI else "MPI"),
             description=description,
         )
 

--- a/pySDC/implementations/convergence_controller_classes/hotrod.py
+++ b/pySDC/implementations/convergence_controller_classes/hotrod.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 from pySDC.core.ConvergenceController import ConvergenceController
-from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
 from pySDC.implementations.convergence_controller_classes.estimate_extrapolation_error import (
     EstimateExtrapolationErrorNonMPI,
 )
@@ -49,7 +48,7 @@ class HotRod(ConvergenceController):
         Returns:
             None
         """
-        if type(controller) == controller_nonMPI:
+        if not self.params.useMPI:
             from pySDC.implementations.convergence_controller_classes.estimate_embedded_error import (
                 EstimateEmbeddedErrorNonMPI,
             )

--- a/pySDC/implementations/convergence_controller_classes/interpolate_between_restarts.py
+++ b/pySDC/implementations/convergence_controller_classes/interpolate_between_restarts.py
@@ -1,0 +1,82 @@
+import numpy as np
+from pySDC.core.ConvergenceController import ConvergenceController
+from pySDC.core.Lagrange import LagrangeApproximation
+from pySDC.core.Collocation import CollBase
+
+
+class InterpolateBetweenRestarts(ConvergenceController):
+    """
+    Interpolate the solution and right hand side to the new set of collocation nodes after a restart.
+    The idea is that when you adjust the step size between restarts, you already know what the new quadrature method
+    is going to be and possibly interpolating the current iterate to these results in a better initial guess than
+    spreading the initial conditions or whatever you usually like to do.
+    """
+
+    def setup(self, controller, params, description, **kwargs):
+        """
+        Store the initial guess used in the sweeper when no restart has happened
+
+        Args:
+            controller (pySDC.Controller.controller): The controller
+            params (dict): Parameters for the convergence controller
+            description (dict): The description object used to instantiate the controller
+
+        Returns:
+            None
+        """
+        defaults = {
+            'control_order': 50,
+            'initial_guess': description['sweeper_params'].get('initial_guess', 'spread'),
+        }
+        return {**defaults, **super().setup(controller, params, description, **kwargs)}
+
+    def setup_status_variables(self, controller, **kwargs):
+        """
+        Add variables to the sweeper containing the interpolated solution and right hand side.
+
+        Args:
+            controller (pySDC.Controller.controller): The controller
+
+        Returns:
+            None
+        """
+        for S in controller.MS if not self.params.useMPI else [controller.S]:
+            self.add_variable(S, 'u_inter', where=['levels', '_level__sweep'])
+            self.add_variable(S, 'f_inter', where=['levels', '_level__sweep'])
+
+    def post_iteration_processing(self, controller, S, **kwargs):
+        """
+        Interpolate the solution and right hand sides and store them in the sweeper, where they will be distributed
+        accordingly in the prediction step.
+
+        This function is called after every iteration instead of just after the step because we might choose to stop
+        iterating as soon as we have decided to restart. If we let the step continue to iterate, this is not the most
+        efficient implementation and you may choose to write a different convergence controller.
+
+        The interpolation is based on Thibaut's magic.
+
+        Args:
+            controller (pySDC.Controller): The controller
+            S (pySDC.Step.step): The current step
+
+        Returns:
+            None
+        """
+
+        if S.status.restart and any([L.status.dt_new for L in S.levels]):
+
+            for L in S.levels:
+                nodes_old = L.sweep.coll.nodes.copy()
+                nodes_new = L.sweep.coll.nodes.copy() * L.status.dt_new / L.params.dt
+
+                interpolator = LagrangeApproximation(points=np.append(0, nodes_old))
+                L.sweep.u_inter = (interpolator.getInterpolationMatrix(np.append(0, nodes_new)) @ L.u[:])[:]
+                L.sweep.f_inter = (interpolator.getInterpolationMatrix(np.append(0, nodes_new)) @ L.f[:])[:]
+
+                L.sweep.params.initial_guess = 'interpolate'
+
+                self.log(f'Interpolating before restart from dt={L.params.dt:.2e} to dt={L.status.dt_new:.2e}', S)
+
+        else:  # if there is no restart planned, please predict as usual
+            for L in S.levels:
+                L.sweep.params.initial_guess = self.params.initial_guess

--- a/pySDC/implementations/convergence_controller_classes/interpolate_between_restarts.py
+++ b/pySDC/implementations/convergence_controller_classes/interpolate_between_restarts.py
@@ -64,7 +64,6 @@ class InterpolateBetweenRestarts(ConvergenceController):
         """
 
         if S.status.restart and any([L.status.dt_new for L in S.levels]):
-
             for L in S.levels:
                 nodes_old = L.sweep.coll.nodes.copy()
                 nodes_new = L.sweep.coll.nodes.copy() * L.status.dt_new / L.params.dt

--- a/pySDC/projects/Resilience/leaky_superconductor.py
+++ b/pySDC/projects/Resilience/leaky_superconductor.py
@@ -12,12 +12,12 @@ import matplotlib.pyplot as plt
 from pySDC.core.Errors import ConvergenceError
 
 
-class live_plot(hooks):  # pragma no cover
+class live_plot(hooks):  # pragma: no cover
     """
     This hook plots the solution and the non-linear part of the right hand side after every step. Keep in mind that using adaptivity will result in restarts, which is not marked in these plots. Prepare to see the temperature profile jumping back again after a restart.
     """
 
-    def _plot_state(self, step, level_number):  # pragma no cover
+    def _plot_state(self, step, level_number):  # pragma: no cover
         """
         Plot the solution at all collocation nodes and the non-linear part of the right hand side
 
@@ -38,7 +38,7 @@ class live_plot(hooks):  # pragma no cover
         self.fig.suptitle(f"t={L.time:.2e}, k={step.status.iter}")
         plt.pause(1e-9)
 
-    def pre_run(self, step, level_number):  # pragma no cover
+    def pre_run(self, step, level_number):  # pragma: no cover
         """
         Setup a figure to plot into
 
@@ -51,7 +51,7 @@ class live_plot(hooks):  # pragma no cover
         """
         self.fig, self.axs = plt.subplots(1, 2, figsize=(10, 4))
 
-    def post_step(self, step, level_number):  # pragma no cover
+    def post_step(self, step, level_number):  # pragma: no cover
         """
         Call the plotting function after the step
 
@@ -170,7 +170,7 @@ def run_leaky_superconductor(
     return stats, controller, Tend
 
 
-def plot_solution(stats, controller):  # pragma no cover
+def plot_solution(stats, controller):  # pragma: no cover
     import matplotlib.pyplot as plt
 
     fig, ax = plt.subplots(1, 1)
@@ -241,7 +241,7 @@ def compare_imex_full(plotting=False):
             assert (
                 max(newton_iter) / num_nodes / maxiter <= newton_iter_max
             ), "Took more Newton iterations than allowed!"
-        if plotting:  # pragma no cover
+        if plotting:  # pragma: no cover
             plot_solution(stats, controller)
 
     diff = abs(res[True] - res[False])

--- a/pySDC/projects/Resilience/paper_plots.py
+++ b/pySDC/projects/Resilience/paper_plots.py
@@ -138,7 +138,7 @@ def plot_recovery_rate(stats_analyser, **kwargs):  # pragma: no cover
     savefig(fig, 'recovery_rate_compared', **kwargs)
 
 
-def plot_recovery_rate_recoverable_only(stats_analyser, fig, ax, **kwargs):  # pragma no cover
+def plot_recovery_rate_recoverable_only(stats_analyser, fig, ax, **kwargs):  # pragma: no cover
     """
     Plot the recovery rate considering only faults that can be recovered theoretically.
 
@@ -166,7 +166,7 @@ def plot_recovery_rate_recoverable_only(stats_analyser, fig, ax, **kwargs):  # p
         )
 
 
-def compare_recovery_rate_problems():  # pragma no cover
+def compare_recovery_rate_problems():  # pragma: no cover
     """
     Compare the recovery rate for vdP, Lorenz and Schroedinger problems.
     Only faults that can be recovered are shown.
@@ -199,7 +199,7 @@ def compare_recovery_rate_problems():  # pragma no cover
     savefig(fig, 'compare_equations')
 
 
-def plot_efficiency_polar(problem, path='data/stats'):  # pragma no cover
+def plot_efficiency_polar(problem, path='data/stats'):  # pragma: no cover
     """
     Plot the recovery rate and the computational cost in a polar plot.
 
@@ -264,7 +264,7 @@ def plot_efficiency_polar(problem, path='data/stats'):  # pragma no cover
     savefig(fig, 'efficiency')
 
 
-def plot_adaptivity_stuff():  # pragma no cover
+def plot_adaptivity_stuff():  # pragma: no cover
     """
     Plot the solution for a van der Pol problem as well as the local error and cost associated with the base scheme and
     adaptivity in k and dt in order to demonstrate that adaptivity is useful.
@@ -319,7 +319,7 @@ def plot_adaptivity_stuff():  # pragma no cover
     savefig(fig, 'adaptivity')
 
 
-def plot_fault_vdp(bit=0):  # pragma no cover
+def plot_fault_vdp(bit=0):  # pragma: no cover
     """
     Make a plot showing the impact of a fault on van der Pol without any resilience.
     The faults are inserted in the last iteration in the last node in u_t such that you can best see the impact.
@@ -388,7 +388,7 @@ def plot_fault_vdp(bit=0):  # pragma no cover
     savefig(fig, f'fault_bit_{bit}')
 
 
-def plot_vdp_solution():  # pragma no cover
+def plot_vdp_solution():  # pragma: no cover
     """
     Plot the solution of van der Pol problem over time to illustrate the varying time scales.
 
@@ -412,7 +412,7 @@ def plot_vdp_solution():  # pragma no cover
     savefig(fig, 'vdp_sol')
 
 
-def make_plots_for_SIAM_CSE23():  # pragma no cover
+def make_plots_for_SIAM_CSE23():  # pragma: no cover
     """
     Make plots for the SIAM talk
     """
@@ -429,7 +429,7 @@ def make_plots_for_SIAM_CSE23():  # pragma no cover
     plot_vdp_solution()
 
 
-def make_plots_for_paper():  # pragma no cover
+def make_plots_for_paper():  # pragma: no cover
     """
     Make plots that are supposed to go in the paper.
     """
@@ -445,7 +445,7 @@ def make_plots_for_paper():  # pragma no cover
     compare_recovery_rate_problems()
 
 
-def make_plots_for_notes():  # pragma no cover
+def make_plots_for_notes():  # pragma: no cover
     """
     Make plots for the notes for the website / GitHub
     """

--- a/pySDC/projects/Resilience/vdp.py
+++ b/pySDC/projects/Resilience/vdp.py
@@ -443,7 +443,7 @@ def check_step_size_limiter(size=4, comm=None):
             print(f'Passed step size limiter test with {size} ranks in MPI implementation')
 
 
-def interpolation_stuff():  # pragma no cover
+def interpolation_stuff():  # pragma: no cover
     """
     Plot interpolation vdp with interpolation after a restart and compare it to other modes of adaptivity.
     """

--- a/pySDC/projects/Resilience/vdp.py
+++ b/pySDC/projects/Resilience/vdp.py
@@ -461,13 +461,13 @@ def interpolation_stuff():  # pragma: no cover
     labels = ['interpolate', 'regular', 'keep iterating']
 
     for i in range(3):
-        convergence_ontrollers = {
+        convergence_controllers = {
             Adaptivity: {'e_tol': 1e-7, 'dt_max': 9.0e-1},
         }
         if i == 0:
-            convergence_ontrollers[InterpolateBetweenRestarts] = {}
+            convergence_controllers[InterpolateBetweenRestarts] = {}
         if i == 2:
-            convergence_ontrollers[Adaptivity]['avoid_restarts'] = True
+            convergence_controllers[Adaptivity]['avoid_restarts'] = True
 
         problem_params = {
             'mu': 5,
@@ -478,7 +478,7 @@ def interpolation_stuff():  # pragma: no cover
         }
 
         custom_description = {
-            'convergence_controllers': convergence_ontrollers,
+            'convergence_controllers': convergence_controllers,
             'problem_params': problem_params,
             'sweeper_params': sweeper_params,
         }

--- a/pySDC/projects/Resilience/vdp.py
+++ b/pySDC/projects/Resilience/vdp.py
@@ -195,6 +195,7 @@ def run_vdp(
     try:
         uend, stats = controller.run(u0=uinit, t0=t0, Tend=Tend)
     except (ProblemError, ConvergenceError):
+        print('Warning: Premature termination!')
         stats = controller.return_stats()
 
     return stats, controller, Tend
@@ -440,6 +441,78 @@ def check_step_size_limiter(size=4, comm=None):
     else:
         if comm.rank == 0:
             print(f'Passed step size limiter test with {size} ranks in MPI implementation')
+
+
+def interpolation_stuff():  # pragma no cover
+    """
+    Plot interpolation vdp with interpolation after a restart and compare it to other modes of adaptivity.
+    """
+    from pySDC.implementations.convergence_controller_classes.interpolate_between_restarts import (
+        InterpolateBetweenRestarts,
+    )
+    from pySDC.implementations.hooks.log_errors import LogLocalErrorPostStep
+    from pySDC.implementations.hooks.log_work import LogWork
+    from pySDC.helpers.plot_helper import figsize_by_journal
+
+    fig, axs = plt.subplots(4, 1, figsize=figsize_by_journal('Springer_Numerical_Algorithms', 1.0, 1.0), sharex=True)
+    restart_ax = axs[2].twinx()
+
+    colors = ['black', 'red', 'blue']
+    labels = ['interpolate', 'regular', 'keep iterating']
+
+    for i in range(3):
+        convergence_ontrollers = {
+            Adaptivity: {'e_tol': 1e-7, 'dt_max': 9.0e-1},
+        }
+        if i == 0:
+            convergence_ontrollers[InterpolateBetweenRestarts] = {}
+        if i == 2:
+            convergence_ontrollers[Adaptivity]['avoid_restarts'] = True
+
+        problem_params = {
+            'mu': 5,
+        }
+
+        sweeper_params = {
+            'QI': 'LU',
+        }
+
+        custom_description = {
+            'convergence_controllers': convergence_ontrollers,
+            'problem_params': problem_params,
+            'sweeper_params': sweeper_params,
+        }
+
+        custom_controller_params = {'logger_level': 30}
+        stats, controller, _ = run_vdp(
+            custom_description=custom_description,
+            custom_controller_params=custom_controller_params,
+            hook_class=[LogLocalErrorPostStep, LogData, LogWork] + hook_collection,
+        )
+
+        k = get_sorted(stats, type='work_newton')
+        restarts = get_sorted(stats, type='restart')
+        u = get_sorted(stats, type='u', recomputed=False)
+        e_loc = get_sorted(stats, type='e_local_post_step', recomputed=False)
+        dt = get_sorted(stats, type='dt', recomputed=False)
+
+        axs[0].plot([me[0] for me in u], [me[1][1] for me in u], color=colors[i], label=labels[i])
+        axs[1].plot([me[0] for me in e_loc], [me[1] for me in e_loc], color=colors[i])
+        axs[2].plot([me[0] for me in k], np.cumsum([me[1] for me in k]), color=colors[i])
+        restart_ax.plot([me[0] for me in restarts], np.cumsum([me[1] for me in restarts]), color=colors[i], ls='--')
+        axs[3].plot([me[0] for me in dt], [me[1] for me in dt], color=colors[i])
+
+    for ax in [axs[1], axs[3]]:
+        ax.set_yscale('log')
+    axs[0].set_ylabel(r'$u$')
+    axs[1].set_ylabel(r'$e_\mathrm{local}$')
+    axs[2].set_ylabel(r'Newton iterations')
+    restart_ax.set_ylabel(r'restarts (dashed)')
+    axs[3].set_ylabel(r'$\Delta t$')
+    axs[3].set_xlabel(r'$t$')
+    axs[0].legend(frameon=False)
+    fig.tight_layout()
+    plt.show()
 
 
 if __name__ == "__main__":

--- a/pySDC/tests/test_convergence_controllers/test_InterpolateBetweenRestarts.py
+++ b/pySDC/tests/test_convergence_controllers/test_InterpolateBetweenRestarts.py
@@ -185,25 +185,30 @@ def test_InterpolateBetweenRestarts(plotting=False):
                 abs(u['double_check'][i][1][j] - u['after'][i][1][j]) < 1e-12
             ), f"The interpolated solution from the convergence controller is not right! Expected {u['double_check'][i][1][j]}, got {u['after'][i][1][j]}"
 
-    import matplotlib.pyplot as plt
+    if plotting:
+        import matplotlib.pyplot as plt
 
-    fig, axs = plt.subplots(2, 1, sharex=True)
+        fig, axs = plt.subplots(2, 1, sharex=True)
 
-    colors = {
-        'before': 'teal',
-        'after': 'violet',
-        'double_check': 'black',
-    }
+        colors = {
+            'before': 'teal',
+            'after': 'violet',
+            'double_check': 'black',
+        }
 
-    ls = {'before': '-', 'after': '--', 'double_check': '-.'}
-    for i in [0, 1]:
-        for key in nodes.keys():
-            axs[0].plot(np.append([0], nodes[key][i][1]), [me[1] for me in u[key][i][1]], color=colors[key], ls=ls[key])
-            axs[1].plot(np.append([0], nodes[key][i][1]), [me[0] for me in u[key][i][1]], color=colors[key], ls=ls[key])
-    axs[1].set_xlabel('$t$')
-    axs[0].set_ylabel('$u_t$')
-    axs[1].set_ylabel('$u$')
-    plt.show()
+        ls = {'before': '-', 'after': '--', 'double_check': '-.'}
+        for i in [0, 1]:
+            for key in nodes.keys():
+                axs[0].plot(
+                    np.append([0], nodes[key][i][1]), [me[1] for me in u[key][i][1]], color=colors[key], ls=ls[key]
+                )
+                axs[1].plot(
+                    np.append([0], nodes[key][i][1]), [me[0] for me in u[key][i][1]], color=colors[key], ls=ls[key]
+                )
+        axs[1].set_xlabel('$t$')
+        axs[0].set_ylabel('$u_t$')
+        axs[1].set_ylabel('$u$')
+        plt.show()
 
 
 if __name__ == "__main__":

--- a/pySDC/tests/test_convergence_controllers/test_InterpolateBetweenRestarts.py
+++ b/pySDC/tests/test_convergence_controllers/test_InterpolateBetweenRestarts.py
@@ -1,0 +1,229 @@
+import pytest
+
+from pySDC.core.Hooks import hooks
+from pySDC.core.Lagrange import LagrangeApproximation
+from pySDC.core.Collocation import CollBase
+import numpy as np
+
+
+class LogInterpolation(hooks):
+    """
+    Log the solution when a step is supposed to be restarted as well as the interpolated solution to the new nodes and
+    the solution that ends up at the nodes after the restart.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.log_u_now = False
+
+    def pre_iteration(self, step, level_number):
+        if self.log_u_now:
+            L = step.levels[level_number]
+
+            self.add_to_stats(
+                process=step.status.slot,
+                time=L.time,
+                level=L.level_index,
+                iter=step.status.iter,
+                sweep=L.status.sweep,
+                type='u_inter',
+                value=L.u,
+            )
+            self.add_to_stats(
+                process=step.status.slot,
+                time=L.time,
+                level=L.level_index,
+                iter=step.status.iter,
+                sweep=L.status.sweep,
+                type='nodes_inter',
+                value=L.sweep.coll.nodes * L.params.dt,
+            )
+            self.log_u_now = False
+
+    def post_step(self, step, level_number):
+        super().post_iteration(step, level_number)
+
+        L = step.levels[level_number]
+
+        if step.status.restart:
+            self.log_u_now = True
+            self.add_to_stats(
+                process=step.status.slot,
+                time=L.time,
+                level=L.level_index,
+                iter=step.status.iter,
+                sweep=L.status.sweep,
+                type='u_before_interpolation',
+                value=L.u,
+            )
+            self.add_to_stats(
+                process=step.status.slot,
+                time=L.time,
+                level=L.level_index,
+                iter=step.status.iter,
+                sweep=L.status.sweep,
+                type='nodes',
+                value=L.sweep.coll.nodes * L.params.dt,
+            )
+
+            self.add_to_stats(
+                process=step.status.slot,
+                time=L.time,
+                level=L.level_index,
+                iter=step.status.iter,
+                sweep=L.status.sweep,
+                type='u_inter_planned',
+                value=L.sweep.u_inter,
+            )
+            self.add_to_stats(
+                process=step.status.slot,
+                time=L.time,
+                level=L.level_index,
+                iter=step.status.iter,
+                sweep=L.status.sweep,
+                type='nodes_inter_planned',
+                value=L.sweep.coll.nodes * L.status.dt_new,
+            )
+
+            # double check
+            nodes_old = L.sweep.coll.nodes.copy()
+            nodes_new = L.sweep.coll.nodes.copy() * L.status.dt_new / L.params.dt
+            interpolator = LagrangeApproximation(points=np.append(0, nodes_old))
+            self.add_to_stats(
+                process=step.status.slot,
+                time=L.time,
+                level=L.level_index,
+                iter=step.status.iter,
+                sweep=L.status.sweep,
+                type='u_inter_double_check',
+                value=(interpolator.getInterpolationMatrix(np.append(0, nodes_new)) @ L.u[:])[:],
+            )
+
+
+@pytest.mark.base
+def test_InterpolateBetweenRestarts(plotting=False):
+    """
+    Check that the solution is interpolated to the new nodes correctly and ends up the next step the way we want it to.
+    """
+    from pySDC.implementations.convergence_controller_classes.adaptivity import Adaptivity
+    from pySDC.implementations.convergence_controller_classes.interpolate_between_restarts import (
+        InterpolateBetweenRestarts,
+    )
+
+    import numpy as np
+    from pySDC.helpers.stats_helper import get_sorted, filter_stats
+    from pySDC.implementations.problem_classes.Van_der_Pol_implicit import vanderpol
+    from pySDC.implementations.sweeper_classes.generic_implicit import generic_implicit
+    from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
+
+    # initialize level parameters
+    level_params = dict()
+    level_params['dt'] = 1e-2
+
+    # initialize sweeper parameters
+    sweeper_params = dict()
+    sweeper_params['quad_type'] = 'RADAU-RIGHT'
+    sweeper_params['num_nodes'] = 3
+    sweeper_params['QI'] = 'IE'
+
+    problem_params = {
+        'mu': 5.0,
+        'newton_tol': 1e-9,
+        'newton_maxiter': 99,
+        'u0': np.array([2.0, 0.0]),
+    }
+
+    # initialize step parameters
+    step_params = dict()
+    step_params['maxiter'] = 4
+
+    # convergence controllers
+    convergence_controllers = {
+        Adaptivity: {'e_tol': 1e-7},
+        InterpolateBetweenRestarts: {},
+    }
+
+    # initialize controller parameters
+    controller_params = dict()
+    controller_params['logger_level'] = 30
+    controller_params['hook_class'] = LogInterpolation
+    controller_params['mssdc_jac'] = False
+
+    # fill description dictionary for easy step instantiation
+    description = dict()
+    description['problem_class'] = vanderpol
+    description['problem_params'] = problem_params
+    description['sweeper_class'] = generic_implicit
+    description['sweeper_params'] = sweeper_params
+    description['level_params'] = level_params
+    description['step_params'] = step_params
+    description['convergence_controllers'] = convergence_controllers
+
+    # set time parameters
+    t0 = 0.0
+
+    # instantiate controller
+    controller = controller_nonMPI(num_procs=1, controller_params=controller_params, description=description)
+
+    # get initial values on finest level
+    P = controller.MS[0].levels[0].prob
+    uinit = P.u_exact(t0)
+
+    uend, stats = controller.run(u0=uinit, t0=t0, Tend=1e-2)
+
+    u = {
+        'before': get_sorted(stats, type='u_before_interpolation'),
+        'planned': get_sorted(stats, type='u_inter_planned'),
+        'after': get_sorted(stats, type='u_inter'),
+        'double_check': get_sorted(stats, type='u_inter_double_check'),
+    }
+
+    nodes = {
+        'before': get_sorted(stats, type='nodes'),
+        'planned': get_sorted(stats, type='nodes_inter_planned'),
+        'after': get_sorted(stats, type='nodes_inter'),
+    }
+
+    for i in range(len(u['before'])):
+        # check the nodes
+        assert np.allclose(
+            nodes['planned'][i][1], nodes['after'][i][1], atol=1e-12
+        ), "Ended up with unexpected collocation nodes somehow!"
+        assert nodes['after'][i][1][-1] < nodes['before'][i][1][-1], "Step size was not reduced!"
+
+        # check the solution
+        for j in range(len(u['planned'][i][1])):
+            assert np.allclose(
+                u['planned'][i][1][j], u['after'][i][1][j]
+            ), f"The interpolated solution did not end up in the next step! Expected {u['planned'][i][1][j]}, got {u['after'][i][1][j]}"
+            assert np.allclose(
+                u['double_check'][i][1][j], u['after'][i][1][j]
+            ), f"The interpolated solution from the convergence controller is not right! Expected {u['double_check'][i][1][j]}, got {u['after'][i][1][j]}"
+
+    import matplotlib.pyplot as plt
+
+    fig, axs = plt.subplots(2, 1, sharex=True)
+
+    colors = {
+        'before': 'blue',
+        'planned': 'green',
+        'after': 'violet',
+    }
+
+    ls = {
+        'before': '-',
+        'planned': '-',
+        'after': '--',
+    }
+    for i in [0]:
+        for key in nodes.keys():
+            axs[0].plot(np.append([0], nodes[key][i][1]), [me[1] for me in u[key][i][1]], color=colors[key], ls=ls[key])
+            axs[1].plot(np.append([0], nodes[key][i][1]), [me[0] for me in u[key][i][1]], color=colors[key], ls=ls[key])
+    axs[1].set_xlabel('$t$')
+    axs[0].set_ylabel('$u_t$')
+    axs[1].set_ylabel('$u$')
+    plt.show()
+
+
+if __name__ == "__main__":
+    test_InterpolateBetweenRestarts(plotting=True)

--- a/pySDC/tests/test_convergence_controllers/test_InterpolateBetweenRestarts.py
+++ b/pySDC/tests/test_convergence_controllers/test_InterpolateBetweenRestarts.py
@@ -97,7 +97,7 @@ class CheckInterpolationOrder(hooks):
         nNodes = len(nodes)
 
         if self.mess_with_solution:
-            self.p = np.poly1d(np.random.rand(nNodes))
+            self.p = np.polynomial.Polynomial(np.random.rand(nNodes))
             self.uStart = self.p(nodes.copy())
             for i in range(nNodes):
                 level.u[i][:] = self.uStart[i]


### PR DESCRIPTION
New convergence controller which interpolates after a restart. There is a test that makes sure that the residual after solving the step for the second time is smaller than without interpolation and that that the interpolated value shows up the next step.

Also, since the non-MPI and MPI controllers deal with the steps differently (`controller.MS` and `controller.S`), I need some controller specific behaviour in the convergence controllers. Since I got tired of importing some controller and type-checking, I added a variable to both the controller as well as the convergence controllers that store if MPI is used or not.