### PR TITLE
Default paramaters for most problem classes + docu for Boussinesq

### DIFF
--- a/pySDC/implementations/problem_classes/AcousticAdvection_1D_FD_imex.py
+++ b/pySDC/implementations/problem_classes/AcousticAdvection_1D_FD_imex.py
@@ -34,8 +34,11 @@ class acoustic_1d_imex(ptype):
     dtype_u = mesh
     dtype_f = imex_mesh
 
-    def __init__(self, nvars, cs, cadv, order_adv, waveno):
+    def __init__(self, nvars=None, cs=0.5, cadv=0.1, order_adv=5, waveno=5):
         """Initialization routine"""
+
+        if nvars is None:
+            nvars = [(2, 300)]
 
         # invoke super init, passing number of dofs
         super().__init__((nvars, None, np.dtype('float64')))

--- a/pySDC/implementations/problem_classes/AllenCahn_1D_FD.py
+++ b/pySDC/implementations/problem_classes/AllenCahn_1D_FD.py
@@ -41,7 +41,16 @@ class allencahn_front_fullyimplicit(ptype):
     dtype_u = mesh
     dtype_f = mesh
 
-    def __init__(self, nvars, dw, eps, newton_maxiter, newton_tol, interval, stop_at_nan=True):
+    def __init__(
+        self,
+        nvars=127,
+        dw=-0.04,
+        eps=0.04,
+        newton_maxiter=100,
+        newton_tol=1e-12,
+        interval=(-0.5, 0.5),
+        stop_at_nan=True,
+    ):
         # we assert that nvars looks very particular here.. this will be necessary for coarsening in space later on
         if (nvars + 1) % 2 != 0:
             raise ProblemError('setup requires nvars = 2^p - 1')
@@ -444,7 +453,17 @@ class allencahn_periodic_fullyimplicit(ptype):
     dtype_u = mesh
     dtype_f = mesh
 
-    def __init__(self, nvars, dw, eps, newton_maxiter, newton_tol, interval, radius, stop_at_nan=True):
+    def __init__(
+        self,
+        nvars=128,
+        dw=-0.04,
+        eps=0.04,
+        newton_maxiter=100,
+        newton_tol=1e-12,
+        interval=(-0.5, 0.5),
+        radius=0.25,
+        stop_at_nan=True,
+    ):
         # we assert that nvars looks very particular here.. this will be necessary for coarsening in space later on
         if (nvars) % 2 != 0:
             raise ProblemError('setup requires nvars = 2^p')
@@ -627,7 +646,17 @@ class allencahn_periodic_semiimplicit(allencahn_periodic_fullyimplicit):
 
     dtype_f = imex_mesh
 
-    def __init__(self, nvars, dw, eps, newton_maxiter, newton_tol, interval, radius, stop_at_nan=True):
+    def __init__(
+        self,
+        nvars=128,
+        dw=-0.04,
+        eps=0.04,
+        newton_maxiter=100,
+        newton_tol=1e-12,
+        interval=(-0.5, 0.5),
+        radius=0.25,
+        stop_at_nan=True,
+    ):
         super().__init__(nvars, dw, eps, newton_maxiter, newton_tol, interval, radius, stop_at_nan)
         self.A -= sp.eye(self.init) * 0.0 / self.eps**2
 
@@ -707,7 +736,17 @@ class allencahn_periodic_multiimplicit(allencahn_periodic_fullyimplicit):
 
     dtype_f = comp2_mesh
 
-    def __init__(self, nvars, dw, eps, newton_maxiter, newton_tol, interval, radius, stop_at_nan=True):
+    def __init__(
+        self,
+        nvars=128,
+        dw=-0.04,
+        eps=0.04,
+        newton_maxiter=100,
+        newton_tol=1e-12,
+        interval=(-0.5, 0.5),
+        radius=0.25,
+        stop_at_nan=True,
+    ):
         super().__init__(nvars, dw, eps, newton_maxiter, newton_tol, interval, radius, stop_at_nan)
         self.A -= sp.eye(self.init) * 0.0 / self.eps**2
 

--- a/pySDC/implementations/problem_classes/AllenCahn_2D_FD.py
+++ b/pySDC/implementations/problem_classes/AllenCahn_2D_FD.py
@@ -50,7 +50,18 @@ class allencahn_fullyimplicit(ptype):
     dtype_u = mesh
     dtype_f = mesh
 
