### PR TITLE
Embedded RK sweeper classes now contain the update order

### DIFF
--- a/pySDC/implementations/convergence_controller_classes/adaptivity.py
+++ b/pySDC/implementations/convergence_controller_classes/adaptivity.py
@@ -268,28 +268,10 @@ class AdaptivityRK(Adaptivity):
     Adaptivity for Runge-Kutta methods. Basically, we need to change the order in the step size update
     """
 
-    def check_parameters(self, controller, params, description, **kwargs):
-        """
-        Check whether parameters are compatible with whatever assumptions went into the step size functions etc.
-        For adaptivity, we need to know the order of the scheme.
-
-        Args:
-            controller (pySDC.Controller): The controller
-            params (dict): The params passed for this specific convergence controller
-            description (dict): The description object used to instantiate the controller
-
-        Returns:
-            bool: Whether the parameters are compatible
-            str: The error message
-        """
-        if "update_order" not in params.keys():
-            return (
-                False,
-                "Adaptivity needs an order for the update rule! Please set some up in \
-description['convergence_control_params']['update_order']!",
-            )
-
-        return super(AdaptivityRK, self).check_parameters(controller, params, description)
+    def setup(self, controller, params, description, **kwargs):
+        defaults = {}
+        defaults['update_order'] = params.get('update_order', description['sweeper_class'].get_update_order())
+        return {**defaults, **super().setup(controller, params, description, **kwargs)}
 
     def get_new_step_size(self, controller, S, **kwargs):
         """

--- a/pySDC/implementations/sweeper_classes/Runge_Kutta.py
+++ b/pySDC/implementations/sweeper_classes/Runge_Kutta.py
@@ -1,12 +1,9 @@
 import numpy as np
 import logging
 
-from pySDC.core.Sweeper import _Pars
+from pySDC.core.Sweeper import sweeper, _Pars
 from pySDC.core.Errors import ParameterError
-from pySDC.implementations.sweeper_classes.generic_implicit import generic_implicit
-from pySDC.implementations.sweeper_classes.imex_1st_order import imex_1st_order
 from pySDC.implementations.datatype_classes.mesh import imex_mesh, mesh
-from pySDC.core.Sweeper import sweeper
 
 
 class ButcherTableau(object):

--- a/pySDC/implementations/sweeper_classes/Runge_Kutta.py
+++ b/pySDC/implementations/sweeper_classes/Runge_Kutta.py
@@ -4,6 +4,9 @@ import logging
 from pySDC.core.Sweeper import _Pars
 from pySDC.core.Errors import ParameterError
 from pySDC.implementations.sweeper_classes.generic_implicit import generic_implicit
+from pySDC.implementations.sweeper_classes.imex_1st_order import imex_1st_order
+from pySDC.implementations.datatype_classes.mesh import imex_mesh, mesh
+from pySDC.core.Sweeper import sweeper
 
 
 class ButcherTableau(object):
@@ -119,7 +122,7 @@ class ButcherTableauEmbedded(object):
         self.implicit = any(matrix[i, i] != 0 for i in range(self.num_nodes - 2))
 
 
