### PR TITLE
Added multistep methods as a sweeper

### DIFF
--- a/pySDC/implementations/sweeper_classes/Multistep.py
+++ b/pySDC/implementations/sweeper_classes/Multistep.py
@@ -1,0 +1,220 @@
+from pySDC.core.Sweeper import sweeper, _Pars
+
+
+class Cache(object):
+    """
+    Class for managing solutions and right hand side evaluations of previous steps for the MultiStep "sweeper".
+
+    Attributes:
+        - u (list): Contains solution from previous steps
+        - f (list): Contains right hand side evaluations from previous steps
+        - t (list): Contains time of previous steps
+    """
+
+    def __init__(self, num_entries):
+        """
+        Initialization routing
+
+        Args:
+            num_entries (int): Number of entries for the cache
+        """
+        self.num_entries = num_entries
+        self.u = [None] * num_entries
+        self.f = [None] * num_entries
+        self.t = [None] * num_entries
+
+    def update(self, t, u, f):
+        """
+        Add a new value to the cache and remove the oldest one.
+
+        Args:
+            t (float): Time of new step
+            u (dtype_u): Solution of new step
+            f (dtype_f): Right hand side evaluation at new step
+        """
+        self.u[:-1] = self.u[1:]
+        self.f[:-1] = self.f[1:]
+        self.t[:-1] = self.t[1:]
+
+        self.u[-1] = u
+        self.f[-1] = f
+        self.t[-1] = t
+
+    def __str__(self):
+        """
+        Print the contents of the cache for debugging purposes.
+        """
+        string = ''
+        for i in range(self.num_entries):
+            string = f'{string} t={self.t[i]}: u={self.u[i]}, f={self.f[i]}'
+
+        return string
+
+
+class MultiStep(sweeper):
+    def __init__(self, params, alpha, beta):
+        """
+        Initialization routine for the base sweeper
+
+        Args:
+            params (dict): parameter object
+
+        """
+        import logging
+        from pySDC.core.Collocation import CollBase
+
+        # set up logger
+        self.logger = logging.getLogger('sweeper')
+
+        if 'collocation_class' not in params:
+            params['collocation_class'] = CollBase
+
+        self.params = _Pars(params)
+
+        # we need a dummy collocation object to instantiate the levels.
+        self.coll = params['collocation_class'](**params)
+
+        # This will be set as soon as the sweeper is instantiated at the level
+        self.__level = None
+
+        self.parallelizable = False
+
+        super().__init__(params)
+
+        # proprietary variables for the multistep methods
+        self.steps = len(alpha)
+        self.cache = Cache(self.steps)
+        self.alpha = alpha
+        self.beta = beta
+
+    def predict(self):
+        """
+        Add the initial conditions to the cache if needed.
+
+        Default prediction for the sweepers, only copies the values to all collocation nodes
+        and evaluates the RHS of the ODE there
+        """
+        lvl = self.level
+
+        if all(me is None for me in self.cache.t):
+            prob = lvl.prob
+            lvl.f[0] = prob.eval_f(lvl.u[0], lvl.time)
+            self.cache.update(lvl.time, lvl.u[0], lvl.f[0])
+
+        lvl.status.unlocked = True
+        lvl.status.updated = True
+
+    def compute_residual(self, stage=None):
+        """
+        Do nothing.
+
+        Args:
+            stage (str): The current stage of the step the level belongs to
+        """
+        lvl = self.level
+        lvl.status.residual = 0.0
+        lvl.status.updated = False
+
+        return None
+
+    def compute_end_point(self):
+        """
+        The solution is stored in the single node that we have.
+        """
+        self.level.uend = self.level.u[-1]
+
+    def update_nodes(self):
+        """
+        Compute the solution to the current step. If the cache is not filled, we compute a provisional solution with a different method.
+        """
+
+        lvl = self.level
+        prob = lvl.prob
+        time = lvl.time + lvl.dt
+
+        if None in self.cache.t:
+            self.generate_starting_values()
+
+        else:
+
+            # build the right hand side from the previous solutions
+            rhs = prob.dtype_u(prob.init)
+            dts = [self.cache.t[i + 1] - self.cache.t[i] for i in range(self.steps - 1)] + [
+                time - self.cache.t[-1]
+            ]  # TODO: Does this work for adaptive step sizes?
+            for i in range(len(self.alpha)):
+                rhs -= self.alpha[i] * self.cache.u[i]
+                rhs += dts[i] * self.beta[i] * self.cache.f[i]
+
+            # compute the solution to the current step "implicit Euler style"
+            lvl.u[1] = prob.solve_system(rhs, lvl.dt * self.beta[-1], self.cache.u[-1], time)
+
+        lvl.f[1] = prob.eval_f(lvl.u[1], time)
+        self.cache.update(time, lvl.u[1], lvl.f[1])
+
+    def generate_starting_values(self):
+        """
+        Compute solutions to the steps when not enough previous values are available for the multistep method.
+        The initial conditions are added in `predict` since this is not bespoke behaviour to any method.
+        """
+        raise NotImplementedError(
+            "No implementation for generating solutions when not enough previous values are available!"
+        )
+
+
+class AdamsBashforthExplicit1Step(MultiStep):
+    """
+    This is just forward Euler.
+    """
+
+    def __init__(self, params):
+        alpha = [-1.0]
+        beta = [1.0, 0.0]
+        super().__init__(params, alpha, beta)
+
+
+class BackwardEuler(MultiStep):
+    """
+    Do you like mess? Me neither! Let me lure you in!
+    """
+
+    def __init__(self, params):
+        alpha = [-1.0]
+        beta = [0.0, 1.0]
+        super().__init__(params, alpha, beta)
+
+
+class AdamsMoultonImplicit1Step(MultiStep):
+    """
+    Trapezoidal method dressed up as a multistep method.
+    """
+
+    def __init__(self, params):
+        alpha = [-1.0]
+        beta = [0.5, 0.5]
+
+        super().__init__(params, alpha, beta)
+
+
+class AdamsMoultonImplicit2Step(MultiStep):
+    """
+    Third order implicit scheme
+    """
+
+    def __init__(self, params):
+        alpha = [0.0, -1.0]
+        beta = [-1.0 / 12.0, 8.0 / 12.0, 5.0 / 12.0]
+        super().__init__(params, alpha, beta)
+
+    def generate_starting_values(self):
+        """
+        Generate starting value by trapezoidal rule.
+        """
+        lvl = self.level
+        prob = lvl.prob
+        time = lvl.time + lvl.dt
+
+        # do trapezoidal rule
+        rhs = lvl.u[0] + lvl.dt / 2 * lvl.f[0]
+
+        lvl.u[1] = prob.solve_system(rhs, lvl.dt / 2.0, lvl.u[0], time)

