### PR TITLE
Fix some tests ignored by pyTest

### DIFF
--- a/pySDC/tests/test_problem.py
+++ b/pySDC/tests/test_problem.py
@@ -44,9 +44,8 @@ def test_scipy_reference(init):
 
 @pytest.mark.base
 class TestBasics:
-    
     from pySDC.implementations.problem_classes.LogisticEquation import logistics_equation
-    
+
     PROBLEMS = {
         logistics_equation: {
             'probParams': dict(u0=2.0, newton_maxiter=100, newton_tol=1e-6, direct=True, lam=0.5, stop_at_nan=True),

--- a/pySDC/tests/test_problem.py
+++ b/pySDC/tests/test_problem.py
@@ -44,22 +44,29 @@ def test_scipy_reference(init):
 
 @pytest.mark.base
 class TestBasics:
-    from pySDC.implementations.problem_classes.LogisticEquation import logistics_equation
+    @staticmethod
+    def importClass(className):
+        if className == 'logistics_equation':
+            from pySDC.implementations.problem_classes.LogisticEquation import logistics_equation
+
+            return logistics_equation
+        else:
+            raise ValueError(f'cannot import {className} problem class')
 
     PROBLEMS = {
-        logistics_equation: {
+        'logistics_equation': {
             'probParams': dict(u0=2.0, newton_maxiter=100, newton_tol=1e-6, direct=True, lam=0.5, stop_at_nan=True),
             'testParams': {'tBeg': 0, 'tEnd': 1.0, 'nSteps': 1000, 'tol': 1e-3},
         }
     }
 
     @pytest.mark.base
-    @pytest.mark.parametrize('probType', PROBLEMS.keys())
-    def test_uExact_accuracy(self, probType):
-        params = self.PROBLEMS[probType]['probParams']
-        prob = probType(**params)
+    @pytest.mark.parametrize('className', PROBLEMS.keys())
+    def test_uExact_accuracy(self, className):
+        params = self.PROBLEMS[className]['probParams']
+        prob = self.importClass(className)(**params)
 
-        testParams = self.PROBLEMS[probType]['testParams']
+        testParams = self.PROBLEMS[className]['testParams']
         tBeg = testParams['tBeg']
         tEnd = testParams['tEnd']
         nSteps = testParams['nSteps']
@@ -74,7 +81,5 @@ class TestBasics:
 if __name__ == '__main__':
     test_scipy_reference([(2, 3)])
 
-    from pySDC.implementations.problem_classes.LogisticEquation import logistics_equation
-
     prob = TestBasics()
-    prob.test_uExact_accuracy(logistics_equation)
+    prob.test_uExact_accuracy('logistics_equation')

--- a/pySDC/tests/test_problem.py
+++ b/pySDC/tests/test_problem.py
@@ -44,15 +44,15 @@ def test_scipy_reference(init):
 
 @pytest.mark.base
 class TestBasics:
-    PROBLEMS = {}
-
-    def __init__(self):
-        from pySDC.implementations.problem_classes.LogisticEquation import logistics_equation
-
-        self.PROBLEMS[logistics_equation] = {
+    
+    from pySDC.implementations.problem_classes.LogisticEquation import logistics_equation
+    
+    PROBLEMS = {
+        logistics_equation: {
             'probParams': dict(u0=2.0, newton_maxiter=100, newton_tol=1e-6, direct=True, lam=0.5, stop_at_nan=True),
             'testParams': {'tBeg': 0, 'tEnd': 1.0, 'nSteps': 1000, 'tol': 1e-3},
         }
+    }
 
     @pytest.mark.base
     @pytest.mark.parametrize('probType', PROBLEMS.keys())


### PR DESCRIPTION
After @brownbaerchen noticed a warning was induced and test ignored, here is a solution that avoid that this part in the `base` test make `fenics` test fail (long story short, clashes between mpi4py imports ...) 