### PR TITLE
Fully implicit nonlinear Schrödinger

### DIFF
--- a/pySDC/core/Problem.py
+++ b/pySDC/core/Problem.py
@@ -32,6 +32,9 @@ class WorkCounter(object):
         # *args and **kwargs are necessary for gmres
         self.niter += 1
 
+    def decrement(self):
+        self.niter -= 1
+
 
 class ptype(RegisterParams):
     """

--- a/pySDC/core/Sweeper.py
+++ b/pySDC/core/Sweeper.py
@@ -296,7 +296,13 @@ class sweeper(object):
             self.parallelizable = True
 
         else:
-            raise NotImplementedError(f'qd_type implicit "{qd_type}" not implemented')
+            # see if an explicit preconditioner with this name is available
+            try:
+                QDmat = self.get_Qdelta_explicit(coll, qd_type)
+                self.logger.warn(f'Using explicit preconditioner \"{qd_type}\" on the left hand side!')
+            except NotImplementedError:
+                raise NotImplementedError(f'qd_type implicit "{qd_type}" not implemented')
+
         # check if we got not more than a lower triangular matrix
         np.testing.assert_array_equal(
             np.triu(QDmat, k=1), np.zeros(QDmat.shape), err_msg='Lower triangular matrix expected!'
@@ -358,7 +364,7 @@ class sweeper(object):
         L.status.unlocked = True
         L.status.updated = True
 
-    def compute_residual(self, stage=None):
+    def compute_residual(self, stage=''):
         """
         Computation of the residual using the collocation matrix Q
 

--- a/pySDC/implementations/problem_classes/NonlinearSchroedinger_MPIFFT.py
+++ b/pySDC/implementations/problem_classes/NonlinearSchroedinger_MPIFFT.py
@@ -1,4 +1,7 @@
 import numpy as np
+from scipy.optimize import newton_krylov, root
+from scipy.optimize.nonlin import NoConvergence
+import scipy.sparse as sp
 from mpi4py import MPI
 from mpi4py_fft import PFFT
 
@@ -29,7 +32,7 @@ class nonlinearschroedinger_imex(ptype):
         """Initialization routine"""
 
         if nvars is None:
-            nvars = [(128, 128)]
+            nvars = (128, 128)
 
         if not L == 2.0 * np.pi:
             raise ProblemError(f'Setup not implemented, L has to be 2pi, got {L}')
@@ -183,4 +186,106 @@ class nonlinearschroedinger_imex(ptype):
         else:
             me[:] = nls_exact_1D(self.ndim * t, sum(self.X), self.c)
 
+        return me
+
+
+class nonlinearschroedinger_fully_implicit(nonlinearschroedinger_imex):
+    dtype_u = mesh
+    dtype_f = mesh
+
+    def __init__(self, lintol=1e-9, liniter=99, **kwargs):
+        super().__init__(**kwargs)
+        self._makeAttributeAndRegister('liniter', 'lintol', localVars=locals(), readOnly=False)
+
+        self.work_counters['newton'] = WorkCounter()
+
+    def eval_f(self, u, t):
+        """
+        Routine to evaluate the right-hand side of the problem.
+
+        Parameters
+        ----------
+        u : dtype_u
+            Current values of the numerical solution.
+        t : float
+            Current time at which the numerical solution is computed.
+
+        Returns
+        -------
+        f : dtype_f
+            The right-hand side of the problem.
+        """
+
+        f = self.dtype_f(self.init)
+
+        if self.spectral:
+            tmp = self.fft.backward(u)
+            tmpf = self.ndim * self.c * 2j * np.absolute(tmp) ** 2 * tmp
+            f[:] = -self.K2 * 1j * u + self.fft.forward(tmpf)
+
+        else:
+            u_hat = self.fft.forward(u)
+            lap_u_hat = -self.K2 * 1j * u_hat
+            f[:] = self.fft.backward(lap_u_hat) + self.ndim * self.c * 2j * np.absolute(u) ** 2 * u
+
+        self.work_counters['rhs']()
+        return f
+
+    def solve_system(self, rhs, factor, u0, t):
+        """
+        Solve the nonlinear system `(1 - factor * f)(u) = rhs` using a scipy Newton-Krylov solver.
+        See this page for details on the solver: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.newton_krylov.html
+
+        Parameters
+        ----------
+        rhs : dtype_f
+            Right-hand side for the linear system.
+        factor : float
+            Abbrev. for the node-to-node stepsize (or any other factor required).
+        u0 : dtype_u
+            Initial guess for the iterative solver (not used here so far).
+        t : float
+            Current time (e.g. for time-dependent BCs).
+
+        Returns
+        -------
+        me : dtype_u
+            The solution as mesh.
+        """
+        me = self.dtype_u(self.init)
+
+        # assemble the nonlinear function F for the solver
+        def F(x):
+            """
+            Nonlinear function for the scipy solver.
+
+            Args:
+                x : dtype_u
+                    Current solution
+            """
+            self.work_counters['rhs'].decrement()
+            return x - factor * self.eval_f(u=x.reshape(self.init[0]), t=t).reshape(x.shape) - rhs.reshape(x.shape)
+
+        # breakpoint()
+        try:
+            sol = newton_krylov(
+                F=F,
+                xin=u0.copy(),
+                maxiter=self.liniter,
+                x_tol=self.lintol,
+                callback=self.work_counters['newton'],
+                method='gmres',
+            )
+            # sol_ = root(
+            #    fun=F,
+            #    x0=u0.copy(),
+            #    #maxiter=self.liniter,
+            #    tol=self.lintol,
+            #    method='df-sane',
+            # )
+            # sol = sol_.x.reshape(self.init[0])
+        except NoConvergence as e:
+            sol = e.args[0]
+
+        me[:] = sol
         return me

