### PR TITLE
Warning for fully_implicit_DAE sweeper

### DIFF
--- a/pySDC/projects/DAE/sweepers/fully_implicit_DAE.py
+++ b/pySDC/projects/DAE/sweepers/fully_implicit_DAE.py
@@ -243,12 +243,10 @@ class fully_implicit_DAE(sweeper):
         if self.coll.right_is_node and not self.params.do_coll_update:
             # a copy is sufficient
             L.uend = P.dtype_u(L.u[-1])
-            print('Right is node')
         else:
             # start with u0 and add integral over the full interval (using coll.weights)
             L.uend = P.dtype_u(L.u[0])
             for m in range(self.coll.num_nodes):
                 L.uend += L.dt * self.coll.weights[m] * L.f[m + 1]
-            print('Right is not node')
 
         return None

--- a/pySDC/projects/DAE/sweepers/fully_implicit_DAE.py
+++ b/pySDC/projects/DAE/sweepers/fully_implicit_DAE.py
@@ -28,6 +28,10 @@ class fully_implicit_DAE(sweeper):
         if 'QI' not in params:
             params['QI'] = 'IE'
 
+        quad_type = params['quad_type']
+        if quad_type == 'LOBATTO' or quad_type == 'RADAU-LEFT':
+            raise ParameterError(f"Quadrature type {quad_type} is not implemented yet. Use 'RADAU-RIGHT' instead!")
+
         # call parent's initialization routine
         super(fully_implicit_DAE, self).__init__(params)
 
@@ -239,10 +243,12 @@ class fully_implicit_DAE(sweeper):
         if self.coll.right_is_node and not self.params.do_coll_update:
             # a copy is sufficient
             L.uend = P.dtype_u(L.u[-1])
+            print('Right is node')
         else:
             # start with u0 and add integral over the full interval (using coll.weights)
             L.uend = P.dtype_u(L.u[0])
             for m in range(self.coll.num_nodes):
                 L.uend += L.dt * self.coll.weights[m] * L.f[m + 1]
+            print('Right is not node')
 
         return None

--- a/pySDC/projects/DAE/sweepers/fully_implicit_DAE.py
+++ b/pySDC/projects/DAE/sweepers/fully_implicit_DAE.py
@@ -32,9 +32,7 @@ class fully_implicit_DAE(sweeper):
         super(fully_implicit_DAE, self).__init__(params)
 
         msg = f"Quadrature type {self.params.quad_type} is not implemented yet. Use 'RADAU-RIGHT' instead!"
-        if not self.coll.right_is_node:
-            raise ParameterError(msg)
-        elif self.coll.right_is_node and self.coll.left_is_node:
+        if self.coll.left_is_node:
             raise ParameterError(msg)
 
         self.QI = self.get_Qdelta_implicit(coll=self.coll, qd_type=self.params.QI)

--- a/pySDC/projects/DAE/sweepers/fully_implicit_DAE.py
+++ b/pySDC/projects/DAE/sweepers/fully_implicit_DAE.py
@@ -28,12 +28,14 @@ class fully_implicit_DAE(sweeper):
         if 'QI' not in params:
             params['QI'] = 'IE'
 
-        quad_type = params['quad_type']
-        if quad_type == 'LOBATTO' or quad_type == 'RADAU-LEFT':
-            raise ParameterError(f"Quadrature type {quad_type} is not implemented yet. Use 'RADAU-RIGHT' instead!")
-
         # call parent's initialization routine
         super(fully_implicit_DAE, self).__init__(params)
+
+        msg = f"Quadrature type {self.params.quad_type} is not implemented yet. Use 'RADAU-RIGHT' instead!"
+        if not self.coll.right_is_node:
+            raise ParameterError(msg)
+        elif self.coll.right_is_node and self.coll.left_is_node:
+            raise ParameterError(msg)
 
         self.QI = self.get_Qdelta_implicit(coll=self.coll, qd_type=self.params.QI)
 

--- a/pySDC/tests/test_projects/test_DAE/test_sweeper.py
+++ b/pySDC/tests/test_projects/test_DAE/test_sweeper.py
@@ -161,7 +161,7 @@ def test_compute_end_point_main():
 
     # initialize sweeper parameters
     sweeper_params = dict()
-    sweeper_params['quad_type'] = 'RADAU-LEFT'
+    sweeper_params['quad_type'] = 'RADAU-RIGHT'
     sweeper_params['num_nodes'] = 3
     sweeper_params['initial_guess'] = 'zero'
 
@@ -191,4 +191,5 @@ def test_compute_end_point_main():
     # computer end point
     L.sweep.compute_end_point()
 
-    assert np.array_equal(L.uend, L.u[0]), "ERROR: end point not computed correctly"
+    for m in range(1, L.sweep.coll.num_nodes):
+        assert np.array_equal(L.u[m], L.uend), "ERROR: end point not computed correctly"


### PR DESCRIPTION
Lobatto and also Radau-left nodes lead to an incorrect solution. In case of a DAE, in each step also an initial condition for the derivative of the solution `du[0]` has to be computed. I will do this in the near future, but for now a warning is added to point out to the user.

I also adapted the test for this sweeper. Does this new test make sense? I hope yes, otherwise please let me know.