### PR TITLE
Added warnings when trying to compute local error with analytic exact solution

### DIFF
--- a/pySDC/implementations/problem_classes/AdvectionEquation_ND_FD.py
+++ b/pySDC/implementations/problem_classes/AdvectionEquation_ND_FD.py
@@ -97,6 +97,11 @@ class advectionNd(GenericNDimFinDiff):
         sol : dtype_u
             The exact solution.
         """
+        if 'u_init' in kwargs.keys() or 't_init' in kwargs.keys():
+            self.logger.warn(
+                f'{type(self).__name__} uses an analytic exact solution from t=0. If you try to compute the local error, you will get the global error instead!'
+            )
+
         # Initialize pointers and variables
         ndim, freq, c, sigma, sol = self.ndim, self.freq, self.c, self.sigma, self.u_init
 

--- a/pySDC/implementations/problem_classes/HeatEquation_ND_FD.py
+++ b/pySDC/implementations/problem_classes/HeatEquation_ND_FD.py
@@ -38,6 +38,11 @@ class heatNd_unforced(GenericNDimFinDiff):
         sol : dtype_u
             The exact solution.
         """
+        if 'u_init' in kwargs.keys() or 't_init' in kwargs.keys():
+            self.logger.warn(
+                f'{type(self).__name__} uses an analytic exact solution from t=0. If you try to compute the local error, you will get the global error instead!'
+            )
+
         ndim, freq, nu, sigma, dx, sol = self.ndim, self.freq, self.nu, self.sigma, self.dx, self.u_init
 
         if ndim == 1:

--- a/pySDC/implementations/problem_classes/NonlinearSchroedinger_MPIFFT.py
+++ b/pySDC/implementations/problem_classes/NonlinearSchroedinger_MPIFFT.py
@@ -164,6 +164,10 @@ class nonlinearschroedinger_imex(ptype):
         u : dtype_u
             The exact solution.
         """
+        if 'u_init' in kwargs.keys() or 't_init' in kwargs.keys():
+            self.logger.warn(
+                f'{type(self).__name__} uses an analytic exact solution from t=0. If you try to compute the local error, you will get the global error instead!'
+            )
 
         def nls_exact_1D(t, x, c):
             ae = 1.0 / np.sqrt(2.0) * np.exp(1j * t)


### PR DESCRIPTION
There is a hook in the implementations that records the local error by generating exact solutions starting from the initial conditions and initial time of the step. However, many problems have an interface that is compatible with the hook, but always compute the exact solution from $t=0$, for instance when an analytic exact solution is available.

I added some warnings when this happens. It's not perfect, but it's better than nothing. If I forgot any problems, feel free to add the warnings yourself or tell me about it and I can do it.