### PR TITLE
Split coverage and test actions because the GitHub action would not be marked as failed correctly

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -82,6 +82,9 @@ jobs:
           import coverage
           coverage.process_startup() " > sitecustomize.py
           coverage run -m pytest --continue-on-collection-errors -v --durations=0 pySDC/tests -m ${{ matrix.env }}
+
+      - name: Make coverage report
+        run: |
           mv data data_${{ matrix.python }}
           coverage combine
           mv .coverage coverage_${{ matrix.env }}_${{ matrix.python }}.dat


### PR DESCRIPTION
I had the same issue with the libpressio container. I think that the last thing (coverage combine) in the step is successful and hence the entire action is marked as successful. Maybe this changed when we updated to the new mamba stuff. Anyways, in the macOS tests, there is no coverage step, so pytest is the last thing that is done in the step already and this was working fine.
Now, pytest is the last thing in its own step and then there is a separate step for the coverage report. Basically the same as for the libpressio container.

Is it really the issue that pytest was not the last command in its step? No idea, just guessing... But I made a fake test to confirm that the action fails when one test fails now.