-    def __init__(self, nvars, nu, eps, newton_maxiter, newton_tol, lin_tol, lin_maxiter, radius, order=2):
+    def __init__(
+        self,
+        nvars=(128, 128),
+        nu=2,
+        eps=0.04,
+        newton_maxiter=200,
+        newton_tol=1e-12,
+        lin_tol=1e-8,
+        lin_maxiter=100,
+        radius=0.25,
+        order=2,
+    ):
         """
         Initialization routine
         """

--- a/pySDC/implementations/problem_classes/AllenCahn_2D_FD_gpu.py
+++ b/pySDC/implementations/problem_classes/AllenCahn_2D_FD_gpu.py
@@ -44,7 +44,17 @@ class allencahn_fullyimplicit(ptype):  # pragma: no cover
     dtype_u = cupy_mesh
     dtype_f = cupy_mesh
 
-    def __init__(self, nvars, nu, eps, newton_maxiter, newton_tol, lin_tol, lin_maxiter, radius):
+    def __init__(
+        self,
+        nvars=(128, 128),
+        nu=2,
+        eps=0.04,
+        newton_maxiter=1e-12,
+        newton_tol=100,
+        lin_tol=1e-8,
+        lin_maxiter=100,
+        radius=0.25,
+    ):
         """
         Initialization routine
 

--- a/pySDC/implementations/problem_classes/AllenCahn_2D_FFT.py
+++ b/pySDC/implementations/problem_classes/AllenCahn_2D_FFT.py
@@ -42,19 +42,11 @@ class allencahn2d_imex(ptype):
     dtype_u = mesh
     dtype_f = imex_mesh
 
-    def __init__(self, nvars, nu, eps, radius, L=1.0, init_type='circle'):
-        """
-        Initialization routine
+    def __init__(self, nvars=None, nu=2, eps=0.04, radius=0.25, L=1.0, init_type='circle'):
+        """Initialization routine"""
 
-        Parameters
-        ----------
-        problem_params : dict
-            Custom parameters for the example
-        dtype_u :
-            mesh data type (will be passed to parent class)
-        dtype_f :
-            mesh data type with implicit and explicit parts (will be passed to parent class)
-        """
+        if nvars is None:
+            nvars = [(256, 256), (64, 64)]
 
         # we assert that nvars looks very particular here.. this will be necessary for coarsening in space later on
         if len(nvars) != 2:
@@ -215,7 +207,12 @@ class allencahn2d_imex_stab(allencahn2d_imex):
         Planned IFFT for backward transformation.
     """
 
-    def __init__(self, nvars, nu, eps, radius, L=1.0, init_type='circle'):
+    def __init__(self, nvars=None, nu=2, eps=0.04, radius=0.25, L=1.0, init_type='circle'):
+        """Initialization routine"""
+
+        if nvars is None:
+            nvars = [(256, 256), (64, 64)]
+
         super().__init__(nvars, nu, eps, radius, L, init_type)
         self.lap -= 2.0 / self.eps**2
 

--- a/pySDC/implementations/problem_classes/AllenCahn_2D_FFT_gpu.py
+++ b/pySDC/implementations/problem_classes/AllenCahn_2D_FFT_gpu.py
@@ -42,8 +42,11 @@ class allencahn2d_imex(ptype):  # pragma: no cover
     dtype_u = cupy_mesh
     dtype_f = imex_cupy_mesh
 
-    def __init__(self, nvars, nu, eps, radius, L=1.0, init_type='circle'):
+    def __init__(self, nvars=None, nu=2, eps=0.04, radius=0.25, L=1.0, init_type='circle'):
         """Initialization routine"""
+
+        if nvars is None:
+            nvars = [(256, 256), (64, 64)]
 
         # we assert that nvars looks very particular here.. this will be necessary for coarsening in space later on
         if len(nvars) != 2:
