### PR TITLE
More tests for error estimates and a fix for extrapolation error

### DIFF
--- a/pySDC/implementations/convergence_controller_classes/estimate_embedded_error.py
+++ b/pySDC/implementations/convergence_controller_classes/estimate_embedded_error.py
@@ -14,20 +14,6 @@ class EstimateEmbeddedError(ConvergenceController):
     you make sure your preconditioner is compatible, which you have to just try out...
     """
 
-    def __init__(self, controller, params, description, **kwargs):
-        """
-        Initialisation routine. Add the hook for recording the local error.
-
-        Args:
-            controller (pySDC.Controller): The controller
-            params (dict): Parameters for the convergence controller
-            description (dict): The description object used to instantiate the controller
-        """
-        from pySDC.implementations.hooks.log_embedded_error_estimate import LogEmbeddedErrorEstimate
-
-        super().__init__(controller, params, description, **kwargs)
-        controller.add_hook(LogEmbeddedErrorEstimate)
-
     @classmethod
     def get_implementation(cls, flavor='standard', useMPI=False):
         """
@@ -72,7 +58,8 @@ class EstimateEmbeddedError(ConvergenceController):
 
     def dependencies(self, controller, description, **kwargs):
         """
-        Load the convergence controller that stores the solution of the last sweep unless we are doing Runge-Kutta
+        Load the convergence controller that stores the solution of the last sweep unless we are doing Runge-Kutta.
+        Add the hook for recording the error.
 
         Args:
             controller (pySDC.Controller): The controller
@@ -83,6 +70,10 @@ class EstimateEmbeddedError(ConvergenceController):
         """
         if RungeKutta not in description["sweeper_class"].__bases__:
             controller.add_convergence_controller(StoreUOld, description=description)
+
+        from pySDC.implementations.hooks.log_embedded_error_estimate import LogEmbeddedErrorEstimate
+
+        controller.add_hook(LogEmbeddedErrorEstimate)
         return None
 
     def estimate_embedded_error_serial(self, L):
@@ -301,6 +292,9 @@ class EstimateEmbeddedErrorCollocation(ConvergenceController):
         controller.add_convergence_controller(
             AdaptiveCollocation, params=self.params.adaptive_coll_params, description=description
         )
+        from pySDC.implementations.hooks.log_embedded_error_estimate import LogEmbeddedErrorEstimate
+
+        controller.add_hook(LogEmbeddedErrorEstimate)
 
     def post_iteration_processing(self, controller, step, **kwargs):
         """

--- a/pySDC/implementations/convergence_controller_classes/estimate_extrapolation_error.py
+++ b/pySDC/implementations/convergence_controller_classes/estimate_extrapolation_error.py
@@ -311,7 +311,11 @@ class EstimateExtrapolationErrorNonMPI(EstimateExtrapolationErrorBase):
 
             # compute the extrapolation coefficients if needed
             if (
-                (None in self.coeff.u or self.params.use_adaptivity)
+                (
+                    None in self.coeff.u
+                    or self.params.use_adaptivity
+                    or (not self.params.no_storage and S.status.time_size > 1)
+                )
                 and None not in self.prev.t
                 and t_eval > max(self.prev.t)
             ):

--- a/pySDC/implementations/problem_classes/TestEquation_0D.py
+++ b/pySDC/implementations/problem_classes/TestEquation_0D.py
@@ -89,17 +89,21 @@ class testequation0d(ptype):
         me[:] = L.solve(rhs)
         return me
 
-    def u_exact(self, t):
+    def u_exact(self, t, u_init=None, t_init=None):
         """
         Routine to compute the exact solution at time t
 
         Args:
             t (float): current time
