### PR TITLE
Default parameters for PinTSimE problem classes + small docu correction

### DIFF
--- a/pySDC/implementations/problem_classes/Battery.py
+++ b/pySDC/implementations/problem_classes/Battery.py
@@ -9,7 +9,7 @@ class battery_n_capacitors(ptype):
     r"""
     Example implementing the battery drain model with :math:`N` capacitors, where :math:`N` is an arbitrary integer greater than zero.
     First, the capacitor :math:`C` serves as a battery and provides energy. When the voltage of the capacitor :math:`u_{C_n}` for
-    :math:`n=1,..,N` drops below their reference value :math:`V_{ref,n-1}', the circuit switches to the next capacitor. If all capacitors
+    :math:`n=1,..,N` drops below their reference value :math:`V_{ref,n-1}`, the circuit switches to the next capacitor. If all capacitors
     has dropped below their reference value, the voltage source :math:`V_s` provides further energy. The problem of simulating the
     battery draining has :math:`N + 1` different states. Each of this state can be expressed as a nonhomogeneous linear system of
     ordinary differential equations (ODEs)

--- a/pySDC/implementations/problem_classes/Battery.py
+++ b/pySDC/implementations/problem_classes/Battery.py
@@ -60,9 +60,7 @@ class battery_n_capacitors(ptype):
     dtype_u = mesh
     dtype_f = imex_mesh
 
-    def __init__(
-        self, ncapacitors=2, Vs=5.0, Rs=0.5, C=None, R=1.0, L=1.0, alpha=1.2, V_ref=None
-    ):
+    def __init__(self, ncapacitors=2, Vs=5.0, Rs=0.5, C=None, R=1.0, L=1.0, alpha=1.2, V_ref=None):
         """Initialization routine"""
         n = ncapacitors
         nvars = n + 1

--- a/pySDC/implementations/problem_classes/Battery.py
+++ b/pySDC/implementations/problem_classes/Battery.py
@@ -435,7 +435,6 @@ class battery_implicit(battery):
         newton_maxiter=200,
         newton_tol=1e-8,
     ):
-
         if C is None:
             C = np.array([1.0])
 

--- a/pySDC/implementations/problem_classes/Battery.py
+++ b/pySDC/implementations/problem_classes/Battery.py
@@ -60,7 +60,7 @@ class battery_n_capacitors(ptype):
     dtype_u = mesh
     dtype_f = imex_mesh
 
-    def __init__(self, ncapacitors, Vs, Rs, C, R, L, alpha, V_ref):
+    def __init__(self, ncapacitors=2, Vs=5.0, Rs=0.5, C=np.array([1.0, 1.0]), R=1.0, L=1.0, alpha=1.2, V_ref=np.array([1.0, 1.0])):
         """Initialization routine"""
         n = ncapacitors
         nvars = n + 1
@@ -416,7 +416,19 @@ class battery_implicit(battery):
     """
     dtype_f = mesh
 
-    def __init__(self, ncapacitors, Vs, Rs, C, R, L, alpha, V_ref, newton_maxiter, newton_tol):
+    def __init__(
+        self,
+        ncapacitors=1,
+        Vs=5.0,
+        Rs=0.5,
+        C=np.array([1.0]),
+        R=1.0,
+        L=1.0,
+        alpha=1.2,
+        V_ref=np.array([1.0]),
+        newton_maxiter=200,
+        newton_tol=1e-8
+    ):
         super().__init__(ncapacitors, Vs, Rs, C, R, L, alpha, V_ref)
         self._makeAttributeAndRegister('newton_maxiter', 'newton_tol', localVars=locals(), readOnly=True)
 

--- a/pySDC/implementations/problem_classes/Battery.py
+++ b/pySDC/implementations/problem_classes/Battery.py
@@ -60,10 +60,18 @@ class battery_n_capacitors(ptype):
     dtype_u = mesh
     dtype_f = imex_mesh
 
-    def __init__(self, ncapacitors=2, Vs=5.0, Rs=0.5, C=np.array([1.0, 1.0]), R=1.0, L=1.0, alpha=1.2, V_ref=np.array([1.0, 1.0])):
+    def __init__(
+        self, ncapacitors=2, Vs=5.0, Rs=0.5, C=None, R=1.0, L=1.0, alpha=1.2, V_ref=None
+    ):
         """Initialization routine"""
         n = ncapacitors
         nvars = n + 1
+
+        if C is None:
+            C = np.array([1.0, 1.0])
+
+        if V_ref is None:
+            V_ref = np.array([1.0, 1.0])
 
         # invoke super init, passing number of dofs, dtype_u and dtype_f
         super().__init__(init=(nvars, None, np.dtype('float64')))
@@ -421,14 +429,21 @@ class battery_implicit(battery):
         ncapacitors=1,
         Vs=5.0,
         Rs=0.5,
-        C=np.array([1.0]),
+        C=None,
         R=1.0,
         L=1.0,
         alpha=1.2,
-        V_ref=np.array([1.0]),
+        V_ref=None,
         newton_maxiter=200,
-        newton_tol=1e-8
+        newton_tol=1e-8,
     ):
