### PR TITLE
More efficient RK sweepers

### DIFF
--- a/pySDC/implementations/problem_classes/TestEquation_0D.py
+++ b/pySDC/implementations/problem_classes/TestEquation_0D.py
@@ -3,7 +3,7 @@ import scipy.sparse as sp
 from scipy.sparse.linalg import splu
 
 from pySDC.core.Errors import ParameterError
-from pySDC.core.Problem import ptype
+from pySDC.core.Problem import ptype, WorkCounter
 from pySDC.implementations.datatype_classes.mesh import mesh
 
 
@@ -38,6 +38,7 @@ class testequation0d(ptype):
 
         self.A = self.__get_A(lambdas)
         self._makeAttributeAndRegister('nvars', 'lambdas', 'u0', localVars=locals(), readOnly=True)
+        self.work_counters['rhs'] = WorkCounter()
 
     @staticmethod
     def __get_A(lambdas):
@@ -68,6 +69,7 @@ class testequation0d(ptype):
 
         f = self.dtype_f(self.init)
         f[:] = self.A.dot(u)
+        self.work_counters['rhs']()
         return f
 
     def solve_system(self, rhs, factor, u0, t):

--- a/pySDC/implementations/sweeper_classes/Runge_Kutta.py
+++ b/pySDC/implementations/sweeper_classes/Runge_Kutta.py
@@ -224,7 +224,7 @@ class RungeKutta(sweeper):
             list of dtype_u: containing the integral as values
         """
 
-        # get current level and problem description
+        # get current level and problem
         lvl = self.level
         prob = lvl.prob
 
@@ -247,7 +247,7 @@ class RungeKutta(sweeper):
             None
         """
 
-        # get current level and problem description
+        # get current level and problem
         lvl = self.level
         prob = lvl.prob
 
@@ -317,7 +317,7 @@ class RungeKutta(sweeper):
         Predictor to fill values at nodes before first sweep
         """
 
-        # get current level and problem description
+        # get current level and problem
         lvl = self.level
         prob = lvl.prob
 

--- a/pySDC/tests/test_Runge_Kutta_sweeper.py
+++ b/pySDC/tests/test_Runge_Kutta_sweeper.py
@@ -56,6 +56,7 @@ def plot_order(sweeper_name, prob, dt_list, description=None, ax=None, Tend_fixe
     description['sweeper_class'] = get_sweeper(sweeper_name)
     description['step_params'] = {'maxiter': 1}
     description['level_params'] = {'restol': +1}
+    description['sweeper_params'] = {'eval_rhs_at_right_boundary': True}
 
     custom_controller_params = {'logger_level': 30}
 
@@ -273,6 +274,7 @@ def test_embedded_estimate_order(sweeper_name):
     description['convergence_controllers'] = convergence_controllers
     description['sweeper_class'] = get_sweeper(sweeper_name)
     description['step_params'] = {'maxiter': 1}
+    description['sweeper_params'] = {'eval_rhs_at_right_boundary': True}
 
     custom_controller_params = {'logger_level': 30}
 
@@ -373,13 +375,13 @@ def test_rhs_evaluations(sweeper_name):
     u_end, stats = controller.run(prob.u_exact(0), 0.0, 2.0)
 
     sweep = controller.MS[0].levels[0].sweep
-    num_nodes = sweep.coll.num_nodes
+    num_stages = sweep.coll.num_nodes - sweep.coll.num_solution_stages
 
     rhs_evaluations = [me[1] for me in get_sorted(stats, type='work_rhs')]
 
     assert all(
-        me == num_nodes for me in rhs_evaluations
-    ), f'Did not perform one RHS evaluation per step and stage in {sweeper_name} method! Expected {num_nodes}, but got {rhs_evaluations}.'
+        me == num_stages for me in rhs_evaluations
+    ), f'Did not perform one RHS evaluation per step and stage in {sweeper_name} method! Expected {num_stages}, but got {rhs_evaluations}.'
 
 
 if __name__ == '__main__':
@@ -389,7 +391,7 @@ if __name__ == '__main__':
     from pySDC.projects.Resilience.vdp import run_vdp
     from pySDC.projects.Resilience.advection import run_advection
 
-    test_rhs_evaluations('CrankNicholson')
+    test_rhs_evaluations('BackwardEuler')
 
     plot_all_orders(
         run_vdp,

--- a/pySDC/tests/test_Runge_Kutta_sweeper.py
+++ b/pySDC/tests/test_Runge_Kutta_sweeper.py
@@ -379,7 +379,7 @@ def test_rhs_evaluations(sweeper_name):
 
     assert all(
         me == num_nodes for me in rhs_evaluations
-    ), f'Did not perform one RHS evaluation per step in {sweeper_name} method! Expected {num_nodes}, but got {rhs_evaluations}.'
+    ), f'Did not perform one RHS evaluation per step and stage in {sweeper_name} method! Expected {num_nodes}, but got {rhs_evaluations}.'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
@ikrom96git noticed that RK sweepers were performing more RHS evaluations than necessary.
Namely, the `predict` function was inherited from the core Sweeper module and evaluated the RHS at the initial conditions.
However, in a similar fashion to the other sweepers, we add always 0 to the nodes and the right hand side evaluation there is never used.
Since the weights are stored as just another explicit stage in this implementation, we add another node for the right boundary (or two in the case of embedded methods). While we used to evaluate the right hand side at the solution(s), this is rarely needed.
When computing the extrapolated error estimate, I rely on the right hand side evaluations of the solutions, but in general, we can forgo this.

So in this PR all unnecessary right hand side evaluations have been removed from the RK sweeper. There is a test making sure that we only perform one for each stage per step.

Makes me wonder if we can remove some right hand side evaluations in SDC sweepers as well...

Thanks a lot to @ikrom96git for paying attention! Now the RK methods will perform even better than SDC, but at least we're more honest :D