### PR TITLE
Small tweaks for RK sweepers

### DIFF
--- a/pySDC/implementations/sweeper_classes/Runge_Kutta.py
+++ b/pySDC/implementations/sweeper_classes/Runge_Kutta.py
@@ -313,30 +313,47 @@ class RungeKutta(sweeper):
         self.__level = lvl
 
 
-class RK1(RungeKutta):
+class ForwardEuler(RungeKutta):
+    """
+    Forward Euler. Still a classic.
+
+    Not very stable first order method.
+    """
+
     def __init__(self, params):
-        implicit = params.get('implicit', False)
         nodes = np.array([0.0])
         weights = np.array([1.0])
-        if implicit:
-            matrix = np.array(
-                [
-                    [1.0],
-                ]
-            )
-        else:
-            matrix = np.array(
-                [
-                    [0.0],
-                ]
-            )
+        matrix = np.array(
+            [
+                [0.0],
+            ]
+        )
         params['butcher_tableau'] = ButcherTableau(weights, nodes, matrix)
-        super(RK1, self).__init__(params)
+        super().__init__(params)
+
+
+class BackwardEuler(RungeKutta):
+    """
+    Backward Euler. A favorite among true connoisseurs of the heat equation.
+
+    A-stable first order method.
+    """
+
+    def __init__(self, params):
+        nodes = np.array([0.0])
+        weights = np.array([1.0])
+        matrix = np.array(
+            [
+                [1.0],
+            ]
+        )
+        params['butcher_tableau'] = ButcherTableau(weights, nodes, matrix)
+        super().__init__(params)
 
 
 class CrankNicholson(RungeKutta):
     """
-    Implicit Runge-Kutta method of second order
+    Implicit Runge-Kutta method of second order, A-stable.
     """
 
     def __init__(self, params):
@@ -346,28 +363,35 @@ class CrankNicholson(RungeKutta):
         matrix[1, 0] = 0.5
         matrix[1, 1] = 0.5
         params['butcher_tableau'] = ButcherTableau(weights, nodes, matrix)
-        super(CrankNicholson, self).__init__(params)
+        super().__init__(params)
 
 
-class MidpointMethod(RungeKutta):
+class ExplicitMidpointMethod(RungeKutta):
     """
-    Runge-Kutta method of second order
+    Explicit Runge-Kutta method of second order.
     """
 
     def __init__(self, params):
-        implicit = params.get('implicit', False)
-        if implicit:
-            nodes = np.array([0.5])
-            weights = np.array([1])
-            matrix = np.zeros((1, 1))
-            matrix[0, 0] = 1.0 / 2.0
-        else:
-            nodes = np.array([0, 0.5])
-            weights = np.array([0, 1])
-            matrix = np.zeros((2, 2))
-            matrix[1, 0] = 0.5
+        nodes = np.array([0, 0.5])
+        weights = np.array([0, 1])
+        matrix = np.zeros((2, 2))
+        matrix[1, 0] = 0.5
         params['butcher_tableau'] = ButcherTableau(weights, nodes, matrix)
-        super(MidpointMethod, self).__init__(params)
+        super().__init__(params)
+
+
+class ImplicitMidpointMethod(RungeKutta):
+    """
+    Implicit Runge-Kutta method of second order.
+    """
+
+    def __init__(self, params):
+        nodes = np.array([0.5])
+        weights = np.array([1])
+        matrix = np.zeros((1, 1))
+        matrix[0, 0] = 1.0 / 2.0
+        params['butcher_tableau'] = ButcherTableau(weights, nodes, matrix)
+        super().__init__(params)
 
 
 class RK4(RungeKutta):
@@ -383,12 +407,12 @@ class RK4(RungeKutta):
         matrix[2, 1] = 0.5
         matrix[3, 2] = 1.0
         params['butcher_tableau'] = ButcherTableau(weights, nodes, matrix)
-        super(RK4, self).__init__(params)
+        super().__init__(params)
 
 
 class Heun_Euler(RungeKutta):
     """
-    Second order explicit embedded Runge-Kutta
+    Second order explicit embedded Runge-Kutta method.
     """
 
     def __init__(self, params):
