### PR TITLE
Split the pre-commit hook in two, such that flakeheaven now shows up as a comment in the commit message instead of aborting the commit

### DIFF
--- a/docs/contrib/02_continuous_integration.md
+++ b/docs/contrib/02_continuous_integration.md
@@ -30,41 +30,47 @@ Some style rules that are automatically enforced :
 - lines should be not longer than 120 characters
 - arithmetic operators (`+`, `*`, ...) should be separated with variables by one empty space
 
-You can automate linting by running black and flakeheaven on all staged files every time you make a commit in a pre-commit hook.
+You can automate linting somewhat by using git hooks.
+In order to run black automatically, we want to do a pre-commit hook which adds the modified files to the commit after reformatting.
 To this end, just add the following to a possibly new file in the path `<pySDC-root-directory>/.git/hooks/pre-commit`:
 
 ```bash
 #!/bin/sh
 
-export repopath=$(git rev-parse --show-toplevel)
-export currentpath=$(pwd)
-
-cd $repopath
- 
-export files=$(git diff --staged --name-only HEAD | grep .py)
+export files=$(git diff --staged --name-only HEAD | grep .py | sed -e "s,^,$(git rev-parse --show-toplevel)/,")
 
 if [[ $files != "" ]]
 then  
         black $files
         git add $files
-         
-        export flakeheaven_output=$(flakeheaven lint $files)
-        if [[ "$flakeheaven_output" != 0 ]]
-        then 
-            flakeheaven lint $files
-            exit 1
-        else
-            echo "No flakeheaven issues"
-            exit 0
-        fi
 fi
-
-cd $currentpath
 ```
 
 You may need to run `chmod +x` on the file to allow it to be executed.
 Be aware that the hook will alter files you may have opened in an editor whenever you make a commit, which may confuse you(r editor). 
-Also, this will not allow you to commit anything that does not pass flakeheaven's linting.
+
+To automate flakeheaven, we want to write a hook that alters the commit message in case any errors are detected. This gives us the choice of aborting the commit and fixing the issues, or we can go ahead and commit them and worry about flakeheaven only when the time comes to do a pull request.
+To obtain this functionality, add the following to `<pySDC-root-directory>/.git/hooks/prepare-commit-msg`:
+
+```bash
+#!/bin/sh
+
+COMMIT_MSG_FILE=$1
+
+export files=$(git diff --staged --name-only HEAD | grep .py | sed -e "s,^,$(git rev-parse --show-toplevel)/,")
+
+if [[ $files != "" ]]
+then
+        export flakeheaven_output=$(flakeheaven lint --format default $files)
+        if [[ "$flakeheaven_output" != 0 ]]
+        then
+                git interpret-trailers --in-place --trailer "$(echo "$flakeheaven_output" | sed -e 's/^/#/')" "$COMMIT_MSG_FILE"
+                git interpret-trailers --in-place --trailer "#!!!!!!!!!! WARNING: FLAKEHEAVEN FAILED !!!!!!!!!!" "$COMMIT_MSG_FILE"
+        fi
+fi
+
+```
+Don't forget to assign execution rights.
 
 As a final note, make sure to regularly update linting related packages, as they constantly introduce checking of more PEP8 guidelines.
 This might cause the linting to fail in the GitHub action, which uses the most up to date versions available on the conda-forge channel, even though it passed locally.


### PR DESCRIPTION
I apologise for the spam! But I was not totally satisfied with aborting the commit every time flakeheaven failed and I realised I can do better.
So now, if you add the git hooks and flakeheaven detects any issues, you can see them in the comments in the commit message which show you what you are committing. Now you can manually abort, or just not care.
You may also choose only to use the flakeheaven hook, which will not touch any files automatically, but reminds you that what you are committing will not pass the lint action.