--- a/pySDC/implementations/sweeper_classes/Multistep.py
+++ b/pySDC/implementations/sweeper_classes/Multistep.py
@@ -136,7 +136,6 @@ class MultiStep(sweeper):
             self.generate_starting_values()
 
         else:
-
             # build the right hand side from the previous solutions
             rhs = prob.dtype_u(prob.init)
             dts = [self.cache.t[i + 1] - self.cache.t[i] for i in range(self.steps - 1)] + [

--- a/pySDC/tests/test_Multistep_sweeper.py
+++ b/pySDC/tests/test_Multistep_sweeper.py
@@ -1,0 +1,192 @@
+import pytest
+
+sweeper_names = [
+    'AdamsMoultonImplicit2Step',
+    'AdamsMoultonImplicit1Step',
+    'BackwardEuler',
+    'AdamsBashforthExplicit1Step',
+]
+
+
+def get_sweeper(sweeper_name):
+    """
+    Retrieve a sweeper from a name
+
+    Args:
+        sweeper_name (str):
+
+    Returns:
+        pySDC.Sweeper.RungeKutta: The sweeper
+    """
+    import pySDC.implementations.sweeper_classes.Multistep as Multistep
+
+    return eval(f'Multistep.{sweeper_name}')
+
+
+def single_run(sweeper_name, dt, Tend, lambdas):
+    """
+    Do a single run of the test equation.
+
+    Args:
+        sweeper_name (str): Name of Multistep method
+        dt (float): Step size to use
+        Tend (float): Time to simulate to
+        lambdas (2d complex numpy.ndarray): Lambdas for test equation
+
+    Returns:
+        dict: Stats
+        pySDC.datatypes.mesh: Initial conditions
+    """
+    from pySDC.implementations.problem_classes.TestEquation_0D import testequation0d
+    from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
+    from pySDC.implementations.hooks.log_work import LogWork
+    from pySDC.implementations.hooks.log_errors import LogGlobalErrorPostRun
+    from pySDC.implementations.hooks.log_solution import LogSolution
+
+    level_params = {'dt': dt}
+
+    step_params = {'maxiter': 1}
+
+    problem_params = {
+        'lambdas': lambdas,
+        'u0': 1.0 + 0.0j,
+    }
+
+    sweeper_params = {
+        'num_nodes': 1,
+        'quad_type': 'RADAU-RIGHT',
+    }
+
+    description = {
+        'level_params': level_params,
+        'step_params': step_params,
+        'sweeper_class': get_sweeper(sweeper_name),
+        'problem_class': testequation0d,
+        'sweeper_params': sweeper_params,
+        'problem_params': problem_params,
+    }
+
+    controller_params = {
+        'logger_level': 30,
+        'hook_class': [LogWork, LogGlobalErrorPostRun, LogSolution],
+    }
+
+    controller = controller_nonMPI(num_procs=1, controller_params=controller_params, description=description)
+
+    prob = controller.MS[0].levels[0].prob
+    ic = prob.u_exact(0)
+    u_end, stats = controller.run(ic, 0.0, Tend)
+
+    return stats, ic
+
+
+@pytest.mark.base
+@pytest.mark.parametrize("sweeper_name", sweeper_names)
+def test_order(sweeper_name):
+    """
+    Test the order in time of the method
+
+    Args:
+        sweeper_name (str): Name of the multistep method
+    """
+    import numpy as np
+
+    from pySDC.helpers.stats_helper import get_sorted
+
+    expected_order = {
+        'AdamsMoultonImplicit1Step': 2,
+        'AdamsMoultonImplicit2Step': 3,
+        'BackwardEuler': 1,
+        'AdamsBashforthExplicit1Step': 1,
+    }
+
+    dt_max = {}
+
+    lambdas = [[-1.0e-1 + 0j]]
+
+    e = {}
+    dts = [dt_max.get(sweeper_name, 1e-1) / 2**i for i in range(5)]
+    for dt in dts:
+        stats, _ = single_run(sweeper_name, dt, 2 * max(dts), lambdas)
+        e[dt] = get_sorted(stats, type='e_global_post_run')[-1][1]
+
+    order = [np.log(e[dts[i]] / e[dts[i + 1]]) / np.log(dts[i] / dts[i + 1]) for i in range(len(dts) - 1)]
+
+    assert np.isclose(
+        np.mean(order), expected_order[sweeper_name], atol=0.2
+    ), f"Got unexpected order {np.mean(order):.2f} for {sweeper_name} method!"
+
+
+@pytest.mark.base
+@pytest.mark.parametrize("sweeper_name", sweeper_names)
+def test_stability(sweeper_name):
+    """
+    Test the stability of the method
+
+    Args:
+        sweeper_name (str): Name of the multistep method
+    """
+    import numpy as np
+    from pySDC.helpers.stats_helper import get_sorted
+
+    expected_A_stability = {
+        'AdamsMoultonImplicit1Step': True,
+        'AdamsMoultonImplicit2Step': True,
+        'BackwardEuler': True,
+        'AdamsBashforthExplicit1Step': False,
+    }
+
+    re = -np.logspace(-3, 6, 50)
+    im = -np.logspace(-3, 6, 50)
+    lambdas = np.array([[complex(re[i], im[j]) for i in range(len(re))] for j in range(len(im))]).reshape(
+        (len(re) * len(im))
+    )
+
+    stats, ic = single_run(sweeper_name, 1.0, 1.0, lambdas)
+    u = get_sorted(stats, type='u')[-1][1]
+
+    unstable = np.abs(u) / np.abs(ic) > 1.0
+
+    Astable = not any(lambdas[unstable].real < 0)
+    assert Astable == expected_A_stability[sweeper_name], f"Unexpected stability properties for {sweeper_name} method!"
+    assert any(~unstable), f"{sweeper_name} method is stable nowhere!"
+
+
+@pytest.mark.base
+@pytest.mark.parametrize("sweeper_name", sweeper_names)
+def test_rhs_evals(sweeper_name):
+    """
+    Test the number of right hand side evaluations.
+
+    Args:
+        sweeper_name (str): Name of the multistep method
+    """
+    from pySDC.helpers.stats_helper import get_sorted
+
+    # record how many right hand side evaluations we expect in the format ([<rhs evals during startup phase>], <rhs side evals per step after startup phase>)
+    expected = {
+        'AdamsMoultonImplicit1Step': ([2], 1),
+        'AdamsMoultonImplicit2Step': ([2], 1),
+        'BackwardEuler': ([2], 1),
+        'AdamsBashforthExplicit1Step': ([2], 1),
+    }
+
+    lambdas = [[-1.0e-1 + 0j]]
+
+    stats, _ = single_run(sweeper_name, 1.0, 10.0, lambdas)
+
+    rhs_evals = [me[1] for me in get_sorted(stats, type='work_rhs')]
+
+    startup_phase_expected = expected[sweeper_name][0]
+    len_startup = len(startup_phase_expected)
+    assert all(
+        rhs_evals[i] == startup_phase_expected[i] for i in range(len_startup)
+    ), f'Unexpected number of rhs evaluations during startup phase for {sweeper_name} method!'
+
+    assert all(
+        rhs_evals[i] == expected[sweeper_name][1] for i in range(len_startup, len(rhs_evals))
+    ), f'Unexpected number of rhs evaluations after startup phase for {sweeper_name} method!'
+
+
+if __name__ == '__main__':
+    test_rhs_evals('AdamsMoultonImplicit2Step')


### PR DESCRIPTION
As discussed in #327, you can abuse the sweeper class to do multistep methods.
I ended up doing this differently from what I initially thought and I don't know if this can be extended to arbitrary multistep methods.
In particular, at the moment it is required to use a fixed step size and restarts will probably also mess everything up.

I thought I start with a simple implementation of the most basic things and anybody is welcome to improve on this.
@lisawim, maybe we can discuss how we get the methods you want into this notation? I don't know exactly what you did with multistep methods so far.

I implemented methods with at most 2 steps, so not overly exciting, but for this I didn't have any issues with generating starting values, as they can be one order below the scheme.

I test the order of accuracy in time, the stability and the number of right hand side evaluations.