### PR TITLE
Adaptivity based on error estimate based on interpolating between quadrature rules based on Thibaut

### DIFF
--- a/pySDC/implementations/convergence_controller_classes/adaptive_collocation.py
+++ b/pySDC/implementations/convergence_controller_classes/adaptive_collocation.py
@@ -195,3 +195,29 @@ class AdaptiveCollocation(ConvergenceController):
             None
         """
         self.switch_sweeper(S)
+
+    def check_parameters(self, controller, params, description, **kwargs):
+        """
+        Check if we allow the scheme to solve the collocation problems to convergence.
+
+        Args:
+            controller (pySDC.Controller): The controller
+            params (dict): The params passed for this specific convergence controller
+            description (dict): The description object used to instantiate the controller
+
+        Returns:
+            bool: Whether the parameters are compatible
+            str: The error message
+        """
+        if description["level_params"].get("restol", -1.0) <= 1e-16:
+            return (
+                False,
+                "Switching the collocation problems requires solving them to some tolerance that can be reached. Please set attainable `restol` in the level params",
+            )
+        if description["step_params"].get("maxiter", -1.0) < 99:
+            return (
+                False,
+                "Switching the collocation problems requires solving them exactly, which may require many iterations please set `maxiter` to at least 99 in the step params",
+            )
+
+        return True, ""

--- a/pySDC/implementations/convergence_controller_classes/adaptive_collocation.py
+++ b/pySDC/implementations/convergence_controller_classes/adaptive_collocation.py
@@ -105,7 +105,7 @@ class AdaptiveCollocation(ConvergenceController):
             P = L.prob
 
             # store solution of current level which will be interpolated to new level
-            u_old = L.u.copy()
+            u_old = [me.flatten() for me in L.u]
             nodes_old = L.sweep.coll.nodes.copy()
 
             # change sweeper
@@ -119,12 +119,13 @@ class AdaptiveCollocation(ConvergenceController):
             # interpolate solution of old collocation problem to new one
             nodes_new = L.sweep.coll.nodes.copy()
             interpolator = LagrangeApproximation(points=np.append(0, nodes_old))
+
             u_inter = interpolator.getInterpolationMatrix(np.append(0, nodes_new)) @ u_old
 
             # assign the interpolated values to the nodes in the level
             for i in range(0, len(u_inter)):
                 me = P.dtype_u(P.init)
-                me[:] = u_inter[i]
+                me[:] = np.reshape(u_inter[i], P.init[0])
                 L.u[i] = me
 
             # reevaluate rhs

--- a/pySDC/implementations/convergence_controller_classes/adaptivity.py
+++ b/pySDC/implementations/convergence_controller_classes/adaptivity.py
@@ -448,6 +448,13 @@ smaller than 0!",
 
 
 class AdaptivityCollocation(AdaptivityBase):
+    """
+    Control the step size via a collocation based estimate of the local error.
+    The error estimate works by subtracting two solutions to collocation problems with different order. You can
+    interpolate between collocation methods as much as you want but the adaptive step size selection will always be
+    based on the last switch of quadrature.
+    """
+
     def setup(self, controller, params, description, **kwargs):
         """
         Add a default value for control order to the parameters.
@@ -537,8 +544,11 @@ class AdaptivityCollocation(AdaptivityBase):
             lvl = S.levels[0]
 
             # compute next step size
-            order = self.status.order[-2] + 1  # local order of second to most accurate solution
+            order = (
+                min(self.status.order[-2::]) + 1
+            )  # local order of less accurate of the last two collocation problems
             e_est = self.get_local_error_estimate(controller, S)
+
             lvl.status.dt_new = self.compute_optimal_step_size(
                 self.params.beta, lvl.params.dt, self.params.e_tol, e_est, order
             )

--- a/pySDC/implementations/convergence_controller_classes/estimate_embedded_error.py
+++ b/pySDC/implementations/convergence_controller_classes/estimate_embedded_error.py
@@ -270,7 +270,7 @@ class EstimateEmbeddedErrorCollocation(ConvergenceController):
             if len(self.status.u) > 1:
                 lvl.status.error_embedded_estimate_collocation = (
                     self.status.iter[-2],
-                    abs(self.status.u[-1] - self.status.u[-2]),
+                    max([np.finfo(float).eps, abs(self.status.u[-1] - self.status.u[-2])]),
                 )
 
     def setup_status_variables(self, controller, **kwargs):

--- a/pySDC/projects/Resilience/vdp.py
+++ b/pySDC/projects/Resilience/vdp.py
@@ -11,7 +11,7 @@ from pySDC.core.Errors import ProblemError, ConvergenceError
 from pySDC.projects.Resilience.hook import LogData, hook_collection
 
 
-def plot_step_sizes(stats, ax):
+def plot_step_sizes(stats, ax, e_em_key='error_embedded_estimate'):
     """
     Plot solution and step sizes to visualize the dynamics in the van der Pol equation.
 
@@ -28,7 +28,7 @@ def plot_step_sizes(stats, ax):
     p = np.array([me[1][1] for me in get_sorted(stats, type='u', recomputed=False, sortby='time')])
     t = np.array([me[0] for me in get_sorted(stats, type='u', recomputed=False, sortby='time')])
 
-    e_em = np.array(get_sorted(stats, type='error_embedded_estimate', recomputed=False, sortby='time'))[:, 1]
+    e_em = np.array(get_sorted(stats, type=e_em_key, recomputed=False, sortby='time'))[:, 1]
     dt = np.array(get_sorted(stats, type='dt', recomputed=False, sortby='time'))
     restart = np.array(get_sorted(stats, type='restart', recomputed=None, sortby='time'))
 

--- a/pySDC/tests/test_projects/test_resilience/test_adaptive_collocation.py
+++ b/pySDC/tests/test_projects/test_resilience/test_adaptive_collocation.py
@@ -2,7 +2,21 @@ import pytest
 
 
 @pytest.mark.base
-def test_main():
-    from pySDC.projects.Resilience.collocation_adaptivity import main
+def test_adaptivity_collocation():
+    from pySDC.projects.Resilience.collocation_adaptivity import adaptivity_collocation
 
-    main()
+    adaptivity_collocation(plotting=False)
+
+
+@pytest.mark.base
+def test_error_estimate_order():
+    from pySDC.projects.Resilience.collocation_adaptivity import order_stuff, run_advection
+
+    order_stuff(run_advection)
+
+
+@pytest.mark.base
+def test_adaptive_collocation():
+    from pySDC.projects.Resilience.collocation_adaptivity import compare_adaptive_collocation, run_vdp
+
+    compare_adaptive_collocation(run_vdp)


### PR DESCRIPTION
I apologise for the title.

This PR includes implementation for adaptivity using the error estimate from a few days ago.
There is a test running this with van der Pol which makes sure that the error threshold is not exceeded and also that the minimum error is no less than a tenth of the threshold. So this somewhat works now.

It remains to be seen what is the best configuration for running this. Should the order of the collocation problems increase or decrease? Do we care by how much we change the order? I.e. should we change the type of nodes or the number?

I have no idea as of now, but I am working on performance plots in other branches, which is why I would like to merge this now and do the analysis later as I go along with the paper, which I am spending 90% of my time on.