### PR TITLE
Copy generated plots into subdir of created html

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -267,6 +267,7 @@ jobs:
           sphinx-build -b html docs/source docs/build/html
           mkdir -p docs/build/html/coverage
           mv htmlcov/* docs/build/html/coverage/.
+          cp -r data docs/build/html/
 
 #      - name: Build html II
 #        if: "!contains(github.event.head_commit.message, '[CI-no-benchmarks]')"

--- a/docs/source/projects/doc_SDC_showdown.rst
+++ b/docs/source/projects/doc_SDC_showdown.rst
@@ -4,7 +4,7 @@ Full code: `pySDC/projects/SDC_showdown/SDC_timing_Fisher.py <https://github.com
 
 Results:
 
-.. image:: ../../../data/timings_SDC_variants_Fisher.png
+.. image:: ./data/timings_SDC_variants_Fisher.png
    :scale: 100 %
 
 
@@ -14,5 +14,5 @@ Full code: `pySDC/projects/SDC_showdown/SDC_timing_GrayScott.py <https://github.
 
 Results:
 
-.. image:: ../../../data/timings_SDC_variants_GrayScott.png
+.. image:: ./data/timings_SDC_variants_GrayScott.png
    :scale: 100 %

--- a/docs/source/projects/doc_asympconv.rst
+++ b/docs/source/projects/doc_asympconv.rst
@@ -1,14 +1,14 @@
 Results:
 
-.. image:: ../../../data/conv_test_niter_NS3.png
+.. image:: ./data/conv_test_niter_NS3.png
    :width: 19%
 
-.. image:: ../../../data/conv_test_niter_NS2.png
+.. image:: ./data/conv_test_niter_NS2.png
    :width: 19%
 
-.. image:: ../../../data/conv_test_niter_Linf_diffusion.png
+.. image:: ./data/conv_test_niter_Linf_diffusion.png
    :width: 19%
 
-.. image:: ../../../data/conv_test_niter_Linf_advection.png
+.. image:: ./data/conv_test_niter_Linf_advection.png
    :width: 19%
 

--- a/docs/source/projects/doc_fput.rst
+++ b/docs/source/projects/doc_fput.rst
@@ -4,13 +4,13 @@ Full code: `pySDC/projects/Hamiltonian/fput.py <https://github.com/Parallel-in-T
 
 Results:
 
-.. literalinclude:: ../../../data/fput_out.txt
+.. literalinclude:: ./data/fput_out.txt
 
-.. image:: ../../../data/fput_hamiltonian.png
+.. image:: ./data/fput_hamiltonian.png
    :scale: 100 %
-.. image:: ../../../data/fput_positions.png
+.. image:: ./data/fput_positions.png
    :scale: 100 %
-.. image:: ../../../data/fput_energy.png
+.. image:: ./data/fput_energy.png
    :scale: 100 %
 .. image:: ../../../pySDC/projects/Hamiltonian/data/fput_energy_full.png
    :scale: 100 %

--- a/docs/source/projects/doc_fwsw_acoustic.rst
+++ b/docs/source/projects/doc_fwsw_acoustic.rst
@@ -1,10 +1,10 @@
 Results:
 
-.. image:: ../../../data/convergence.png
+.. image:: ./data/convergence.png
    :width: 19%
 
-.. image:: ../../../data/iteration.png
+.. image:: ./data/iteration.png
    :width: 19%
 
-.. image:: ../../../data/multiscale-K2-M2.png
+.. image:: ./data/multiscale-K2-M2.png
    :width: 19%

--- a/docs/source/projects/doc_fwsw_boussinesq.rst
+++ b/docs/source/projects/doc_fwsw_boussinesq.rst
@@ -1,4 +1,4 @@
 Results (generated with `plotgmrescounter_boussinesq.py <https://github.com/Parallel-in-Time/pySDC/blob/master/pySDC/projects/FastWaveSlowWave/plotgmrescounter_boussinesq.py>`_):
 
-.. image:: ../../../data/boussinesq.png
+.. image:: ./data/boussinesq.png
    :width: 19%

--- a/docs/source/projects/doc_fwsw_theory.rst
+++ b/docs/source/projects/doc_fwsw_theory.rst
@@ -1,22 +1,22 @@
 Results:
 
-.. image:: ../../../data/stifflimit-specrad.png
+.. image:: ./data/stifflimit-specrad.png
    :width: 19%
 
-.. image:: ../../../data/stifflimit-norm.png
+.. image:: ./data/stifflimit-norm.png
    :width: 19%
 
-.. image:: ../../../data/stability-K3-M3.png
+.. image:: ./data/stability-K3-M3.png
    :width: 19%
 
-.. image:: ../../../data/stab_vs_k_resolved.png
+.. image:: ./data/stab_vs_k_resolved.png
    :width: 19%
 
-.. image:: ../../../data/stab_vs_k_unresolved.png
+.. image:: ./data/stab_vs_k_unresolved.png
    :width: 19%
 
-.. image:: ../../../data/phase-K3-M3.png
+.. image:: ./data/phase-K3-M3.png
    :width: 19%
 
-.. image:: ../../../data/ampfactor-K3-M3.png
+.. image:: ./data/ampfactor-K3-M3.png
    :width: 19%

--- a/docs/source/projects/doc_hamiltonian_simple.rst
+++ b/docs/source/projects/doc_hamiltonian_simple.rst
@@ -4,10 +4,10 @@ Full code: `pySDC/projects/Hamiltonian/simple_problems.py <https://github.com/Pa
 
 Results:
 
-.. image:: ../../../data/harmonic_hamiltonian.png
+.. image:: ./data/harmonic_hamiltonian.png
    :scale: 50 %
 
-.. image:: ../../../data/henonheiles_hamiltonian.png
+.. image:: ./data/henonheiles_hamiltonian.png
    :scale: 50 %
 
 

--- a/docs/source/projects/doc_matrixPFASST_matrix.rst
+++ b/docs/source/projects/doc_matrixPFASST_matrix.rst
@@ -4,4 +4,4 @@ Full code: `pySDC/projects/matrixPFASST/compare_to_matrixbased.py <https://githu
 
 Results:
 
-.. literalinclude:: ../../../data/comparison_matrix_vs_nomat_detail.txt
+.. literalinclude:: ./data/comparison_matrix_vs_nomat_detail.txt

--- a/docs/source/projects/doc_matrixPFASST_propagator.rst
+++ b/docs/source/projects/doc_matrixPFASST_propagator.rst
@@ -4,4 +4,4 @@ Full code: `pySDC/projects/matrixPFASST/compare_to_propagator.py <https://github
 
 Results:
 
-.. literalinclude:: ../../../data/comparison_matrix_vs_propagator_detail.txt
+.. literalinclude:: ./data/comparison_matrix_vs_propagator_detail.txt

--- a/docs/source/projects/doc_parallelSDC_nonlinear.rst
+++ b/docs/source/projects/doc_parallelSDC_nonlinear.rst
@@ -4,11 +4,11 @@ Full code: `pySDC/projects/parallelSDC/nonlinear_playground.py <https://github.c
 
 Results:
 
-.. literalinclude:: ../../../data/parallelSDC_nonlinear_out.txt
+.. literalinclude:: ./data/parallelSDC_nonlinear_out.txt
 
 Results:
 
-.. image:: ../../../data/parallelSDC_fisher.png
+.. image:: ./data/parallelSDC_fisher.png
    :scale: 100 %
 
 Full code: `pySDC/projects/parallelSDC/newton_vs_sdc.py <https://github.com/Parallel-in-Time/pySDC/blob/master/pySDC/projects/parallelSDC/newton_vs_sdc.py>`_
@@ -17,5 +17,5 @@ Full code: `pySDC/projects/parallelSDC/newton_vs_sdc.py <https://github.com/Para
 
 Results:
 
-.. image:: ../../../data/parallelSDC_fisher_newton.png
+.. image:: ./data/parallelSDC_fisher_newton.png
    :scale: 100 %

--- a/docs/source/projects/doc_parallelSDC_preconditioner.rst
+++ b/docs/source/projects/doc_parallelSDC_preconditioner.rst
@@ -4,15 +4,15 @@ Full code: `pySDC/projects/parallelSDC/preconditioner_playground.py <https://git
 
 Results:
 
-.. image:: ../../../data/parallelSDC_preconditioner_heat.png
+.. image:: ./data/parallelSDC_preconditioner_heat.png
    :scale: 100 %
 
-.. image:: ../../../data/parallelSDC_preconditioner_advection.png
+.. image:: ./data/parallelSDC_preconditioner_advection.png
    :scale: 100 %
 
-.. image:: ../../../data/parallelSDC_preconditioner_vanderpol.png
+.. image:: ./data/parallelSDC_preconditioner_vanderpol.png
    :scale: 100 %
 
-.. image:: ../../../data/parallelSDC_preconditioner_fisher.png
+.. image:: ./data/parallelSDC_preconditioner_fisher.png
    :scale: 100 %
 

--- a/docs/source/projects/doc_parallelSDC_preconditioner_MPI.rst
+++ b/docs/source/projects/doc_parallelSDC_preconditioner_MPI.rst
@@ -4,15 +4,15 @@ Full code: `pySDC/projects/parallelSDC/preconditioner_playground_MPI.py <https:/
 
 Results:
 
-.. image:: ../../../data/parallelSDC_preconditioner_MPI_heat.png
+.. image:: ./data/parallelSDC_preconditioner_MPI_heat.png
    :scale: 100 %
 
-.. image:: ../../../data/parallelSDC_preconditioner_MPI_advection.png
+.. image:: ./data/parallelSDC_preconditioner_MPI_advection.png
    :scale: 100 %
 
-.. image:: ../../../data/parallelSDC_preconditioner_MPI_vanderpol.png
+.. image:: ./data/parallelSDC_preconditioner_MPI_vanderpol.png
    :scale: 100 %
 
-.. image:: ../../../data/parallelSDC_preconditioner_MPI_fisher.png
+.. image:: ./data/parallelSDC_preconditioner_MPI_fisher.png
    :scale: 100 %
 

--- a/docs/source/projects/doc_solar_system.rst
+++ b/docs/source/projects/doc_solar_system.rst
@@ -4,16 +4,16 @@ Full code: `pySDC/projects/Hamiltonian/solar_system.py <https://github.com/Paral
 
 Results:
 
-.. literalinclude:: ../../../data/outer_solar_system_out.txt
+.. literalinclude:: ./data/outer_solar_system_out.txt
 
-.. image:: ../../../data/outer_solar_system_hamiltonian.png
+.. image:: ./data/outer_solar_system_hamiltonian.png
    :scale: 100 %
-.. image:: ../../../data/outer_solar_system_positions.png
+.. image:: ./data/outer_solar_system_positions.png
    :scale: 100 %
 
-.. literalinclude:: ../../../data/full_solar_system_out.txt
+.. literalinclude:: ./data/full_solar_system_out.txt
 
-.. image:: ../../../data/full_solar_system_hamiltonian.png
+.. image:: ./data/full_solar_system_hamiltonian.png
    :scale: 100 %
-.. image:: ../../../data/full_solar_system_positions.png
+.. image:: ./data/full_solar_system_positions.png
    :scale: 100 %

--- a/docs/source/tutorial/doc_step_1_A.rst
+++ b/docs/source/tutorial/doc_step_1_A.rst
@@ -4,4 +4,4 @@ Full code: `pySDC/tutorial/step_1/A_spatial_problem_setup.py <https://github.com
 
 Results:
 
-.. literalinclude:: ../../../data/step_1_A_out.txt
+.. literalinclude:: ./data/step_1_A_out.txt

--- a/docs/source/tutorial/doc_step_1_B.rst
+++ b/docs/source/tutorial/doc_step_1_B.rst
@@ -4,7 +4,7 @@ Full code: `pySDC/tutorial/step_1/B_spatial_accuracy_check.py <https://github.co
 
 Results:
 
-.. literalinclude:: ../../../data/step_1_B_out.txt
+.. literalinclude:: ./data/step_1_B_out.txt
 
-.. image:: ../../../data/step_1_accuracy_test_space.png
+.. image:: ./data/step_1_accuracy_test_space.png
    :scale: 50 %

--- a/docs/source/tutorial/doc_step_1_C.rst
+++ b/docs/source/tutorial/doc_step_1_C.rst
@@ -4,4 +4,4 @@ Full code: `pySDC/tutorial/step_1/C_collocation_problem_setup.py <https://github
 
 Results:
 
-.. literalinclude:: ../../../data/step_1_C_out.txt
+.. literalinclude:: ./data/step_1_C_out.txt

--- a/docs/source/tutorial/doc_step_1_D.rst
+++ b/docs/source/tutorial/doc_step_1_D.rst
@@ -4,7 +4,7 @@ Full code: `pySDC/tutorial/step_1/D_collocation_accuracy_check.py <https://githu
 
 Results:
 
-.. literalinclude:: ../../../data/step_1_D_out.txt
+.. literalinclude:: ./data/step_1_D_out.txt
 
-.. image:: ../../../data/step_1_accuracy_test_coll.png
+.. image:: ./data/step_1_accuracy_test_coll.png
    :scale: 50 %

--- a/docs/source/tutorial/doc_step_2_A.rst
+++ b/docs/source/tutorial/doc_step_2_A.rst
@@ -4,4 +4,4 @@ Full code: `pySDC/tutorial/step_2/A_step_data_structure.py <https://github.com/P
 
 Results:
 
-.. literalinclude:: ../../../data/step_2_A_out.txt
+.. literalinclude:: ./data/step_2_A_out.txt

--- a/docs/source/tutorial/doc_step_2_B.rst
+++ b/docs/source/tutorial/doc_step_2_B.rst
@@ -4,4 +4,4 @@ Full code: `pySDC/tutorial/step_2/B_my_first_sweeper.py <https://github.com/Para
 
 Results:
 
-.. literalinclude:: ../../../data/step_2_B_out.txt
+.. literalinclude:: ./data/step_2_B_out.txt

--- a/docs/source/tutorial/doc_step_2_C.rst
+++ b/docs/source/tutorial/doc_step_2_C.rst
@@ -4,4 +4,4 @@ Full code: `pySDC/tutorial/step_2/C_using_pySDCs_frontend.py <https://github.com
 
 Results:
 
-.. literalinclude:: ../../../data/step_2_C_out.txt
+.. literalinclude:: ./data/step_2_C_out.txt

--- a/docs/source/tutorial/doc_step_3_A.rst
+++ b/docs/source/tutorial/doc_step_3_A.rst
@@ -4,4 +4,4 @@ Full code: `pySDC/tutorial/step_3/A_getting_statistics.py <https://github.com/Pa
 
 Results:
 
-.. literalinclude:: ../../../data/step_3_A_out.txt
+.. literalinclude:: ./data/step_3_A_out.txt

--- a/docs/source/tutorial/doc_step_3_B.rst
+++ b/docs/source/tutorial/doc_step_3_B.rst
@@ -4,4 +4,4 @@ Full code: `pySDC/tutorial/step_3/B_adding_statistics.py <https://github.com/Par
 
 Results:
 
-.. literalinclude:: ../../../data/step_3_B_out.txt
+.. literalinclude:: ./data/step_3_B_out.txt

--- a/docs/source/tutorial/doc_step_3_C.rst
+++ b/docs/source/tutorial/doc_step_3_C.rst
@@ -4,4 +4,4 @@ Full code: `pySDC/tutorial/step_3/C_study_collocations.py <https://github.com/Pa
 
 Results:
 
-.. literalinclude:: ../../../data/step_3_C_out.txt
+.. literalinclude:: ./data/step_3_C_out.txt

--- a/docs/source/tutorial/doc_step_4_A.rst
+++ b/docs/source/tutorial/doc_step_4_A.rst
@@ -4,4 +4,4 @@ Full code: `pySDC/tutorial/step_4/A_spatial_transfer_operators.py <https://githu
 
 Results:
 
-.. literalinclude:: ../../../data/step_4_A_out.txt
+.. literalinclude:: ./data/step_4_A_out.txt

--- a/docs/source/tutorial/doc_step_4_B.rst
+++ b/docs/source/tutorial/doc_step_4_B.rst
@@ -4,4 +4,4 @@ Full code: `pySDC/tutorial/step_4/B_multilevel_hierarchy.py <https://github.com/
 
 Results:
 
-.. literalinclude:: ../../../data/step_4_B_out.txt
+.. literalinclude:: ./data/step_4_B_out.txt

--- a/docs/source/tutorial/doc_step_4_C.rst
+++ b/docs/source/tutorial/doc_step_4_C.rst
@@ -4,4 +4,4 @@ Full code: `pySDC/tutorial/step_4/C_SDC_vs_MLSDC.py <https://github.com/Parallel
 
 Results:
 
-.. literalinclude:: ../../../data/step_4_C_out.txt
+.. literalinclude:: ./data/step_4_C_out.txt

--- a/docs/source/tutorial/doc_step_4_D.rst
+++ b/docs/source/tutorial/doc_step_4_D.rst
@@ -4,4 +4,4 @@ Full code: `pySDC/tutorial/step_4/D_MLSDC_with_particles.py <https://github.com/
 
 Results:
 
-.. literalinclude:: ../../../data/step_4_D_out.txt
+.. literalinclude:: ./data/step_4_D_out.txt

--- a/docs/source/tutorial/doc_step_5_A.rst
+++ b/docs/source/tutorial/doc_step_5_A.rst
@@ -4,4 +4,4 @@ Full code: `pySDC/tutorial/step_5/A_multistep_multilevel_hierarchy.py <https://g
 
 Results:
 
-.. literalinclude:: ../../../data/step_5_A_out.txt
+.. literalinclude:: ./data/step_5_A_out.txt

--- a/docs/source/tutorial/doc_step_5_B.rst
+++ b/docs/source/tutorial/doc_step_5_B.rst
@@ -4,4 +4,4 @@ Full code: `pySDC/tutorial/step_5/B_my_first_PFASST_run.py <https://github.com/P
 
 Results:
 
-.. literalinclude:: ../../../data/step_5_B_out.txt
+.. literalinclude:: ./data/step_5_B_out.txt

--- a/docs/source/tutorial/doc_step_5_C.rst
+++ b/docs/source/tutorial/doc_step_5_C.rst
@@ -4,4 +4,4 @@ Full code: `pySDC/tutorial/step_5/C_advection_and_PFASST.py <https://github.com/
 
 Results:
 
-.. literalinclude:: ../../../data/step_5_C_out.txt
+.. literalinclude:: ./data/step_5_C_out.txt

--- a/docs/source/tutorial/doc_step_6_A.rst
+++ b/docs/source/tutorial/doc_step_6_A.rst
@@ -4,5 +4,5 @@ Full code: `pySDC/tutorial/step_6/A_run_non_MPI_controller.py <https://github.co
 
 Results:
 
-.. literalinclude:: ../../../data/step_6_A_sl_out.txt
-.. literalinclude:: ../../../data/step_6_A_ml_out.txt
+.. literalinclude:: ./data/step_6_A_sl_out.txt
+.. literalinclude:: ./data/step_6_A_ml_out.txt

--- a/docs/source/tutorial/doc_step_6_B.rst
+++ b/docs/source/tutorial/doc_step_6_B.rst
@@ -4,4 +4,4 @@ Full code: `pySDC/tutorial/step_6/B_odd_temporal_distribution.py <https://github
 
 Results:
 
-.. literalinclude:: ../../../data/step_6_B_out.txt
+.. literalinclude:: ./data/step_6_B_out.txt

--- a/docs/source/tutorial/doc_step_6_C.rst
+++ b/docs/source/tutorial/doc_step_6_C.rst
@@ -6,5 +6,5 @@ Full code: `pySDC/tutorial/step_6/C_MPI_parallelization.py <https://github.com/P
 
 Results:
 
-.. literalinclude:: ../../../data/step_6_C1_out.txt
-.. literalinclude:: ../../../data/step_6_C2_out.txt
+.. literalinclude:: ./data/step_6_C1_out.txt
+.. literalinclude:: ./data/step_6_C2_out.txt

--- a/docs/source/tutorial/doc_step_7_A.rst
+++ b/docs/source/tutorial/doc_step_7_A.rst
@@ -4,4 +4,4 @@ Full code: `pySDC/tutorial/step_7/A_pySDC_with_FEniCS.py <https://github.com/Par
 
 Results:
 
-.. literalinclude:: ../../../data/step_7_A_out.txt
+.. literalinclude:: ./data/step_7_A_out.txt

--- a/docs/source/tutorial/doc_step_7_B.rst
+++ b/docs/source/tutorial/doc_step_7_B.rst
@@ -4,4 +4,4 @@ Full code: `pySDC/tutorial/step_7/B_pySDC_with_mpi4pyfft.py <https://github.com/
 
 Results:
 
-.. literalinclude:: ../../../data/step_7_B_out.txt
+.. literalinclude:: ./data/step_7_B_out.txt

--- a/docs/source/tutorial/doc_step_7_C.rst
+++ b/docs/source/tutorial/doc_step_7_C.rst
@@ -6,12 +6,12 @@ Results:
 
 1 processor in time, 1 processor in space
 
-.. literalinclude:: ../../../data/step_7_C_out_1x1.txt
+.. literalinclude:: ./data/step_7_C_out_1x1.txt
 
 1 processor in time, 2 processors in space
 
-.. literalinclude:: ../../../data/step_7_C_out_1x2.txt
+.. literalinclude:: ./data/step_7_C_out_1x2.txt
 
 2 processor in time, 2 processors in space
 
-.. literalinclude:: ../../../data/step_7_C_out_2x2.txt
+.. literalinclude:: ./data/step_7_C_out_2x2.txt

--- a/docs/source/tutorial/doc_step_8_A.rst
+++ b/docs/source/tutorial/doc_step_8_A.rst
@@ -4,7 +4,7 @@ Full code: `pySDC/tutorial/step_8/A_visualize_residuals.py <https://github.com/P
 
 Results:
 
-.. literalinclude:: ../../../data/step_8_A_out.txt
+.. literalinclude:: ./data/step_8_A_out.txt
 
-.. image:: ../../../data/step_8_residuals.png
+.. image:: ./data/step_8_residuals.png
    :scale: 50 %

--- a/docs/source/tutorial/doc_step_8_B.rst
+++ b/docs/source/tutorial/doc_step_8_B.rst
@@ -4,10 +4,10 @@ Full code: `pySDC/tutorial/step_8/B_multistep_SDC.py <https://github.com/Paralle
 
 Results:
 
-.. literalinclude:: ../../../data/step_8_B_out.txt
+.. literalinclude:: ./data/step_8_B_out.txt
 
-.. image:: ../../../data/step_8_residuals_mssdc_jac.png
+.. image:: ./data/step_8_residuals_mssdc_jac.png
    :scale: 50 %
 
-.. image:: ../../../data/step_8_residuals_mssdc_gs.png
+.. image:: ./data/step_8_residuals_mssdc_gs.png
    :scale: 50 %

--- a/docs/source/tutorial/doc_step_8_C.rst
+++ b/docs/source/tutorial/doc_step_8_C.rst
@@ -4,4 +4,4 @@ Full code: `pySDC/tutorial/step_8/C_iteration_estimator.py <https://github.com/P
 
 Results:
 
-.. literalinclude:: ../../../data/step_8_C_out.txt
+.. literalinclude:: ./data/step_8_C_out.txt


### PR DESCRIPTION
The previous version of the generated website did not include the plots that were created in the same CI.

Now, the plots are copied into a subdir of the website and are therefore also published, as all content of that directory is used for publication. The links in the RST-files have been updated accordingly.