### PR TITLE
Reference solution for Quench problem

### DIFF
--- a/pySDC/core/Problem.py
+++ b/pySDC/core/Problem.py
@@ -70,12 +70,16 @@ class ptype(object):
         """
         raise NotImplementedError('ERROR: if you want a mass matrix, implement apply_mass_matrix(u)')
 
-    def generate_scipy_reference_solution(self, eval_rhs, t, u_init=None, t_init=None):
+    def generate_scipy_reference_solution(self, eval_rhs, t, u_init=None, t_init=None, **kwargs):
         """
         Compute a reference solution using `scipy.solve_ivp` with very small tolerances.
         Keep in mind that scipy needs the solution to be a one dimensional array. If you are solving something higher
         dimensional, you need to make sure the function `eval_rhs` takes a flattened one-dimensional version as an input
         and output, but reshapes to whatever the problem needs for evaluation.
+
+        The keyword arguments will be passed to `scipy.solve_ivp`. You should consider passing `method='BDF'` for stiff
+        problems and to accelerate that you can pass a function that evaluates the Jacobian with arguments `jac(t, u)`
+        as `jac=jac`.
 
         Args:
             eval_rhs (function): Function evaluate the full right hand side. Must have signature `eval_rhs(float: t, numpy.1darray: u)`
@@ -94,4 +98,6 @@ class ptype(object):
         t_init = 0 if t_init is None else t_init
 
         u_shape = u_init.shape
-        return solve_ivp(eval_rhs, (t_init, t), u_init.flatten(), rtol=tol, atol=tol).y[:, -1].reshape(u_shape)
+        return (
+            solve_ivp(eval_rhs, (t_init, t), u_init.flatten(), rtol=tol, atol=tol, **kwargs).y[:, -1].reshape(u_shape)
+        )

--- a/pySDC/implementations/problem_classes/LeakySuperconductor.py
+++ b/pySDC/implementations/problem_classes/LeakySuperconductor.py
@@ -40,6 +40,7 @@ class LeakySuperconductor(ptype):
             'u_max': 2e-2,
             'Q_max': 1.0,
             'leak_range': (0.45, 0.55),
+            'leak_type': 'linear',
             'order': 2,
             'stencil_type': 'center',
             'bc': 'neumann-zero',
@@ -116,7 +117,13 @@ class LeakySuperconductor(ptype):
         Q_max = self.params.Q_max
         me = self.dtype_u(self.init)
 
-        me[:] = (u - u_thresh) / (u_max - u_thresh) * Q_max
+        if self.params.leak_type == 'linear':
+            me[:] = (u - u_thresh) / (u_max - u_thresh) * Q_max
+        elif self.params.leak_type == 'exponential':
+            me[:] = Q_max * (np.exp(u) - np.exp(u_thresh)) / (np.exp(u_max) - np.exp(u_thresh))
+        else:
+            raise NotImplementedError(f'Leak type {self.params.leak_type} not implemented!')
+
         me[u < u_thresh] = 0
         me[self.leak] = Q_max
         me[u >= u_max] = Q_max
@@ -160,7 +167,13 @@ class LeakySuperconductor(ptype):
         Q_max = self.params.Q_max
         me = self.dtype_u(self.init)
 
-        me[:] = Q_max / (u_max - u_thresh)
+        if self.params.leak_type == 'linear':
+            me[:] = Q_max / (u_max - u_thresh)
+        elif self.params.leak_type == 'exponential':
+            me[:] = Q_max * np.exp(u) / (np.exp(u_max) - np.exp(u_thresh))
+        else:
+            raise NotImplementedError(f'Leak type {self.params.leak_type} not implemented!')
+
         me[u < u_thresh] = 0
         me[u > u_max] = 0
         me[self.leak] = 0

--- a/pySDC/implementations/problem_classes/LeakySuperconductor.py
+++ b/pySDC/implementations/problem_classes/LeakySuperconductor.py
@@ -145,6 +145,34 @@ class LeakySuperconductor(ptype):
         self.work_counters['rhs']()
         return f
 
