### PR TITLE
Added pre-commit hook to contribution guidelines for automating linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ and is now maintained and developed by a small community of scientists intereste
 Checkout the [Changelog](./CHANGELOG.md) to see pySDC's evolution since 2016.
 
 Any contribution is dearly welcome ! If you want to take part of this, please take the time to read our [Contribution Guidelines](./CONTRIBUTING.md)
-(and don't forget to take a pick at our nice [Code of Conduct](./CODE_OF_CONDUCT.md) :wink:).
+(and don't forget to take a peek at our nice [Code of Conduct](./CODE_OF_CONDUCT.md) :wink:).
 
 
 ## Acknowledgements

--- a/docs/contrib/02_continuous_integration.md
+++ b/docs/contrib/02_continuous_integration.md
@@ -19,7 +19,7 @@ black pySDC --check --diff --color
 flakeheaven lint --benchmark pySDC
 ```
 
-> :bell: To avoid any error about formatting (`black`), you can simply use this program to reformat directly your code using the command :
+> :bell: To avoid any error about formatting (`black`), you can simply use this program to reformat your code directly using the command :
 >
 > ```bash
 > black pySDC
@@ -29,6 +29,45 @@ Some style rules that are automatically enforced :
 
 - lines should be not longer than 120 characters
 - arithmetic operators (`+`, `*`, ...) should be separated with variables by one empty space
+
+You can automate linting by running black and flakeheaven on all staged files every time you make a commit in a pre-commit hook.
+To this end, just add the following to a possibly new file in the path `<pySDC-root-directory>/.git/hooks/pre-commit`:
+
+```bash
+#!/bin/sh
+
+export repopath=$(git rev-parse --show-toplevel)
+export currentpath=$(pwd)
+
+cd $repopath
+ 
+export files=$(git diff --staged --name-only HEAD | grep .py)
+
+if [[ $files != "" ]]
+then  
+        black $files
+        git add $files
+         
+        export flakeheaven_output=$(flakeheaven lint $files)
+        if [[ "$flakeheaven_output" != 0 ]]
+        then 
+            flakeheaven lint $files
+            exit 1
+        else
+            echo "No flakeheaven issues"
+            exit 0
+        fi
+fi
+
+cd $currentpath
+```
+
+You may need to run `chmod +x` on the file to allow it to be executed.
+Be aware that the hook will alter files you may have opened in an editor whenever you make a commit, which may confuse you(r editor). 
+Also, this will not allow you to commit anything that does not pass flakeheaven's linting.
+
+As a final note, make sure to regularly update linting related packages, as they constantly introduce checking of more PEP8 guidelines.
+This might cause the linting to fail in the GitHub action, which uses the most up to date versions available on the conda-forge channel, even though it passed locally.
 
 ## Code testing
 


### PR DESCRIPTION
The pre-commit hook I added will run black on all staged files and then add them to git again. Then, it will run flakeheaven and abort the commit if it finds any issues. 
You may consider this very annoying and intrusive. I find it less annoying then getting tons of emails because the linting action failed again.
If you don't like it, feel free to just close the PR without merging, but I personally find the hook quite useful.