### PR TITLE
Improved tests for error estimate of Q

### DIFF
--- a/pySDC/tests/test_projects/test_resilience/test_extrapolated_error_within_Q.py
+++ b/pySDC/tests/test_projects/test_resilience/test_extrapolated_error_within_Q.py
@@ -2,21 +2,22 @@ import pytest
 
 
 @pytest.mark.base
-@pytest.mark.parametrize("prob_name", ['run_advection', 'run_piline'])
+@pytest.mark.parametrize("prob_name", ['advection', 'piline'])
 @pytest.mark.parametrize('num_nodes', [2, 3])
 @pytest.mark.parametrize('quad_type', ['RADAU-RIGHT', 'GAUSS'])
 def test_order_extrapolation_estimate_within_Q(prob_name, num_nodes, quad_type):
     from pySDC.projects.Resilience.extrapolation_within_Q import check_order
 
-    if prob_name == 'run_advection':
+    if prob_name == 'advection':
         from pySDC.projects.Resilience.advection import run_advection
 
         prob = run_advection
-    elif prob_name == 'run_piline':
+    elif prob_name == 'piline':
         from pySDC.projects.Resilience.piline import run_piline
 
         prob = run_piline
+
     else:
         raise NotImplementedError(f'Problem \"{prob_name}\" not implemented in this test!')
 
-    check_order(None, prob=prob, dts=[1e-1, 5e-2, 1e-2], Tend=5e-1, num_nodes=num_nodes, quad_type=quad_type)
+    check_order(None, prob=prob, dts=[5e-1, 1e-1, 5e-2, 1e-2], num_nodes=num_nodes, quad_type=quad_type)


### PR DESCRIPTION
I was excluding the test for the local error of the solution of the collocation problem because for advection I found it to be one order lower than expected. Later, I remembered this is because for advection, we have an analytic solution. That means when I use the hook for computing the local error, I am really computing the global error, which is one order less. So I tricked myself... Not a good sign...

Anyways, I now solve not to a specified time, but to a specified number of time steps, which gives me the local error again, which is of the expected order, and the tests assert this now.
This comes with the benefit of being faster as well.

So no functionality changes in the tiny PR, just a small fix for my stupidity which slightly improves the tests.