### PR TITLE
Embedded error for multiple steps is no longer linearized by default

### DIFF
--- a/pySDC/implementations/convergence_controller_classes/adaptive_collocation.py
+++ b/pySDC/implementations/convergence_controller_classes/adaptive_collocation.py
@@ -63,7 +63,7 @@ class AdaptiveCollocation(ConvergenceController):
         }
 
         # only these keys can be changed by this convergence controller
-        self.allowed_sweeper_keys = ['quad_type', 'num_nodes', 'node_type']
+        self.allowed_sweeper_keys = ['quad_type', 'num_nodes', 'node_type', 'do_coll_update']
         self.allowed_level_keys = ['restol']
 
         # add the keys to lists so we know what we need to change later

--- a/pySDC/implementations/convergence_controller_classes/check_convergence.py
+++ b/pySDC/implementations/convergence_controller_classes/check_convergence.py
@@ -47,7 +47,7 @@ class CheckConvergence(ConvergenceController):
             )
 
             controller.add_convergence_controller(
-                EstimateEmbeddedError.get_implementation("nonMPI" if not self.params.useMPI else "MPI"),
+                EstimateEmbeddedError,
                 description=description,
             )
 

--- a/pySDC/implementations/convergence_controller_classes/estimate_contraction_factor.py
+++ b/pySDC/implementations/convergence_controller_classes/estimate_contraction_factor.py
@@ -35,7 +35,7 @@ class EstimateContractionFactor(ConvergenceController):
             None
         """
         controller.add_convergence_controller(
-            EstimateEmbeddedError.get_implementation("nonMPI" if not self.params.useMPI else "MPI"),
+            EstimateEmbeddedError,
             description=description,
         )
 

--- a/pySDC/implementations/convergence_controller_classes/hotrod.py
+++ b/pySDC/implementations/convergence_controller_classes/hotrod.py
@@ -48,21 +48,17 @@ class HotRod(ConvergenceController):
         Returns:
             None
         """
-        if not self.params.useMPI:
-            from pySDC.implementations.convergence_controller_classes.estimate_embedded_error import (
-                EstimateEmbeddedErrorNonMPI,
-            )
+        from pySDC.implementations.convergence_controller_classes.estimate_embedded_error import EstimateEmbeddedError
 
-            controller.add_convergence_controller(EstimateEmbeddedErrorNonMPI, description=description)
+        controller.add_convergence_controller(
+            EstimateEmbeddedError.get_implementation(flavor='linearized', useMPI=self.params.useMPI),
+            description=description,
+        )
+        if not self.params.useMPI:
             controller.add_convergence_controller(
                 EstimateExtrapolationErrorNonMPI, description=description, params={'no_storage': self.params.no_storage}
             )
         else:
-            from pySDC.implementations.convergence_controller_classes.estimate_embedded_error import (
-                EstimateEmbeddedErrorMPI,
-            )
-
-            controller.add_convergence_controller(EstimateEmbeddedErrorMPI, description=description)
             raise NotImplementedError("Don't know how to estimate extrapolated error with MPI")
 
     def check_parameters(self, controller, params, description, **kwargs):

--- a/pySDC/projects/Resilience/accuracy_check.py
+++ b/pySDC/projects/Resilience/accuracy_check.py
@@ -3,7 +3,7 @@ import matplotlib.pylab as plt
 import numpy as np
 
 from pySDC.helpers.stats_helper import get_sorted
-from pySDC.implementations.convergence_controller_classes.estimate_embedded_error import EstimateEmbeddedErrorNonMPI
+from pySDC.implementations.convergence_controller_classes.estimate_embedded_error import EstimateEmbeddedError
 from pySDC.implementations.convergence_controller_classes.estimate_extrapolation_error import (
     EstimateExtrapolationErrorNonMPI,
 )
@@ -123,7 +123,7 @@ def multiple_runs(
         desc = {
             'step_params': {'maxiter': k},
             'convergence_controllers': {
-                EstimateEmbeddedErrorNonMPI: {},
+                EstimateEmbeddedError: {},
                 EstimateExtrapolationErrorNonMPI: {'no_storage': not serial},
             },
         }

--- a/pySDC/projects/Resilience/collocation_adaptivity.py
+++ b/pySDC/projects/Resilience/collocation_adaptivity.py
@@ -244,7 +244,7 @@ def check_order(prob, coll_name, ax, k_ax):
             order = get_accuracy_order(me, key=i, thresh=1e-9)
             assert np.isclose(
                 np.mean(order), expected_order, atol=0.3
-            ), f"Expected order: {expected_order}, got {order:.2f}!"
+            ), f"Expected order: {expected_order}, got {np.mean(order):.2f}!"
         ax.loglog(result['dt'], result[i], label=f'{label} nodes: order: {np.mean(order):.1f}', color=CMAP[i])
 
         if i > 0:

--- a/pySDC/projects/Resilience/piline.py
+++ b/pySDC/projects/Resilience/piline.py
@@ -352,6 +352,7 @@ def main():
         if use_adaptivity:
             custom_description['convergence_controllers'][Adaptivity] = {
                 'e_tol': 1e-7,
+                'embedded_error_flavor': 'linearized',
             }
 
         for num_procs in [1, 4]:

--- a/pySDC/tests/test_Runge_Kutta_sweeper.py
+++ b/pySDC/tests/test_Runge_Kutta_sweeper.py
@@ -15,7 +15,7 @@ def test_rk():
         DIRK34,
     )
     from pySDC.implementations.convergence_controller_classes.adaptivity import AdaptivityRK
-    from pySDC.implementations.convergence_controller_classes.estimate_embedded_error import EstimateEmbeddedErrorNonMPI
+    from pySDC.implementations.convergence_controller_classes.estimate_embedded_error import EstimateEmbeddedError
     from pySDC.helpers.stats_helper import get_sorted
 
     colors = {
@@ -230,7 +230,7 @@ def test_rk():
 
         # change only the things in the description that we need for adaptivity
         convergence_controllers = dict()
-        convergence_controllers[EstimateEmbeddedErrorNonMPI] = {}
+        convergence_controllers[EstimateEmbeddedError] = {}
 
         description = dict()
         description['convergence_controllers'] = convergence_controllers


### PR DESCRIPTION
This turns out to be more efficient for adaptivity.
Also when continuing to iterate instead of restarting, we make sure not to over-resolve the collocation problem now.