--- a/pySDC/implementations/problem_classes/NonlinearSchroedinger_MPIFFT.py
+++ b/pySDC/implementations/problem_classes/NonlinearSchroedinger_MPIFFT.py
@@ -266,7 +266,6 @@ class nonlinearschroedinger_fully_implicit(nonlinearschroedinger_imex):
             self.work_counters['rhs'].decrement()
             return x - factor * self.eval_f(u=x.reshape(self.init[0]), t=t).reshape(x.shape) - rhs.reshape(x.shape)
 
-        # breakpoint()
         try:
             sol = newton_krylov(
                 F=F,
@@ -276,14 +275,6 @@ class nonlinearschroedinger_fully_implicit(nonlinearschroedinger_imex):
                 callback=self.work_counters['newton'],
                 method='gmres',
             )
-            # sol_ = root(
-            #    fun=F,
-            #    x0=u0.copy(),
-            #    #maxiter=self.liniter,
-            #    tol=self.lintol,
-            #    method='df-sane',
-            # )
-            # sol = sol_.x.reshape(self.init[0])
         except NoConvergence as e:
             sol = e.args[0]
 

--- a/pySDC/implementations/problem_classes/Quench.py
+++ b/pySDC/implementations/problem_classes/Quench.py
@@ -249,9 +249,7 @@ class Quench(ptype):
             G = u - factor * self.eval_f(u, t) - rhs
             self.work_counters[
                 'rhs'
-            ].niter -= (
-                1  # Work regarding construction of the Jacobian etc. should count into the Newton iterations only
-            )
+            ].decrement()  # Work regarding construction of the Jacobian etc. should count into the Newton iterations only
 
             res = np.linalg.norm(G, np.inf)
             if res <= self.newton_tol and n > 0:  # we want to make at least one Newton iteration

--- a/pySDC/projects/Resilience/Schroedinger.py
+++ b/pySDC/projects/Resilience/Schroedinger.py
@@ -183,8 +183,9 @@ def run_Schroedinger(
         nvars = [me / 2 for me in problem_params['nvars']]
         nvars[0] += 1
 
-        rnd_args = {'problem_pos': nvars}
-        prepare_controller_for_faults(controller, fault_stuff, rnd_args)
+        rnd_args = {'iteration': 5, 'problem_pos': nvars, 'min_node': 1}
+        args = {'time': 0.3, 'target': 0}
+        prepare_controller_for_faults(controller, fault_stuff, rnd_args, args)
 
     # call main function to get things done...
     uend, stats = controller.run(u0=uinit, t0=t0, Tend=Tend)

--- a/pySDC/tests/test_problems/test_NonlinearSchroedinger_MPIFFT.py
+++ b/pySDC/tests/test_problems/test_NonlinearSchroedinger_MPIFFT.py
@@ -1,0 +1,57 @@
+import pytest
+
+
+@pytest.mark.mpi4py
+@pytest.mark.parametrize('spectral', [True, False])
+def test_imex_vs_fully_implicit(spectral):
+    import numpy as np
+    from pySDC.implementations.problem_classes.NonlinearSchroedinger_MPIFFT import (
+        nonlinearschroedinger_fully_implicit,
+        nonlinearschroedinger_imex,
+    )
+
+    params = {
+        'spectral': spectral,
+        'nvars': (32, 32),
+    }
+    t = 0
+
+    imex = nonlinearschroedinger_imex(**params)
+    full = nonlinearschroedinger_fully_implicit(**params)
+
+    u0 = imex.u_exact(t=t)
+
+    # check right hand side evaluation
+    temp = imex.eval_f(u0, t=t)
+    f_imex = temp.expl + temp.impl
+    f_full = full.eval_f(u0, t=t)
+    assert np.allclose(
+        f_imex, f_full
+    ), 'Right hand side evaluations do not match between fully implicit and IMEX implementations of nonlinear Schroedinger!'
+
+    # check solver with one step of implicit Euler
+    dt = 1e-3
+    args = {
+        'rhs': u0.copy(),
+        'factor': dt,
+        'u0': u0.copy(),
+        't': t,
+    }
+    u_imex = imex.solve_system(**args)
+    u_full = full.solve_system(**args)
+    u_exact = imex.u_exact(t + dt)
+
+    e_imex = abs(u_imex - u_exact) / abs(u_exact)
+    e_full = abs(u_full - u_exact) / abs(u_exact)
+
+    assert e_imex < 7e-2, 'Error unexpectedly large in IMEX nonlinear Schroedinger problem'
+    assert e_full < 2e-5, 'Error unexpectedly large in fully implicit Schroedinger problem'
+
+    # check number of right hand side evaluations
+    assert (
+        imex.work_counters['rhs'].niter == full.work_counters['rhs'].niter
+    ), 'Did not log the same number of right hand side evaluations'
+
+
+if __name__ == '__main__':
+    test_imex_vs_fully_implicit(True)


### PR DESCRIPTION
Simple fully implicit version of nonlinear Schrödinger based on a `scipy` Jacobian-free Newton-Krylov solver. There is a test that this version does more or less the same as the IMEX version.

There is also a small change to the sweeper class which allows to use an explicit preconditioner for `QI`. This will warn you that you are doing something which is sort of stupid. But I find it useful for quick testing. That is to say when I want to use an explicit preconditioner, I can continue to use the implicit sweepers. If you don't like it, we can remove it.