-class RungeKutta(generic_implicit):
+class RungeKutta(sweeper):
     """
     Runge-Kutta scheme that fits the interface of a sweeper.
     Actually, the sweeper idea fits the Runge-Kutta idea when using only lower triangular rules, where solutions
@@ -184,6 +187,55 @@ class RungeKutta(generic_implicit):
         self.parallelizable = False
         self.QI = self.coll.Qmat
 
+    @classmethod
+    def get_update_order(cls):
+        """
+        Get the order of the lower order method for doing adaptivity. Only applies to embedded methods.
+        """
+        raise NotImplementedError(
+            f"There is not an update order for RK scheme \"{cls.__name__}\" implemented. Maybe it is not an embedded scheme?"
+        )
+
+    def get_full_f(self, f):
+        """
+        Get the full right hand side as a `mesh` from the right hand side
+
+        Args:
+            f (dtype_f): Right hand side at a single node
+
+        Returns:
+            mesh: Full right hand side as a mesh
+        """
+        if type(f) == mesh:
+            return f
+        elif type(f) == imex_mesh:
+            return f.impl + f.expl
+        else:
+            raise NotImplementedError(f'Type \"{type(f)}\" not implemented in Runge-Kutta sweeper')
+
+    def integrate(self):
+        """
+        Integrates the right-hand side
+
+        Returns:
+            list of dtype_u: containing the integral as values
+        """
+
+        # get current level and problem description
+        L = self.level
+        P = L.prob
+
+        me = []
+
+        # integrate RHS over all collocation nodes
+        for m in range(1, self.coll.num_nodes + 1):
+            # new instance of dtype_u, initialize values with 0
+            me.append(P.dtype_u(P.init, val=0.0))
+            for j in range(1, self.coll.num_nodes + 1):
+                me[-1] += L.dt * self.coll.Qmat[m, j] * self.get_full_f(L.f[j])
+
+        return me
+
     def update_nodes(self):
         """
         Update the u- and f-values at the collocation nodes
@@ -207,7 +259,7 @@ class RungeKutta(generic_implicit):
             # build rhs, consisting of the known values from above and new values from previous nodes (at k+1)
             rhs = L.u[0]
             for j in range(1, m + 1):
-                rhs += L.dt * self.QI[m + 1, j] * L.f[j]
+                rhs += L.dt * self.QI[m + 1, j] * self.get_full_f(L.f[j])
 
             # implicit solve with prefactor stemming from the diagonal of Qd
             if self.coll.implicit:
@@ -223,6 +275,12 @@ class RungeKutta(generic_implicit):
         L.status.updated = True
 
         return None
+
+    def compute_end_point(self):
+        """
+        In this Runge-Kutta implementation, the solution to the step is always stored in the last node
+        """
+        self.level.uend = self.level.u[-1]
 
 
 class RK1(RungeKutta):
@@ -284,7 +342,7 @@ class MidpointMethod(RungeKutta):
 
 class RK4(RungeKutta):
     """
-    Explicit Runge-Kutta of fourth order: Everybodies darling.
+    Explicit Runge-Kutta of fourth order: Everybody's darling.
     """
 
     def __init__(self, params):
@@ -311,10 +369,14 @@ class Heun_Euler(RungeKutta):
         params['butcher_tableau'] = ButcherTableauEmbedded(weights, nodes, matrix)
         super(Heun_Euler, self).__init__(params)
 
+    @classmethod
+    def get_update_order(cls):
+        return 2
+
 
 class Cash_Karp(RungeKutta):
     """
-    Fifth order explicit embedded Runge-Kutta
+    Fifth order explicit embedded Runge-Kutta. See [here](https://doi.org/10.1145/79505.79507).
     """
 
     def __init__(self, params):
@@ -333,6 +395,10 @@ class Cash_Karp(RungeKutta):
         matrix[5, :5] = [1631.0 / 55296.0, 175.0 / 512.0, 575.0 / 13824.0, 44275.0 / 110592.0, 253.0 / 4096.0]
         params['butcher_tableau'] = ButcherTableauEmbedded(weights, nodes, matrix)
         super(Cash_Karp, self).__init__(params)
+
+    @classmethod
+    def get_update_order(cls):
+        return 5
 
 
 class DIRK34(RungeKutta):
@@ -354,3 +420,7 @@ class DIRK34(RungeKutta):
         matrix[3, :] = [4007.0 / 6075.0, -31031.0 / 24300.0, -133.0 / 2700.0, 5.0 / 6.0]
         params['butcher_tableau'] = ButcherTableauEmbedded(weights, nodes, matrix)
         super().__init__(params)
+
+    @classmethod
+    def get_update_order(cls):
+        return 4