@@ -397,7 +421,7 @@ class Heun_Euler(RungeKutta):
         matrix = np.zeros((2, 2))
         matrix[1, 0] = 1
         params['butcher_tableau'] = ButcherTableauEmbedded(weights, nodes, matrix)
-        super(Heun_Euler, self).__init__(params)
+        super().__init__(params)
 
     @classmethod
     def get_update_order(cls):
@@ -424,7 +448,7 @@ class Cash_Karp(RungeKutta):
         matrix[4, :4] = [-11.0 / 54.0, 5.0 / 2.0, -70.0 / 27.0, 35.0 / 27.0]
         matrix[5, :5] = [1631.0 / 55296.0, 175.0 / 512.0, 575.0 / 13824.0, 44275.0 / 110592.0, 253.0 / 4096.0]
         params['butcher_tableau'] = ButcherTableauEmbedded(weights, nodes, matrix)
-        super(Cash_Karp, self).__init__(params)
+        super().__init__(params)
 
     @classmethod
     def get_update_order(cls):

--- a/pySDC/implementations/sweeper_classes/Runge_Kutta.py
+++ b/pySDC/implementations/sweeper_classes/Runge_Kutta.py
@@ -3,6 +3,7 @@ import logging
 
 from pySDC.core.Sweeper import sweeper, _Pars
 from pySDC.core.Errors import ParameterError
+from pySDC.core.Level import level
 from pySDC.implementations.datatype_classes.mesh import imex_mesh, mesh
 
 
@@ -143,7 +144,7 @@ class RungeKutta(sweeper):
 
     All of these variables are either determined by the RK rule, or are not part of an RK scheme.
 
-    Attribues:
+    Attributes:
         butcher_tableau (ButcherTableau): Butcher tableau for the Runge-Kutta scheme that you want
     """
 
@@ -283,6 +284,33 @@ class RungeKutta(sweeper):
         In this Runge-Kutta implementation, the solution to the step is always stored in the last node
         """
         self.level.uend = self.level.u[-1]
+
+    @property
+    def level(self):
+        """
+        Returns the current level
+
+        Returns:
+            pySDC.Level.level: Current level
+        """
+        return self.__level
+
+    @level.setter
+    def level(self, lvl):
+        """
+        Sets a reference to the current level (done in the initialization of the level)
+
+        Args:
+            lvl (pySDC.Level.level): Current level
+        """
+        assert isinstance(lvl, level), f"You tried to set the sweeper's level with an instance of {type(lvl)}!"
+        if lvl.params.restol > 0:
+            lvl.params.restol = -1
+            self.logger.warning(
+                'Overwriting residual tolerance with -1 because RK methods are direct and hence may not compute a residual at all!'
+            )
+
+        self.__level = lvl
 
 
 class RK1(RungeKutta):

--- a/pySDC/projects/Resilience/accuracy_check.py
+++ b/pySDC/projects/Resilience/accuracy_check.py
@@ -9,6 +9,7 @@ from pySDC.implementations.convergence_controller_classes.estimate_extrapolation
 )
 from pySDC.core.Hooks import hooks
 from pySDC.implementations.hooks.log_errors import LogLocalErrorPostStep
+from pySDC.projects.Resilience.strategies import merge_descriptions
 
 import pySDC.helpers.plot_helper as plt_helper
 from pySDC.projects.Resilience.piline import run_piline