@@ -191,7 +194,12 @@ class allencahn2d_imex_stab(allencahn2d_imex):
         Planned IFFT for backward transformation.
     """
 
-    def __init__(self, nvars, nu, eps, radius, L=1.0, init_type='circle'):
+    def __init__(self, nvars=None, nu=2, eps=0.04, radius=0.25, L=1.0, init_type='circle'):
+        """Initialization routine"""
+
+        if nvars is None:
+            nvars = [(256, 256), (64, 64)]
+
         super().__init__(nvars, nu, eps, radius, L, init_type)
         self.lap -= 2.0 / self.eps**2
 

--- a/pySDC/implementations/problem_classes/AllenCahn_MPIFFT.py
+++ b/pySDC/implementations/problem_classes/AllenCahn_MPIFFT.py
@@ -51,15 +51,22 @@ class allencahn_imex(ptype):
     dtype_u = mesh
     dtype_f = imex_mesh
 
-    def __init__(self, nvars, eps, radius, spectral, dw=0.0, L=1.0, init_type='circle', comm=None):
-        """
-        Initialization routine
+    def __init__(
+        self,
+        nvars=None,
+        eps=0.04,
+        radius=0.25,
+        spectral=None,
+        dw=0.0,
+        L=1.0,
+        init_type='circle',
+        comm=None,
+    ):
+        """Initialization routine"""
 
-        Args:
-            problem_params (dict): custom parameters for the example
-            dtype_u: fft data type (will be passed to parent class)
-            dtype_f: fft data type wuth implicit and explicit parts (will be passed to parent class)
-        """
+        if nvars is None:
+            nvars = [(128, 128), (32, 32)]
+
         if not (isinstance(nvars, tuple) and len(nvars) > 1):
             raise ProblemError('Need at least two dimensions')
 

--- a/pySDC/implementations/problem_classes/AllenCahn_Temp_MPIFFT.py
+++ b/pySDC/implementations/problem_classes/AllenCahn_Temp_MPIFFT.py
@@ -54,7 +54,19 @@ class allencahn_temp_imex(ptype):
     dtype_u = mesh
     dtype_f = imex_mesh
 
-    def __init__(self, nvars, eps, radius, spectral, TM, D, dw=0.0, L=1.0, init_type='circle', comm=None):
+    def __init__(
+        self,
+        nvars=None,
+        eps=0.04,
+        radius=0.25,
+        spectral=None,
+        TM=1.0,
+        D=10.0,
+        dw=0.0,
+        L=1.0,
+        init_type='circle',
+        comm=None,
+    ):
         """
         Initialization routine
 
