### PR TITLE
TL: added MIN-SR implicit sweepers

### DIFF
--- a/pySDC/tests/test_sweeper.py
+++ b/pySDC/tests/test_sweeper.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pytest
+
+from pySDC.core.Sweeper import sweeper as Sweeper
+
+node_types = ['EQUID', 'LEGENDRE'] + [f'CHEBY-{i}' for i in [1, 2, 3, 4]]
+quad_types = ['GAUSS', 'LOBATTO', 'RADAU-RIGHT', 'RADAU-LEFT']
+
+
+@pytest.mark.base
+@pytest.mark.parametrize("node_type", node_types)
+@pytest.mark.parametrize("quad_type", quad_types)
+def test_MIN_SR(node_type, quad_type):
+    for M in [2, 3, 4, 5]:
+        params = {'num_nodes': M, 'quad_type': quad_type, 'node_type': node_type}
+
+        sweeper = Sweeper(params)
+        Q = sweeper.coll.Qmat[1:, 1:]
+
+        # Check non-stiff limit
+        QDelta = sweeper.get_Qdelta_implicit(sweeper.coll, 'MIN-SR-NS')[1:, 1:]
+        assert np.all(np.diag(np.diag(QDelta)) == QDelta), "no diagonal QDelta"
+        K = Q - QDelta
+        Km = np.linalg.matrix_power(K, M)
+        nilpotency = np.linalg.norm(Km, ord=np.inf)
+        assert nilpotency < 1e-10, "Q-QDelta not nilpotent " f"(M={M}, norm={nilpotency})"
+
+        # Check stiff limit
+        QDelta = sweeper.get_Qdelta_implicit(sweeper.coll, 'MIN-SR-S')[1:, 1:]
+        assert np.all(np.diag(np.diag(QDelta)) == QDelta), "no diagonal QDelta"
+
+        if params['quad_type'] in ['LOBATTO', 'RADAU-LEFT']:
+            QDelta = np.diag(1 / np.diag(QDelta[1:, 1:]))
+            Q = Q[1:, 1:]
+        else:
+            QDelta = np.diag(1 / np.diag(QDelta))
+
+        K = np.eye(Q.shape[0]) - QDelta @ Q
+        Km = np.linalg.matrix_power(K, M)
+        nilpotency = np.linalg.norm(Km, ord=np.inf)
+        assert nilpotency < 1e-10, "I-QDelta^{-1}Q not nilpotent " f"(M={M}, norm={nilpotency})"
+
+
+if __name__ == '__main__':
+    test_MIN_SR('LEGENDRE', 'RADAU-RIGHT')
+    test_MIN_SR('EQUID', 'LOBATTO')


### PR DESCRIPTION
Following some ongoing work with @caklovicka, I've added the new diagonal SDC preconditionners :

- MIN-SR-NS : diagonal $Q_{\Delta}$ minimizing the spectral radius of the non-stiff limit of the SDC iteration matrix, i.e $Q-Q_{\Delta}$
- MIN-SR-S : diagonal $Q_{\Delta}$ minimizing the spectral radius of the stiff limit of the SDC iteration matrix, i.e $I-Q_{\Delta}^{-1}Q$

Actually, the `MIN-SR-NS` was already implemented under the name `MIN_GT`, so `MIN-SR-NS` an alias.
I've added automated tests that verify that the spectral radius is numerically zero by checking if the $Q-Q_{\Delta}$ and $I-Q_{\Delta}^{-1}Q$ are nilpotent to the power $M$.

The whole theory behind it is in progress (but you can already check that in the https://github.com/tlunet/why repo). For now, the non-stiff limit is obtained "exactly", while the stiff limit is obtained using a mix between an analytic and a numerical approach. The later still need some improvements to go over $M=5$, but in the meantime those preconditionners can be tested for different problems and arbitrary nodes, if some others want to play a bit with it ... @pancetta @brownbaerchen @lisawim 