@@ -87,6 +88,7 @@ def multiple_runs(
     custom_controller_params=None,
     var='dt',
     avoid_restarts=False,
+    embedded_error_flavor=None,
 ):
     """
     A simple test program to compute the order of accuracy.
@@ -103,6 +105,7 @@ def multiple_runs(
         custom_controller_params (dict): Custom parameters to pass to the problem
         var (str): The variable to check the order against
         avoid_restarts (bool): Mode of running adaptivity if applicable
+        embedded_error_flavor (str): Flavor for the estimation of embedded error
 
     Returns:
         dict: The errors for different values of var
@@ -118,7 +121,9 @@ def multiple_runs(
 
     num_procs = 1 if serial else 5
 
-    embedded_error_flavor = 'standard' if avoid_restarts else 'linearized'
+    embedded_error_flavor = (
+        embedded_error_flavor if embedded_error_flavor else 'standard' if avoid_restarts else 'linearized'
+    )
 
     # perform rest of the tests
     for i in range(0, len(dt_list)):
@@ -143,7 +148,7 @@ def multiple_runs(
             }
 
         if custom_description is not None:
-            desc = {**desc, **custom_description}
+            desc = merge_descriptions(desc, custom_description)
         Tend = Tend_fixed if Tend_fixed else 30 * dt_list[i]
         stats, controller, _ = prob(
             custom_description=desc,
@@ -194,7 +199,7 @@ def plot_order(res, ax, k):
     ax.legend(frameon=False, loc='lower right')
 
 
-def plot(res, ax, k, var='dt'):
+def plot(res, ax, k, var='dt', keys=None):
     """
     Plot the order of various errors using the results from `multiple_runs`.
 
@@ -203,11 +208,12 @@ def plot(res, ax, k, var='dt'):
         ax: Somewhere to plot
         k (int): Number of SDC sweeps
         var (str): The variable to compute the order against
+        keys (list): List of keys to plot from the results
 
     Returns:
         None
     """
-    keys = ['e_embedded', 'e_extrapolated', 'e']
+    keys = keys if keys else ['e_embedded', 'e_extrapolated', 'e']
     ls = ['-', ':', '-.']
     color = plt.rcParams['axes.prop_cycle'].by_key()['color'][k - 2]
 
@@ -267,9 +273,8 @@ def get_accuracy_order(results, key='e_embedded', thresh=1e-14, var='dt'):
     for i in range(1, len(dt_list)):
         # compute order as log(prev_error/this_error)/log(this_dt/old_dt) <-- depends on the sorting of the list!
         try:
-            tmp = np.log(results[key][i] / results[key][i - 1]) / np.log(dt_list[i] / dt_list[i - 1])
             if results[key][i] > thresh and results[key][i - 1] > thresh:
-                order.append(tmp)
+                order.append(np.log(results[key][i] / results[key][i - 1]) / np.log(dt_list[i] / dt_list[i - 1]))
         except TypeError:
             print('Type Warning', results[key])
 
@@ -285,6 +290,7 @@ def plot_orders(
     prob=run_piline,
     dt_list=None,
     custom_controller_params=None,
+    embedded_error_flavor=None,
 ):
     """
     Plot only the local error.