--- a/pySDC/tests/test_Runge_Kutta_sweeper.py
+++ b/pySDC/tests/test_Runge_Kutta_sweeper.py
@@ -1,309 +1,300 @@
-import matplotlib.pyplot as plt
-import numpy as np
 import pytest
 
-from pySDC.implementations.sweeper_classes.Runge_Kutta import (
-    RK1,
-    RK4,
-    MidpointMethod,
-    CrankNicholson,
-    Cash_Karp,
-    Heun_Euler,
-    DIRK34,
-)
-from pySDC.implementations.convergence_controller_classes.adaptivity import AdaptivityRK
-from pySDC.implementations.convergence_controller_classes.estimate_embedded_error import EstimateEmbeddedErrorNonMPI
-from pySDC.helpers.stats_helper import get_sorted
 
-
-colors = {
-    RK1: 'blue',
-    MidpointMethod: 'red',
-    RK4: 'orange',
-    CrankNicholson: 'purple',
-    Cash_Karp: 'teal',
-}
-
-
-def plot_order(sweeper, prob, dt_list, description=None, ax=None, Tend_fixed=None, implicit=True):
-    """
-    Make a plot of the order of the scheme and test if it has the correct order
-
-    Args:
-        sweeper (pySDC.Sweeper.RungeKutta): The RK rule to try
-        prob (function): Some function that runs a pySDC problem and accepts suitable parameters, see resilience project
-        dt_list (list): List of step sizes to try
-        description (dict): A description to use for running the problem
-        ax: Somewhere to plot
-        Tend_fixed (float): Time to integrate to with each step size
-        implicit (bool): Whether to use implicit or explicit versions of RK rules
-
-    Returns:
-        None
-    """
-    from pySDC.projects.Resilience.accuracy_check import plot_orders
-
-    if ax is None:
-        fig, ax = plt.subplots(1, 1)
-
-    description = dict() if description is None else description
-    description['sweeper_class'] = sweeper
-    description['sweeper_params'] = {'implicit': implicit}
-    description['step_params'] = {'maxiter': 1}
-
-    custom_controller_params = {'logger_level': 40}
-
-    # determine the order
-    plot_orders(
-        ax,
-        [1],
-        True,
-        Tend_fixed=Tend_fixed,
-        custom_description=description,
-        dt_list=dt_list,
-        prob=prob,
-        custom_controller_params=custom_controller_params,
+@pytest.mark.base
+def test_rk():
+    import matplotlib.pyplot as plt
+    import numpy as np
+    from pySDC.implementations.sweeper_classes.Runge_Kutta import (
+        RK1,
+        RK4,
+        MidpointMethod,
+        CrankNicholson,
+        Cash_Karp,
+        Heun_Euler,
+        DIRK34,
     )
+    from pySDC.implementations.convergence_controller_classes.adaptivity import AdaptivityRK
+    from pySDC.implementations.convergence_controller_classes.estimate_embedded_error import EstimateEmbeddedErrorNonMPI
+    from pySDC.helpers.stats_helper import get_sorted
 
-    # check if we got the expected order for the local error
-    orders = {
-        RK1: 2,
-        MidpointMethod: 3,
-        RK4: 5,
-        CrankNicholson: 3,
-        Cash_Karp: 6,
+    colors = {
+        RK1: 'blue',
+        MidpointMethod: 'red',
+        RK4: 'orange',
+        CrankNicholson: 'purple',
+        Cash_Karp: 'teal',
     }
-    numerical_order = float(ax.get_lines()[-1].get_label()[7:])
-    expected_order = orders.get(sweeper, numerical_order)
-    assert np.isclose(
-        numerical_order, expected_order, atol=2.6e-1
-    ), f"Expected order {expected_order}, got {numerical_order}!"
 
-    # decorate
-    ax.get_lines()[-1].set_color(colors.get(sweeper, 'black'))
+    def plot_order(sweeper, prob, dt_list, description=None, ax=None, Tend_fixed=None, implicit=True):
+        """
+        Make a plot of the order of the scheme and test if it has the correct order
 
-    label = f'{sweeper.__name__} - {ax.get_lines()[-1].get_label()[5:]}'
-    ax.get_lines()[-1].set_label(label)
-    ax.legend(frameon=False)
+        Args:
+            sweeper (pySDC.Sweeper.RungeKutta): The RK rule to try
+            prob (function): Some function that runs a pySDC problem and accepts suitable parameters, see resilience project
+            dt_list (list): List of step sizes to try
+            description (dict): A description to use for running the problem
+            ax: Somewhere to plot
+            Tend_fixed (float): Time to integrate to with each step size
+            implicit (bool): Whether to use implicit or explicit versions of RK rules
 
+        Returns:
+            None
+        """
+        from pySDC.projects.Resilience.accuracy_check import plot_orders
 
-def plot_stability_single(sweeper, ax=None, description=None, implicit=True, re=None, im=None, crosshair=True):
-    """
-    Plot the domain of stability for a single RK rule.
+        if ax is None:
+            fig, ax = plt.subplots(1, 1)
 
-    Args:
-        sweeper (pySDC.Sweeper.RungeKutta)
-        ax: Somewhere to plot
-        description (dict): A description to use for running the problem
-        implicit (bool): Whether to use implicit or explicit versions of RK rules
-        re (numpy.ndarray): A range of values for the real axis
-        im (numpy.ndarray): A range of values for the imaginary axis
-        crosshair (bool): Whether to emphasize the axes
+        description = dict() if description is None else description
+        description['sweeper_class'] = sweeper
+        description['sweeper_params'] = {'implicit': implicit}
+        description['step_params'] = {'maxiter': 1}
 
-    Returns:
-        None
-    """
-    from pySDC.projects.Resilience.dahlquist import run_dahlquist, plot_stability
+        custom_controller_params = {'logger_level': 40}
 
-    if ax is None:
+        # determine the order
+        plot_orders(
+            ax,
+            [1],
+            True,
+            Tend_fixed=Tend_fixed,
+            custom_description=description,
+            dt_list=dt_list,
+            prob=prob,
+            custom_controller_params=custom_controller_params,
+        )
+
+        # check if we got the expected order for the local error
+        orders = {
+            RK1: 2,
+            MidpointMethod: 3,
+            RK4: 5,
+            CrankNicholson: 3,
+            Cash_Karp: 6,
+        }
+        numerical_order = float(ax.get_lines()[-1].get_label()[7:])
+        expected_order = orders.get(sweeper, numerical_order)
+        assert np.isclose(
+            numerical_order, expected_order, atol=2.6e-1
+        ), f"Expected order {expected_order}, got {numerical_order}!"
+
+        # decorate
+        ax.get_lines()[-1].set_color(colors.get(sweeper, 'black'))
+
+        label = f'{sweeper.__name__} - {ax.get_lines()[-1].get_label()[5:]}'
+        ax.get_lines()[-1].set_label(label)
+        ax.legend(frameon=False)
+
+    def plot_stability_single(sweeper, ax=None, description=None, implicit=True, re=None, im=None, crosshair=True):
+        """
+        Plot the domain of stability for a single RK rule.
+
+        Args:
+            sweeper (pySDC.Sweeper.RungeKutta)
+            ax: Somewhere to plot
+            description (dict): A description to use for running the problem
+            implicit (bool): Whether to use implicit or explicit versions of RK rules
+            re (numpy.ndarray): A range of values for the real axis
+            im (numpy.ndarray): A range of values for the imaginary axis
+            crosshair (bool): Whether to emphasize the axes
+
+        Returns:
+            None
+        """
+        from pySDC.projects.Resilience.dahlquist import run_dahlquist, plot_stability
+
+        if ax is None:
+            fig, ax = plt.subplots(1, 1)
+
+        description = dict() if description is None else description
+        description['sweeper_class'] = sweeper
+        description['sweeper_params'] = {'implicit': implicit}
+        description['step_params'] = {'maxiter': 1}
+
+        custom_controller_params = {'logger_level': 40}
+
+        re = np.linspace(-30, 30, 400) if re is None else re
+        im = np.linspace(-50, 50, 400) if im is None else im
+        lambdas = np.array([[complex(re[i], im[j]) for i in range(len(re))] for j in range(len(im))]).reshape(
+            (len(re) * len(im))
+        )
+        custom_problem_params = {'lambdas': lambdas}
+
+        stats, _, _ = run_dahlquist(
+            custom_description=description,
+            custom_problem_params=custom_problem_params,
+            custom_controller_params=custom_controller_params,
+        )
+        Astable = plot_stability(
+            stats, ax=ax, iter=[1], colors=[colors.get(sweeper, 'black')], crosshair=crosshair, fill=True
+        )
+
+        # check if we think the method should be A-stable
+        Astable_methods = [RK1, CrankNicholson, MidpointMethod, DIRK34]  # only the implicit versions are A-stable
+        assert (
+            implicit and sweeper in Astable_methods
+        ) == Astable, f"Unexpected region of stability for {sweeper.__name__} sweeper!"
+
+        ax.get_lines()[-1].set_label(sweeper.__name__)
+        ax.legend(frameon=False)
+
+    def test_all_stability():
+        """
+        Make a figure showing domains of stability for a range of RK rules, both implicit and explicit.
+
+        Returns:
+            None
+        """
+        fig, axs = plt.subplots(1, 2, figsize=(11, 5))
+
+        impl = [True, False]
+        sweepers = [[RK1, MidpointMethod, CrankNicholson], [RK1, MidpointMethod, RK4, Cash_Karp]]
+        titles = ['implicit', 'explicit']
+        re = np.linspace(-4, 4, 400)
+        im = np.linspace(-4, 4, 400)
+        crosshair = [True, False, False, False]
+
+        for j in range(len(impl)):
+            for i in range(len(sweepers[j])):
+                plot_stability_single(sweepers[j][i], implicit=impl[j], ax=axs[j], re=re, im=im, crosshair=crosshair[i])
+            axs[j].set_title(titles[j])
+
+        plot_stability_single(DIRK34, re=re, im=im)
+
+        fig.tight_layout()
+
+    def plot_all_orders(prob, dt_list, Tend, sweepers, implicit=True):
+        """
+        Make a plot with various sweepers and check their order.
+
+        Args:
+            prob (function): Some function that runs a pySDC problem and accepts suitable parameters, see resilience project
+            dt_list (list): List of step sizes to try
+            Tend (float): Time to solve to with each step size
+            sweepers (list): List of RK rules to try
+            implicit (bool): Whether to use implicit or explicit versions of RK rules
+
+        Returns:
+            None
+        """
+        fig, ax = plt.subplots(1, 1)
+        for i in range(len(sweepers)):
+            plot_order(sweepers[i], prob, dt_list, Tend_fixed=Tend, ax=ax, implicit=implicit)
+
+    def test_vdp():
+        """
+        Here, we check the order in time for various implicit RK rules with the van der Pol problem.
+        This is interesting, because van der Pol is non-linear.
+
+        Returns:
+            None
+        """
+        from pySDC.projects.Resilience.vdp import run_vdp
+
+        Tend = 7e-2
+        plot_all_orders(
+            run_vdp, Tend * 2.0 ** (-np.arange(8)), Tend, [RK1, MidpointMethod, CrankNicholson, RK4, Cash_Karp]
+        )
+
+    def test_advection():
+        """
+        Here, we check the order in time for various implicit and explicit RK rules with an advection problem.
+
+        Returns:
+            None
+        """
+        from pySDC.projects.Resilience.advection import run_advection
+
+        plot_all_orders(
+            run_advection, 1.0e-3 * 2.0 ** (-np.arange(8)), None, [RK1, MidpointMethod, CrankNicholson], implicit=True
+        )
+        plot_all_orders(run_advection, 1.0e-3 * 2.0 ** (-np.arange(8)), None, [RK1, MidpointMethod], implicit=False)
+
+    def test_embedded_estimate_order(sweeper):
+        """
+        Test the order of embedded Runge-Kutta schemes. They are not run with adaptivity here,
+        so we can simply vary the step size and check the embedded error estimate.
+
+        Args:
+            sweeper (pySDC.Sweeper.RungeKutta)
+
+        Returns:
+            None
+        """
+        from pySDC.projects.Resilience.vdp import run_vdp
+        from pySDC.projects.Resilience.accuracy_check import plot_all_errors
+
         fig, ax = plt.subplots(1, 1)
 
-    description = dict() if description is None else description
-    description['sweeper_class'] = sweeper
-    description['sweeper_params'] = {'implicit': implicit}
-    description['step_params'] = {'maxiter': 1}
+        # change only the things in the description that we need for adaptivity
+        convergence_controllers = dict()
+        convergence_controllers[EstimateEmbeddedErrorNonMPI] = {}
 
-    custom_controller_params = {'logger_level': 40}
+        description = dict()
+        description['convergence_controllers'] = convergence_controllers
+        description['sweeper_class'] = sweeper
+        description['step_params'] = {'maxiter': 1}
 
-    re = np.linspace(-30, 30, 400) if re is None else re
-    im = np.linspace(-50, 50, 400) if im is None else im
-    lambdas = np.array([[complex(re[i], im[j]) for i in range(len(re))] for j in range(len(im))]).reshape(
-        (len(re) * len(im))
-    )
-    custom_problem_params = {'lambdas': lambdas}
+        custom_controller_params = {'logger_level': 40}
 
-    stats, _, _ = run_dahlquist(
-        custom_description=description,
-        custom_problem_params=custom_problem_params,
-        custom_controller_params=custom_controller_params,
-    )
-    Astable = plot_stability(
-        stats, ax=ax, iter=[1], colors=[colors.get(sweeper, 'black')], crosshair=crosshair, fill=True
-    )
+        Tend = 7e-2
+        dt_list = Tend * 2.0 ** (-np.arange(8))
+        prob = run_vdp
+        plot_all_errors(
+            ax,
+            [sweeper.get_update_order()],
+            True,
+            Tend_fixed=Tend,
+            custom_description=description,
+            dt_list=dt_list,
+            prob=prob,
+            custom_controller_params=custom_controller_params,
+        )
 
-    # check if we think the method should be A-stable
-    Astable_methods = [RK1, CrankNicholson, MidpointMethod, DIRK34]  # only the implicit versions are A-stable
-    assert (
-        implicit and sweeper in Astable_methods
-    ) == Astable, f"Unexpected region of stability for {sweeper.__name__} sweeper!"
+    def test_embedded_method():
+        """
+        Here, we test if Cash Karp's method gives a hard-coded result and number of restarts when running with adaptivity.
 
-    ax.get_lines()[-1].set_label(sweeper.__name__)
-    ax.legend(frameon=False)
+        Returns:
+            None
+        """
+        from pySDC.projects.Resilience.vdp import run_vdp, plot_step_sizes
 
+        sweeper = Cash_Karp
+        fig, ax = plt.subplots(1, 1)
 
-@pytest.mark.base
-def test_all_stability():
-    """
-    Make a figure showing domains of stability for a range of RK rules, both implicit and explicit.
+        # change only the things in the description that we need for adaptivity
+        adaptivity_params = dict()
+        adaptivity_params['e_tol'] = 1e-7
+        adaptivity_params['update_order'] = 5
 
-    Returns:
-        None
-    """
-    fig, axs = plt.subplots(1, 2, figsize=(11, 5))
+        convergence_controllers = dict()
+        convergence_controllers[AdaptivityRK] = adaptivity_params
 
-    impl = [True, False]
-    sweepers = [[RK1, MidpointMethod, CrankNicholson], [RK1, MidpointMethod, RK4, Cash_Karp]]
-    titles = ['implicit', 'explicit']
-    re = np.linspace(-4, 4, 400)
-    im = np.linspace(-4, 4, 400)
-    crosshair = [True, False, False, False]
+        description = dict()
+        description['convergence_controllers'] = convergence_controllers
+        description['sweeper_class'] = sweeper
+        description['step_params'] = {'maxiter': 1}
 
-    for j in range(len(impl)):
-        for i in range(len(sweepers[j])):
-            plot_stability_single(sweepers[j][i], implicit=impl[j], ax=axs[j], re=re, im=im, crosshair=crosshair[i])
-        axs[j].set_title(titles[j])
+        custom_controller_params = {'logger_level': 40}
 
-    plot_stability_single(DIRK34, re=re, im=im)
+        stats, _, _ = run_vdp(description, 1, custom_controller_params=custom_controller_params)
+        plot_step_sizes(stats, ax)
 
-    fig.tight_layout()
+        fig.tight_layout()
 
+        dt_last = get_sorted(stats, type='dt')[-2][1]
+        restarts = sum([me[1] for me in get_sorted(stats, type='restart')])
+        assert np.isclose(
+            dt_last, 0.14175080252629996
+        ), "Cash-Karp has computed a different last step size than before!"
+        assert restarts == 17, "Cash-Karp has restarted a different number of times than before"
 
-def plot_all_orders(prob, dt_list, Tend, sweepers, implicit=True):
-    """
-    Make a plot with various sweepers and check their order.
-
-    Args:
-        prob (function): Some function that runs a pySDC problem and accepts suitable parameters, see resilience project
-        dt_list (list): List of step sizes to try
-        Tend (float): Time to solve to with each step size
-        sweepers (list): List of RK rules to try
-        implicit (bool): Whether to use implicit or explicit versions of RK rules
-
-    Returns:
-        None
-    """
-    fig, ax = plt.subplots(1, 1)
-    for i in range(len(sweepers)):
-        plot_order(sweepers[i], prob, dt_list, Tend_fixed=Tend, ax=ax, implicit=implicit)
-
-
-@pytest.mark.base
-def test_vdp():
-    """
-    Here, we check the order in time for various implicit RK rules with the van der Pol problem.
-    This is interesting, because van der Pol is non-linear.
-
-    Returns:
-        None
-    """
-    from pySDC.projects.Resilience.vdp import run_vdp
-
-    Tend = 7e-2
-    plot_all_orders(run_vdp, Tend * 2.0 ** (-np.arange(8)), Tend, [RK1, MidpointMethod, CrankNicholson, RK4, Cash_Karp])
-
-
-@pytest.mark.base
-def test_advection():
-    """
-    Here, we check the order in time for various implicit and explicit RK rules with an advection problem.
-
-    Returns:
-        None
-    """
-    from pySDC.projects.Resilience.advection import run_advection
-
-    plot_all_orders(
-        run_advection, 1.0e-3 * 2.0 ** (-np.arange(8)), None, [RK1, MidpointMethod, CrankNicholson], implicit=True
-    )
-    plot_all_orders(run_advection, 1.0e-3 * 2.0 ** (-np.arange(8)), None, [RK1, MidpointMethod], implicit=False)
-
-
-@pytest.mark.base
-@pytest.mark.parametrize("sweeper", [Cash_Karp, Heun_Euler, DIRK34])
-def test_embedded_estimate_order(sweeper):
-    """
-    Test the order of embedded Runge-Kutta schemes. They are not run with adaptivity here,
-    so we can simply vary the step size and check the embedded error estimate.
-
-    Args:
-        sweeper (pySDC.Sweeper.RungeKutta)
-
-    Returns:
-        None
-    """
-    from pySDC.projects.Resilience.vdp import run_vdp
-    from pySDC.projects.Resilience.accuracy_check import plot_all_errors
-
-    fig, ax = plt.subplots(1, 1)
-
-    # change only the things in the description that we need for adaptivity
-    convergence_controllers = dict()
-    convergence_controllers[EstimateEmbeddedErrorNonMPI] = {}
-
-    description = dict()
-    description['convergence_controllers'] = convergence_controllers
-    description['sweeper_class'] = sweeper
-    description['step_params'] = {'maxiter': 1}
-
-    custom_controller_params = {'logger_level': 40}
-
-    Tend = 7e-2
-    dt_list = Tend * 2.0 ** (-np.arange(8))
-    prob = run_vdp
-    plot_all_errors(
-        ax,
-        [sweeper.get_update_order()],
-        True,
-        Tend_fixed=Tend,
-        custom_description=description,
-        dt_list=dt_list,
-        prob=prob,
-        custom_controller_params=custom_controller_params,
-    )
-
-
-@pytest.mark.base
-def test_embedded_method():
-    """
-    Here, we test if Cash Karp's method gives a hard-coded result and number of restarts when running with adaptivity.
-
-    Returns:
-        None
-    """
-    from pySDC.projects.Resilience.vdp import run_vdp, plot_step_sizes
-
-    sweeper = Cash_Karp
-    fig, ax = plt.subplots(1, 1)
-
-    # change only the things in the description that we need for adaptivity
-    adaptivity_params = dict()
-    adaptivity_params['e_tol'] = 1e-7
-    adaptivity_params['update_order'] = 5
-
-    convergence_controllers = dict()
-    convergence_controllers[AdaptivityRK] = adaptivity_params
-
-    description = dict()
-    description['convergence_controllers'] = convergence_controllers
-    description['sweeper_class'] = sweeper
-    description['step_params'] = {'maxiter': 1}
-
-    custom_controller_params = {'logger_level': 40}
-
-    stats, _, _ = run_vdp(description, 1, custom_controller_params=custom_controller_params)
-    plot_step_sizes(stats, ax)
-
-    fig.tight_layout()
-
-    dt_last = get_sorted(stats, type='dt')[-2][1]
-    restarts = sum([me[1] for me in get_sorted(stats, type='restart')])
-    assert np.isclose(dt_last, 0.14175080252629996), "Cash-Karp has computed a different last step size than before!"
-    assert restarts == 17, "Cash-Karp has restarted a different number of times than before"
-
-
-if __name__ == '__main__':
     test_embedded_method()
-    test_embedded_estimate_order(Cash_Karp)
+    for sweep in [Cash_Karp, Heun_Euler, DIRK34]:
+        test_embedded_estimate_order(sweep)
     test_vdp()
     test_advection()
     test_all_stability()

--- a/pySDC/tests/test_Runge_Kutta_sweeper.py
+++ b/pySDC/tests/test_Runge_Kutta_sweeper.py
@@ -247,18 +247,12 @@ def test_embedded_estimate_order(sweeper):
 
     custom_controller_params = {'logger_level': 40}
 
-    expected_order = {
-        Cash_Karp: [5],
-        Heun_Euler: [2],
-        DIRK34: [4],
-    }
-
     Tend = 7e-2
     dt_list = Tend * 2.0 ** (-np.arange(8))
     prob = run_vdp
     plot_all_errors(
         ax,
-        expected_order.get(sweeper, None),
+        [sweeper.get_update_order()],
         True,
         Tend_fixed=Tend,
         custom_description=description,


### PR DESCRIPTION
Previously you had to supply that manually, which was stupid. That's all that changed in this PR functionality wise.

Because of the aforementioned CI nonsense, I had to put all tests inside a function where I can do the imports. This is not the most pretty thing because then you can't easily see which test exactly failed, but this is a lazy approach that works...