@@ -67,6 +79,10 @@ class allencahn_temp_imex(ptype):
         dtype_f :
             fft data type wuth implicit and explicit parts (will be passed to parent class).
         """
+
+        if nvars is None:
+            nvars = [(128, 128)]
+
         if not (isinstance(nvars, tuple) and len(nvars) > 1):
             raise ProblemError('Need at least two dimensions')
 

--- a/pySDC/implementations/problem_classes/FermiPastaUlamTsingou.py
+++ b/pySDC/implementations/problem_classes/FermiPastaUlamTsingou.py
@@ -16,8 +16,12 @@ class fermi_pasta_ulam_tsingou(ptype):
     dtype_u = particles
     dtype_f = acceleration
 
-    def __init__(self, npart, alpha, k, energy_modes):
+    def __init__(self, npart=2048, alpha=0.25, k=1.0, energy_modes=None):
         """Initialization routine"""
+
+        if energy_modes is None:
+            energy_modes = [1, 2, 3, 4]
+
         # invoke super init, passing nparts
         super().__init__((npart, None, np.dtype('float64')))
         self._makeAttributeAndRegister('npart', 'alpha', 'k', 'energy_modes', localVars=locals(), readOnly=True)

--- a/pySDC/implementations/problem_classes/GeneralizedFisher_1D_FD_implicit.py
+++ b/pySDC/implementations/problem_classes/GeneralizedFisher_1D_FD_implicit.py
@@ -21,7 +21,9 @@ class generalized_fisher(ptype):
     dtype_u = mesh
     dtype_f = mesh
 
-    def __init__(self, nvars, nu, lambda0, newton_maxiter, newton_tol, interval, stop_at_nan=True):
+    def __init__(
+        self, nvars=127, nu=1.0, lambda0=2.0, newton_maxiter=100, newton_tol=1e-12, interval=(-5, 5), stop_at_nan=True
+    ):
         """Initialization routine"""
 
         # we assert that nvars looks very particular here.. this will be necessary for coarsening in space later on

--- a/pySDC/implementations/problem_classes/GrayScott_MPIFFT.py
+++ b/pySDC/implementations/problem_classes/GrayScott_MPIFFT.py
@@ -28,7 +28,7 @@ class grayscott_imex_diffusion(ptype):
     dtype_u = mesh
     dtype_f = imex_mesh
 
-    def __init__(self, nvars, Du, Dv, A, B, spectral, L=2.0, comm=MPI.COMM_WORLD):
+    def __init__(self, nvars=127, Du=1.0, Dv=0.01, A=0.09, B=0.086, spectral=None, L=2.0, comm=MPI.COMM_WORLD):
         if not (isinstance(nvars, tuple) and len(nvars) > 1):
             raise ProblemError('Need at least two dimensions')
 
@@ -204,7 +204,7 @@ class grayscott_imex_diffusion(ptype):
 
 
 class grayscott_imex_linear(grayscott_imex_diffusion):
-    def __init__(self, nvars, Du, Dv, A, B, spectral, L=2.0, comm=MPI.COMM_WORLD):
+    def __init__(self, nvars=127, Du=1.0, Dv=0.01, A=0.09, B=0.086, spectral=None, L=2.0, comm=MPI.COMM_WORLD):
         super().__init__(nvars, Du, Dv, A, B, spectral, L, comm)
         self.Ku -= self.A
         self.Kv -= self.B
@@ -256,7 +256,19 @@ class grayscott_imex_linear(grayscott_imex_diffusion):
 class grayscott_mi_diffusion(grayscott_imex_diffusion):
     dtype_f = comp2_mesh
 
-    def __init__(self, nvars, Du, Dv, A, B, spectral, newton_maxiter, newton_tol, L=2.0, comm=MPI.COMM_WORLD):
+    def __init__(
+        self,
+        nvars=127,
+        Du=1.0,
+        Dv=0.01,
+        A=0.09,
+        B=0.086,
+        spectral=None,
+        newton_maxiter=100,
+        newton_tol=1e-12,
+        L=2.0,
+        comm=MPI.COMM_WORLD,
+    ):
         super().__init__(nvars, Du, Dv, A, B, spectral, L, comm)
         # This may not run in parallel yet..
         assert self.comm.Get_size() == 1
@@ -430,7 +442,19 @@ class grayscott_mi_diffusion(grayscott_imex_diffusion):
 class grayscott_mi_linear(grayscott_imex_linear):
     dtype_f = comp2_mesh
 
-    def __init__(self, nvars, Du, Dv, A, B, spectral, newton_maxiter, newton_tol, L=2.0, comm=MPI.COMM_WORLD):
+    def __init__(
+        self,
+        nvars=127,
+        Du=1.0,
+        Dv=0.01,
+        A=0.09,
+        B=0.086,
+        spectral=None,
+        newton_maxiter=100,
+        newton_tol=1e-12,
+        L=2.0,
+        comm=MPI.COMM_WORLD,
+    ):
         super().__init__(nvars, Du, Dv, A, B, spectral, L, comm)
         # This may not run in parallel yet..
         assert self.comm.Get_size() == 1

--- a/pySDC/implementations/problem_classes/HarmonicOscillator.py
+++ b/pySDC/implementations/problem_classes/HarmonicOscillator.py
@@ -14,7 +14,7 @@ class harmonic_oscillator(ptype):
     dtype_u = particles
     dtype_f = acceleration
 
-    def __init__(self, k, mu=0.0, u0=(1, 0), phase=1.0, amp=0.0):
+    def __init__(self, k=0, mu=0.0, u0=(1, 0), phase=1.0, amp=0.0):
         """Initialization routine"""
         # invoke super init, passing nparts, dtype_u and dtype_f
         u0 = np.asarray(u0)

--- a/pySDC/implementations/problem_classes/HeatEquation_1D_FEniCS_matrix_forced.py
+++ b/pySDC/implementations/problem_classes/HeatEquation_1D_FEniCS_matrix_forced.py
@@ -23,7 +23,7 @@ class fenics_heat(ptype):
     dtype_u = fenics_mesh
     dtype_f = rhs_fenics_mesh
 
-    def __init__(self, c_nvars, t0, family, order, refinements, nu):
+    def __init__(self, c_nvars=128, t0=0.0, family='CG', order=4, refinements=1, nu=0.1):
         """
         Initialization routine
 

--- a/pySDC/implementations/problem_classes/HeatEquation_1D_FEniCS_weak_forced.py
+++ b/pySDC/implementations/problem_classes/HeatEquation_1D_FEniCS_weak_forced.py
@@ -24,7 +24,7 @@ class fenics_heat_weak_fullyimplicit(ptype):
     dtype_u = fenics_mesh
     dtype_f = fenics_mesh
 
