### PR TITLE
Migrating to new mamba action

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Install Conda environment with Micromamba
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: ${{ env.YML }}
 
@@ -70,10 +70,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Conda environment with Micromamba
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: "etc/environment-${{ matrix.env }}.yml"
-          extra-specs: |
+          create-args: >-
               python=${{ matrix.python }}
 
       - name: Run pytest for CPU stuff
@@ -156,7 +156,7 @@ jobs:
         uses: actions/checkout@v3
   
       - name: Install Conda environment with Micromamba
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: "etc/environment-${{ matrix.env }}.yml"
   
@@ -212,7 +212,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Conda environment with Micromamba
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: "etc/environment-base.yml"
 


### PR DESCRIPTION
When running some actions, there is a warning that our CI is deprecated and will no longer work in the near future.
There is a [migration guide](https://github.com/mamba-org/provision-with-micromamba#migration-to-setup-micromamba) which I followed to update to the new version. I did not check that the post_processing action works, so maybe glance over the migration guide before merging. 