+    def get_non_linear_Jacobian(self, u):
+        """
+        Evaluate the non-linear part of the Jacobian only
+
+        Args:
+            u (dtype_u): Current solution
+
+        Returns:
+            scipy.sparse.csc: The derivative of the non-linear part of the solution w.r.t. to the solution.
+        """
+        u_thresh = self.params.u_thresh
+        u_max = self.params.u_max
+        Q_max = self.params.Q_max
+        me = self.dtype_u(self.init)
+
+        me[:] = Q_max / (u_max - u_thresh)
+        me[u < u_thresh] = 0
+        me[u > u_max] = 0
+        me[self.leak] = 0
+
+        # boundary conditions
+        me[0] = 0.0
+        me[-1] = 0.0
+
+        me[:] /= self.params.Cv
+
+        return sp.diags(me, format='csc')
+
     def solve_system(self, rhs, factor, u0, t):
         """
         Simple Newton solver for (I-factor*f)(u) = rhs
@@ -158,34 +186,6 @@ class LeakySuperconductor(ptype):
         Returns:
             dtype_u: solution as mesh
         """
-
-        def get_non_linear_Jacobian(u):
-            """
-            Evaluate the non-linear part of the Jacobian only
-
-            Args:
-                u (dtype_u): Current solution
-
-            Returns:
-                scipy.sparse.csc: The derivative of the non-linear part of the solution w.r.t. to the solution.
-            """
-            u_thresh = self.params.u_thresh
-            u_max = self.params.u_max
-            Q_max = self.params.Q_max
-            me = self.dtype_u(self.init)
-
-            me[:] = Q_max / (u_max - u_thresh)
-            me[u < u_thresh] = 0
-            me[u > u_max] = 0
-            me[self.leak] = 0
-
-            # boundary conditions
-            me[0] = 0.0
-            me[-1] = 0.0
-
-            me[:] /= self.params.Cv
-
-            return sp.diags(me, format='csc')
 
         u = self.dtype_u(u0)
         res = np.inf
@@ -209,7 +209,7 @@ class LeakySuperconductor(ptype):
                 break
 
             # assemble Jacobian J of G
-            J = self.Id - factor * (self.A + get_non_linear_Jacobian(u))
+            J = self.Id - factor * (self.A + self.get_non_linear_Jacobian(u))
 
             # solve the linear system
             if self.params.direct_solver:
@@ -251,6 +251,19 @@ class LeakySuperconductor(ptype):
 
         if t > 0:
 
+            def jac(t, u):
+                """
+                Get the Jacobian for the implicit BDF method to use in `scipy.odeint`
+
+                Args:
+                    t (float): The current time
+                    u (dtype_u): Current solution
+
+                Returns:
+                    scipy.sparse.csc: The derivative of the non-linear part of the solution w.r.t. to the solution.
+                """
+                return self.A + self.get_non_linear_Jacobian(u)
+
             def eval_rhs(t, u):
                 """
                 Function to pass to `scipy.solve_ivp` to evaluate the full RHS
@@ -264,7 +277,7 @@ class LeakySuperconductor(ptype):
                 """
                 return self.eval_f(u.reshape(self.init[0]), t).flatten()
 
-            me[:] = self.generate_scipy_reference_solution(eval_rhs, t, u_init, t_init)
+            me[:] = self.generate_scipy_reference_solution(eval_rhs, t, u_init, t_init, method='BDF', jac=jac)
         return me
 
 
@@ -326,6 +339,19 @@ class LeakySuperconductorIMEX(LeakySuperconductor):
 
         if t > 0:
 