-    def __init__(self, c_nvars, t0, family, order, refinements, nu):
+    def __init__(self, c_nvars=128, t0=0.0, family='CG', order=4, refinements=1, nu=0.1):
         """
         Initialization routine
 
@@ -227,7 +227,7 @@ class fenics_heat_weak_imex(ptype):
     dtype_u = fenics_mesh
     dtype_f = rhs_fenics_mesh
 
-    def __init__(self, c_nvars, t0, family, order, refinements, nu):
+    def __init__(self, c_nvars=128, t0=0.0, family='CG', order=4, refinements=1, nu=0.1):
         """
         Initialization routine
 

--- a/pySDC/implementations/problem_classes/HeatEquation_ND_FD_CuPy.py
+++ b/pySDC/implementations/problem_classes/HeatEquation_ND_FD_CuPy.py
@@ -23,7 +23,16 @@ class heatNd_forced(ptype):  # pragma: no cover
     dtype_f = imex_cupy_mesh
 
     def __init__(
-        self, nvars, nu, freq, bc, order=2, stencil_type='center', lintol=1e-12, liniter=10000, solver_type='direct'
+        self,
+        nvars=512,
+        nu=0.1,
+        freq=2,
+        bc='periodic',
+        order=2,
+        stencil_type='center',
+        lintol=1e-12,
+        liniter=10000,
+        solver_type='direct',
     ):
         """Initialization routine"""
 

--- a/pySDC/implementations/problem_classes/NonlinearSchroedinger_MPIFFT.py
+++ b/pySDC/implementations/problem_classes/NonlinearSchroedinger_MPIFFT.py
@@ -25,15 +25,12 @@ class nonlinearschroedinger_imex(ptype):
     dtype_u = mesh
     dtype_f = imex_mesh
 
-    def __init__(self, nvars, spectral, L=2 * np.pi, c=1.0, comm=MPI.COMM_WORLD):
-        """
-        Initialization routine
+    def __init__(self, nvars=None, spectral=None, L=2 * np.pi, c=1.0, comm=MPI.COMM_WORLD):
+        """Initialization routine"""
 
-        Args:
-            problem_params (dict): custom parameters for the example
-            dtype_u: fft data type (will be passed to parent class)
-            dtype_f: fft data type wuth implicit and explicit parts (will be passed to parent class)
-        """
+        if nvars is None:
+            nvars = [(128, 128)]
+
         if not L == 2.0 * np.pi:
             raise ProblemError(f'Setup not implemented, L has to be 2pi, got {L}')
 

--- a/pySDC/implementations/problem_classes/TestEquation_0D.py
+++ b/pySDC/implementations/problem_classes/TestEquation_0D.py
@@ -20,7 +20,7 @@ class testequation0d(ptype):
     dtype_f = mesh
 
     # TODO : add default values
-    def __init__(self, lambdas, u0):
+    def __init__(self, lambdas=1, u0=0.0):
         """
         Initialization routine
 

--- a/pySDC/implementations/problem_classes/Van_der_Pol_implicit.py
+++ b/pySDC/implementations/problem_classes/Van_der_Pol_implicit.py
@@ -16,11 +16,13 @@ class vanderpol(ptype):
     dtype_u = mesh
     dtype_f = mesh
 
-    def __init__(self, u0, mu, newton_maxiter, newton_tol, stop_at_nan=True, crash_at_maxiter=True):
-        """
-        Initialization routine
-        """
+    def __init__(self, u0=None, mu=5.0, newton_maxiter=100, newton_tol=1e-9, stop_at_nan=True, crash_at_maxiter=True):
+        """Initialization routine"""
         nvars = 2
+
+        if u0 is None:
+            u0 = [2.0, 0.0]
+
         super().__init__((nvars, None, np.dtype('float64')))
         self._makeAttributeAndRegister('nvars', 'u0', localVars=locals(), readOnly=True)
         self._makeAttributeAndRegister(


### PR DESCRIPTION
For most of the problem classes I added default parameters (except for the classes using PETSc and `penningtrap`) (#206). Since flakebaerchen (sound similar to @brownbaerchen :D) has compliants like

```
Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them. [flake8-bugbear]
``` 

when I add something like

```
def __init__(self, nvars=[(256, 256)])
```

Hence, I set such parameters to None and set it inside the `__init__` function. 

I also found the Boussinesq equations in your fast-wave slow-wave publication, so I added docu for that problem. One problem less to document.

Let's see what pytest says..