+            u_init : pySDC.problem.testequation0d.dtype_u
+            t_init : float
 
         Returns:
             dtype_u: exact solution
         """
+        u_init = (self.u0 if u_init is None else u_init) * 1.0
+        t_init = 0.0 if t_init is None else t_init * 1.0
 
         me = self.dtype_u(self.init)
-        me[:] = self.u0 * np.exp(t * np.array(self.lambdas))
+        me[:] = u_init * np.exp((t - t_init) * np.array(self.lambdas))
         return me

--- a/pySDC/tests/test_convergence_controllers/test_error_convergence_controllers.py
+++ b/pySDC/tests/test_convergence_controllers/test_error_convergence_controllers.py
@@ -1,0 +1,231 @@
+import pytest
+
+
+def run_problem(maxiter=1, num_procs=1, n_steps=1, error_estimator=None, params=None, restol=-1):
+    import numpy as np
+    from pySDC.implementations.problem_classes.TestEquation_0D import testequation0d
+    from pySDC.implementations.sweeper_classes.generic_implicit import generic_implicit
+    from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
+    from pySDC.implementations.hooks.log_errors import (
+        LogLocalErrorPostIter,
+        LogGlobalErrorPostIter,
+        LogLocalErrorPostStep,
+    )
+
+    # initialize level parameters
+    level_params = {}
+    level_params['dt'] = 6e-3
+    level_params['restol'] = restol
+
+    # initialize sweeper parameters
+    sweeper_params = {}
+    sweeper_params['quad_type'] = 'RADAU-RIGHT'
+    sweeper_params['num_nodes'] = 3
+    sweeper_params['QI'] = 'IE'
+    # sweeper_params['initial_guess'] = 'random'
+
+    # build lambdas
+    re = np.linspace(-30, -1, 10)
+    im = np.linspace(-50, 50, 11)
+    lambdas = np.array([[complex(re[i], im[j]) for i in range(len(re))] for j in range(len(im))]).reshape(
+        (len(re) * len(im))
+    )
+
+    problem_params = {
+        'lambdas': lambdas,
+        'u0': 1.0 + 0.0j,
+    }
+
+    # initialize step parameters
+    step_params = dict()
+    step_params['maxiter'] = maxiter
+
+    # convergence controllers
+    convergence_controllers = {error_estimator: params}
+
+    # initialize controller parameters
+    controller_params = {}
+    controller_params['logger_level'] = 15
+    controller_params['hook_class'] = [LogLocalErrorPostIter, LogGlobalErrorPostIter, LogLocalErrorPostStep]
+    controller_params['mssdc_jac'] = False
+
+    # fill description dictionary for easy step instantiation
+    description = {}
+    description['problem_class'] = testequation0d
+    description['problem_params'] = problem_params
+    description['sweeper_class'] = generic_implicit
+    description['sweeper_params'] = sweeper_params
+    description['level_params'] = level_params
+    description['step_params'] = step_params
+    description['convergence_controllers'] = convergence_controllers
+
+    # set time parameters
+    t0 = 0.0
+
+    # instantiate controller
+    controller = controller_nonMPI(num_procs=num_procs, controller_params=controller_params, description=description)
+
+    # get initial values on finest level
+    P = controller.MS[0].levels[0].prob
+    uinit = P.u_exact(t0)
+
+    # call main function to get things done...
+    uend, stats = controller.run(u0=uinit, t0=t0, Tend=n_steps * level_params['dt'])
+    return stats
+
+
+@pytest.mark.base
+def test_EstimateExtrapolationErrorNonMPI_serial(order_time_marching=2, n_steps=3, thresh=0.15):
+    from pySDC.implementations.convergence_controller_classes.estimate_extrapolation_error import (
+        EstimateExtrapolationErrorNonMPI,
+    )
+    from pySDC.helpers.stats_helper import get_sorted, filter_stats, sort_stats
+
+    params = {
+        'no_storage': False,
+    }
+    preperatory_steps = (order_time_marching + 3) // 2
+
+    stats = run_problem(
+        maxiter=order_time_marching,
+        n_steps=n_steps + preperatory_steps,
+        error_estimator=EstimateExtrapolationErrorNonMPI,
+        params=params,
+        num_procs=1,
+    )
+
+    e_local = sort_stats(filter_stats(stats, type='e_local_post_iteration', iter=order_time_marching), sortby='time')
+    e_estimated = get_sorted(stats, type='error_extrapolation_estimate')
+
+    rel_diff = [
+        abs(e_local[i][1] - e_estimated[i][1]) / e_estimated[i][1]
+        for i in range(len(e_estimated))
+        if e_estimated[i][1] is not None
+    ]
+    assert all(
+        me < thresh for me in rel_diff
+    ), f'Extrapolated error estimate failed! Relative difference to true error: {rel_diff}'
+
+
+@pytest.mark.base
+@pytest.mark.parametrize('no_storage', [True, False])
+def test_EstimateExtrapolationErrorNonMPI_parallel(
+    no_storage, order_time_marching=4, n_steps=3, num_procs=3, thresh=0.50
+):
+    from pySDC.implementations.convergence_controller_classes.estimate_extrapolation_error import (
+        EstimateExtrapolationErrorNonMPI,
+    )
+    from pySDC.helpers.stats_helper import get_sorted, filter_stats, sort_stats
+
+    params = {
+        'no_storage': no_storage,
+    }
+    preperatory_steps = (order_time_marching + 3) // 2
+
+    if no_storage:
+        num_procs = max(num_procs, preperatory_steps + 1)
+
+    stats = run_problem(
+        maxiter=order_time_marching,
+        n_steps=n_steps + preperatory_steps,
+        error_estimator=EstimateExtrapolationErrorNonMPI,
+        params=params,
+        num_procs=num_procs,
+    )
+
+    e_local = sort_stats(filter_stats(stats, type='e_local_post_iteration', iter=order_time_marching), sortby='time')
+    e_estimated = get_sorted(stats, type='error_extrapolation_estimate')
+
+    rel_diff = [
+        abs(e_local[i][1] - e_estimated[i][1]) / e_local[i][1]
+        for i in range(len(e_estimated))
+        if e_estimated[i][1] is not None
+    ]
+    assert all(
+        me < thresh for me in rel_diff
+    ), f'Extrapolated error estimate failed! Relative difference to true error: {rel_diff}'
+
+
+@pytest.mark.base
+def test_EstimateEmbeddedErrorSerial(order_time_marching=3, n_steps=6, thresh=0.05):
+    from pySDC.implementations.convergence_controller_classes.estimate_embedded_error import EstimateEmbeddedError
+    from pySDC.helpers.stats_helper import get_sorted, filter_stats, sort_stats
+
+    params = {}
+
+    stats = run_problem(
+        maxiter=order_time_marching, n_steps=n_steps, error_estimator=EstimateEmbeddedError, params=params, num_procs=1
+    )
+
+    e_local = sort_stats(
+        filter_stats(stats, type='e_local_post_iteration', iter=order_time_marching - 1), sortby='time'
+    )
+    e_estimated = get_sorted(stats, type='error_embedded_estimate')
+
+    rel_diff = [abs(e_local[i][1] - e_estimated[i][1]) / e_local[i][1] for i in range(len(e_estimated))]
+
+    assert all(
+        me < thresh for me in rel_diff
+    ), f'Embedded error estimate failed! Relative difference to true error: {rel_diff}'
+
+
+@pytest.mark.base
+def test_EstimateEmbeddedErrorParallel(order_time_marching=3, num_procs=3, thresh=0.10):
+    from pySDC.implementations.convergence_controller_classes.estimate_embedded_error import EstimateEmbeddedError
+    from pySDC.helpers.stats_helper import get_sorted, filter_stats, sort_stats
+
+    params = {}
+
+    stats = run_problem(
+        maxiter=order_time_marching,
+        n_steps=num_procs,
+        error_estimator=EstimateEmbeddedError,
+        params=params,
+        num_procs=num_procs,
+    )
+
+    e_global = sort_stats(
+        filter_stats(stats, type='e_global_post_iteration', iter=order_time_marching - 1), sortby='time'
+    )
+    e_estimated = get_sorted(stats, type='error_embedded_estimate')
+
+    rel_diff = [abs(e_global[i][1] - e_estimated[i][1]) / e_global[i][1] for i in range(len(e_estimated))]
+
+    assert all(
+        me < thresh for me in rel_diff
+    ), f'Embedded error estimate failed! Relative difference to true error: {rel_diff}'
+
+
+@pytest.mark.base
+def test_EstimateEmbeddedErrorCollocation(n_steps=6, thresh=0.01):
+    from pySDC.implementations.convergence_controller_classes.estimate_embedded_error import (
+        EstimateEmbeddedErrorCollocation,
+    )
+    from pySDC.helpers.stats_helper import get_sorted, filter_stats, sort_stats
+
+    adaptive_coll_params = {
+        'num_nodes': [3, 2],
+    }
+    params = {'adaptive_coll_params': adaptive_coll_params}
+
+    stats = run_problem(
+        maxiter=99,
+        n_steps=n_steps,
+        error_estimator=EstimateEmbeddedErrorCollocation,
+        params=params,
+        num_procs=1,
+        restol=1e-13,
+    )
+
+    e_estimated = get_sorted(stats, type='error_embedded_estimate_collocation')
+    e_local = sort_stats(filter_stats(stats, type='e_local_post_step'), sortby='time')
+
+    rel_diff = [abs(e_local[i][1] - e_estimated[i][1]) / e_local[i][1] for i in range(len(e_estimated))]
+
+    assert all(
+        me < thresh for me in rel_diff
+    ), f'Embedded error estimate failed! Relative difference to true error: {rel_diff}'
+
+
+if __name__ == '__main__':
+    test_EstimateEmbeddedErrorCollocation()


### PR DESCRIPTION
TEST TEST TEST TEST TEST TEST TEST

I noticed an error in one of the implementations of the extrapolation error, so naturally I wrote some tests.
This PR includes a fix for the error and some tests for the error estimates. In a different test, I test that their order is correct, but here I test that the magnitude is comparable to the true error.

It shows that different error estimates perform differently, with the one comparing the solutions of two different collocation problems performing the best for this particular setup.