+            def jac(t, u):
+                """
+                Get the Jacobian for the implicit BDF method to use in `scipy.odeint`
+
+                Args:
+                    t (float): The current time
+                    u (dtype_u): Current solution
+
+                Returns:
+                    scipy.sparse.csc: The derivative of the non-linear part of the solution w.r.t. to the solution.
+                """
+                return self.A
+
             def eval_rhs(t, u):
                 """
                 Function to pass to `scipy.solve_ivp` to evaluate the full RHS
@@ -340,5 +366,5 @@ class LeakySuperconductorIMEX(LeakySuperconductor):
                 f = self.eval_f(u.reshape(self.init[0]), t)
                 return (f.impl + f.expl).flatten()
 
-            me[:] = self.generate_scipy_reference_solution(eval_rhs, t, u_init, t_init)
+            me[:] = self.generate_scipy_reference_solution(eval_rhs, t, u_init, t_init, method='BDF', jac=jac)
         return me

--- a/pySDC/projects/Resilience/leaky_superconductor.py
+++ b/pySDC/projects/Resilience/leaky_superconductor.py
@@ -194,7 +194,7 @@ def plot_solution(stats, controller):  # pragma: no cover
     dt_ax.set_ylabel(r'$\Delta t$')
 
 
-def compare_imex_full(plotting=False):
+def compare_imex_full(plotting=False, leak_type='linear'):
     """
     Compare the results of IMEX and fully implicit runs. For IMEX we need to limit the step size in order to achieve convergence, but for fully implicit, adaptivity can handle itself better.
 
@@ -218,6 +218,7 @@ def compare_imex_full(plotting=False):
         'newton_tol': 1e-10,
         'newton_iter': newton_iter_max,
         'nvars': 2**9,
+        'leak_type': leak_type,
     }
     custom_description['step_params'] = {'maxiter': maxiter}
     custom_description['sweeper_params'] = {'num_nodes': num_nodes}
@@ -229,7 +230,7 @@ def compare_imex_full(plotting=False):
             custom_description=custom_description,
             custom_controller_params=custom_controller_params,
             imex=imex,
-            Tend=5e2,
+            Tend=4.3e2,
             hook_class=[LogWork, LogGlobalErrorPostRun],
         )
 

--- a/pySDC/tests/test_convergence_controllers/test_InterpolateBetweenRestarts.py
+++ b/pySDC/tests/test_convergence_controllers/test_InterpolateBetweenRestarts.py
@@ -155,6 +155,7 @@ def run_vdp(hook, adaptivity=True):
         'newton_tol': 1e-9,
         'newton_maxiter': 99,
         'u0': np.array([2.0, 0.0]),
+        'crash_at_maxiter': False,
     }
 
     # initialize step parameters

--- a/pySDC/tests/test_projects/test_resilience/test_leaky_superconductor.py
+++ b/pySDC/tests/test_projects/test_resilience/test_leaky_superconductor.py
@@ -2,10 +2,11 @@ import pytest
 
 
 @pytest.mark.base
-def test_imex_vs_fully_implicit_leaky_superconductor():
+@pytest.mark.parametrize('leak_type', ['linear', 'exponential'])
+def test_imex_vs_fully_implicit_leaky_superconductor(leak_type):
     """
     Test if the IMEX and fully implicit schemes get the same solution and that the runaway process has started.
     """
     from pySDC.projects.Resilience.leaky_superconductor import compare_imex_full
 
-    compare_imex_full()
+    compare_imex_full(plotting=False, leak_type=leak_type)


### PR DESCRIPTION
Turns out I have been very stupid. The reason that scipy wouldn't give me a reference solution in time was because the problem is so stiff that RK45 is not a good method to solve the problem. But `scipy.solve_ivp` can also do implicit time stepping with a "BDF" scheme. This seems to work reasonably well to produce reference solutions rather fast. At least the error is decreased when I increase the accuracy requirements of SDC. I failed to show any sort of order, but I don't know if the reference solution is bad or if the problem is nasty. At least I can get errors down to machine precision with the reference solution, so I thought it's probably fine.

Also, I implemented an exponential transition term in the leak. However, it doesn't lead to faster heat up than the linear part because it is rescaled to fit between 0 and 1. In that scenario linear can be steeper. I am not a modelling expert. Maybe there is a different way to model exponential growths that connects smoothly to the other terms that I don't know about.

Also, the interpolation stuff resulted in a flaky test. When you replace the solution in a van der Pol problem by a random polynomial, the Newton solver does not converge every time. I hope I fixed that in the last commit where I just deactivated crash when Newton didn't converge. We'll see. At least on my fork this went through.