### PR TITLE
Moved MPI communication from `sort_stats` to `filter_stats`

### DIFF
--- a/pySDC/core/Hooks.py
+++ b/pySDC/core/Hooks.py
@@ -2,6 +2,9 @@ import logging
 from collections import namedtuple
 
 
+Entry = namedtuple('Entry', ['process', 'time', 'level', 'iter', 'sweep', 'type', 'num_restarts'])
+
+
 # noinspection PyUnusedLocal,PyShadowingBuiltins,PyShadowingNames
 class hooks(object):
     """
@@ -28,7 +31,7 @@ class hooks(object):
 
         # create statistics and entry elements
         self.__stats = {}
-        self.__entry = namedtuple('Entry', ['process', 'time', 'level', 'iter', 'sweep', 'type', 'num_restarts'])
+        self.__entry = Entry
 
     def add_to_stats(self, process, time, level, iter, sweep, type, value):
         """


### PR DESCRIPTION
Before, it was in `sort_stats` because of pickling issues in mpi4py with the named tuple in the hooks class. It turns out that for some weird reason, the pickling is possible when moving the `Entry` named tuple outside of the hooks class.

Having the communication in `filter_stats` is useful because you don't necessarily want to sort the stats that you filter.