@@ -298,6 +304,7 @@ def plot_orders(
         prob (function): A function that can accept suitable arguments and run a problem (see the Resilience project)
         dt_list (list): A list of values to check the order with
         custom_controller_params (dict): Custom parameters to pass to the problem
+        embedded_error_flavor (str): Flavor for the estimation of embedded error
 
     Returns:
         None
@@ -313,6 +320,7 @@ def plot_orders(
             dt_list=dt_list,
             hook_class=DoNothing,
             custom_controller_params=custom_controller_params,
+            embedded_error_flavor=embedded_error_flavor,
         )
         plot_order(res, ax, k)
 
@@ -328,6 +336,8 @@ def plot_all_errors(
     custom_controller_params=None,
     var='dt',
     avoid_restarts=False,
+    embedded_error_flavor=None,
+    keys=None,
 ):
     """
     Make tests for plotting the error and plot a bunch of error estimates
@@ -343,6 +353,8 @@ def plot_all_errors(
         custom_controller_params (dict): Custom parameters to pass to the problem
         var (str): The variable to compute the order against
         avoid_restarts (bool): Mode of running adaptivity if applicable
+        embedded_error_flavor (str): Flavor for the estimation of embedded error
+        keys (list): List of keys to plot from the results
 
     Returns:
         None
@@ -359,10 +371,11 @@ def plot_all_errors(
             custom_controller_params=custom_controller_params,
             var=var,
             avoid_restarts=avoid_restarts,
+            embedded_error_flavor=embedded_error_flavor,
         )
 
         # visualize results
-        plot(res, ax, k, var=var)
+        plot(res, ax, k, var=var, keys=keys)
 
     ax.plot([None, None], color='black', label=r'$\epsilon_\mathrm{embedded}$', ls='-')
     ax.plot([None, None], color='black', label=r'$\epsilon_\mathrm{extrapolated}$', ls=':')

--- a/pySDC/tests/test_Runge_Kutta_sweeper.py
+++ b/pySDC/tests/test_Runge_Kutta_sweeper.py
@@ -55,8 +55,9 @@ def plot_order(sweeper_name, prob, dt_list, description=None, ax=None, Tend_fixe
     description['sweeper_class'] = get_sweeper(sweeper_name)
     description['sweeper_params'] = {'implicit': implicit}
     description['step_params'] = {'maxiter': 1}
+    description['level_params'] = {'restol': +1}
 
-    custom_controller_params = {'logger_level': 40}
+    custom_controller_params = {'logger_level': 30}
 
     # determine the order
     plot_orders(
@@ -68,6 +69,7 @@ def plot_order(sweeper_name, prob, dt_list, description=None, ax=None, Tend_fixe
         dt_list=dt_list,
         prob=prob,
         custom_controller_params=custom_controller_params,
+        embedded_error_flavor='standard',
     )
 
     # check if we got the expected order for the local error
@@ -120,7 +122,7 @@ def plot_stability_single(sweeper_name, ax=None, description=None, implicit=True
     description['sweeper_params'] = {'implicit': implicit}
     description['step_params'] = {'maxiter': 1}
 
-    custom_controller_params = {'logger_level': 40}
+    custom_controller_params = {'logger_level': 30}
 
     re = np.linspace(-30, 30, 400) if re is None else re
     im = np.linspace(-50, 50, 400) if im is None else im
@@ -271,14 +273,14 @@ def test_embedded_estimate_order(sweeper_name):
 
     # change only the things in the description that we need for adaptivity
     convergence_controllers = {}
-    convergence_controllers[EstimateEmbeddedError] = {}
+    convergence_controllers[EstimateEmbeddedError.get_implementation('standard')] = {}
 
     description = {}
     description['convergence_controllers'] = convergence_controllers
     description['sweeper_class'] = get_sweeper(sweeper_name)
     description['step_params'] = {'maxiter': 1}
 
-    custom_controller_params = {'logger_level': 40}
+    custom_controller_params = {'logger_level': 30}
 
     Tend = 7e-2
     dt_list = Tend * 2.0 ** (-np.arange(8))
@@ -292,6 +294,8 @@ def test_embedded_estimate_order(sweeper_name):
         dt_list=dt_list,
         prob=prob,
         custom_controller_params=custom_controller_params,
+        embedded_error_flavor='standard',
+        keys=['e', 'e_embedded'],
     )
 
 


### PR DESCRIPTION
This PR includes two small changes to RK implementations.

First, @ikrom96git noticed that when supplying a residual tolerance larger than 0, the RK sweepers would do nothing and don't tell you about it. This is now fixed by setting the residual tolerance to -1 in the setter for the level as well as raising a warning when this is done.
Because RK methods are direct with a single iteration, the residual drops to machine precision after the first iteration. We can compute this to confirm that the method does what it's supposed to, but this is very computationally expensive and could dominate the computational time for explicit methods. So the residual is usually never computed and set to 0 instead.

The second change is regarding tests. The same things are testet as before (although I removed some redundant tests, I think), but in a more finely grained fashion. Instead of testing if all methods are A stable at the same time, there are now individual tests for the different methods. So if a test failed, you don't see: Some RK method is no longer A stable, but you see: These specific RK methods are no longer A stable. This also makes it easier to add new methods.
Because I want to test that the methods now work when giving a residual tolerance larger than 0, annoyingly I had to rewrite the script that computes the order a bit... I guess when I tried to write one script that does all, I failed to make things more simple and instead just complicated everything more than necessary.

@tlunet: Since Robert is on vacation and this is only a small change, I think you can merge this PR if you see fit. I don't think we need to wait until he comes back. Feel free to suggest improvements of course!