+
+        if C is None:
+            C = np.array([1.0])
+
+        if V_ref is None:
+            V_ref = np.array([1.0])
+
         super().__init__(ncapacitors, Vs, Rs, C, R, L, alpha, V_ref)
         self._makeAttributeAndRegister('newton_maxiter', 'newton_tol', localVars=locals(), readOnly=True)
 

--- a/pySDC/implementations/problem_classes/BuckConverter.py
+++ b/pySDC/implementations/problem_classes/BuckConverter.py
@@ -79,7 +79,7 @@ class buck_converter(ptype):
     dtype_u = mesh
     dtype_f = imex_mesh
 
-    def __init__(self, duty, fsw, Vs, Rs, C1, Rp, L1, C2, Rl):
+    def __init__(self, duty=0.5, fsw=1e3, Vs=10.0, Rs=0.5, C1=1e-3, Rp=0.01, L1=1e-3, C2=1e-3, Rl=10):
         """Initialization routine"""
 
         # invoke super init, passing number of dofs

--- a/pySDC/implementations/problem_classes/Piline.py
+++ b/pySDC/implementations/problem_classes/Piline.py
@@ -51,7 +51,7 @@ class piline(ptype):
     dtype_u = mesh
     dtype_f = imex_mesh
 
-    def __init__(self, Vs, Rs, C1, Rpi, Lpi, C2, Rl):
+    def __init__(self, Vs=100.0, Rs=1.0, C1=1.0, Rpi=0.2, Lpi=1.0, C2=1.0, Rl=5.0):
         """Initialization routine"""
 
         nvars = 3

--- a/pySDC/projects/PinTSimE/battery_model.py
+++ b/pySDC/projects/PinTSimE/battery_model.py
@@ -100,15 +100,8 @@ def generate_description(
 
     # initialize problem parameters
     problem_params = dict()
-    if problem == battery_implicit:
-        problem_params['newton_maxiter'] = 200
-        problem_params['newton_tol'] = 1e-08
     problem_params['ncapacitors'] = ncapacitors  # number of capacitors
-    problem_params['Vs'] = 5.0
-    problem_params['Rs'] = 0.5
     problem_params['C'] = C
-    problem_params['R'] = 1.0
-    problem_params['L'] = 1.0
     problem_params['alpha'] = alpha
     problem_params['V_ref'] = V_ref
 

--- a/pySDC/projects/PinTSimE/buck_model.py
+++ b/pySDC/projects/PinTSimE/buck_model.py
@@ -32,13 +32,6 @@ def main():
     problem_params = dict()
     problem_params['duty'] = 0.5  # duty cycle
     problem_params['fsw'] = 1e3  # switching freqency
-    problem_params['Vs'] = 10.0
-    problem_params['Rs'] = 0.5
-    problem_params['C1'] = 1e-3
-    problem_params['Rp'] = 0.01
-    problem_params['L1'] = 1e-3
-    problem_params['C2'] = 1e-3
-    problem_params['Rl'] = 10
 
     # initialize step parameters
     step_params = dict()
@@ -46,7 +39,7 @@ def main():
 
     # initialize controller parameters
     controller_params = dict()
-    controller_params['logger_level'] = 20
+    controller_params['logger_level'] = 30
     controller_params['hook_class'] = log_data
 
     # fill description dictionary for easy step instantiation

--- a/pySDC/projects/PinTSimE/piline_model.py
+++ b/pySDC/projects/PinTSimE/piline_model.py
@@ -70,29 +70,19 @@ def main():
     sweeper_params['num_nodes'] = 5
     # sweeper_params['QI'] = 'LU'  # For the IMEX sweeper, the LU-trick can be activated for the implicit part
 
-    # initialize problem parameters
-    problem_params = dict()
-    problem_params['Vs'] = 100.0
-    problem_params['Rs'] = 1.0
-    problem_params['C1'] = 1.0
-    problem_params['Rpi'] = 0.2
-    problem_params['C2'] = 1.0
-    problem_params['Lpi'] = 1.0
-    problem_params['Rl'] = 5.0
-
     # initialize step parameters
     step_params = dict()
     step_params['maxiter'] = 20
 
     # initialize controller parameters
     controller_params = dict()
-    controller_params['logger_level'] = 20
+    controller_params['logger_level'] = 30
     controller_params['hook_class'] = log_data
 
     # fill description dictionary for easy step instantiation
+    # keep in mind: default params are used for the problem, but can be changed
     description = dict()
     description['problem_class'] = piline  # pass problem class
-    description['problem_params'] = problem_params  # pass problem parameters
     description['sweeper_class'] = imex_1st_order  # pass sweeper
     description['sweeper_params'] = sweeper_params  # pass sweeper parameters
     description['level_params'] = level_params  # pass level parameters


### PR DESCRIPTION
The problem classes of the PinTSimE project now has also default parameters. In the battery classes I have to set V_ref and C equal to None and they were initialised as a numpy array afterwards, because flake raises an error when I set both values to a numpy array. 

Furthermore, there is a very small correction of docu of battery classes since I did a typo last time.. 