### PR TITLE
Fix failing pre-commit hook when deleting files

### DIFF
--- a/docs/contrib/02_continuous_integration.md
+++ b/docs/contrib/02_continuous_integration.md
@@ -37,8 +37,18 @@ To this end, just add the following to a possibly new file in the path `<pySDC-r
 ```bash
 #!/bin/sh
 
+# get files that have been staged
 export files=$(git diff --staged --name-only HEAD | grep .py | sed -e "s,^,$(git rev-parse --show-toplevel)/,")
 
+# remove any deleted files because black will otherwise fail
+for file in $files
+do
+        if [ ! -f "$file" ]; then
+            files=( ${files[@]/$file} )
+        fi
+done
+
+# apply black and stage the changes that black made
 if [[ $files != "" ]]
 then  
         black $files


### PR DESCRIPTION
I don't know if anybody apart form me actually uses these git hooks, but if we make them public, I want them to work. I noticed only now that black fails when you give it a path that doesn't exist. (The same is not true for flakeheaven) Since deleting a file in git will stage it, but its path no longer exists, this hook will prevent you from committing deleted files. So I fixed it in a not so pretty way because I am bad at bash. If you have a better idea, feel free to suggest something.