### PR TITLE
More meta data in statistics

### DIFF
--- a/pySDC/core/Sweeper.py
+++ b/pySDC/core/Sweeper.py
@@ -455,3 +455,7 @@ class sweeper(object):
         """
         assert isinstance(L, level)
         self.__level = L
+
+    @property
+    def rank(self):
+        return 0

--- a/pySDC/implementations/hooks/default_hook.py
+++ b/pySDC/implementations/hooks/default_hook.py
@@ -144,6 +144,7 @@ class DefaultHooks(hooks):
 
             self.add_to_stats(
                 process=step.status.slot,
+                process_sweeper=L.sweep.rank,
                 time=L.time,
                 level=L.level_index,
                 iter=step.status.iter,
@@ -179,6 +180,7 @@ class DefaultHooks(hooks):
 
         self.add_to_stats(
             process=step.status.slot,
+            process_sweeper=L.sweep.rank,
             time=L.time,
             level=L.level_index,
             iter=step.status.iter,
@@ -188,6 +190,7 @@ class DefaultHooks(hooks):
         )
         self.add_to_stats(
             process=step.status.slot,
+            process_sweeper=L.sweep.rank,
             time=L.time,
             level=L.level_index,
             iter=step.status.iter,
@@ -211,6 +214,7 @@ class DefaultHooks(hooks):
 
         self.add_to_stats(
             process=step.status.slot,
+            process_sweeper=L.sweep.rank,
             time=L.time,
             level=-1,
             iter=step.status.iter,
@@ -220,6 +224,7 @@ class DefaultHooks(hooks):
         )
         self.add_to_stats(
             process=step.status.slot,
+            process_sweeper=L.sweep.rank,
             time=L.time,
             level=L.level_index,
             iter=step.status.iter,
@@ -243,6 +248,7 @@ class DefaultHooks(hooks):
 
         self.add_to_stats(
             process=step.status.slot,
+            process_sweeper=L.sweep.rank,
             time=L.time,
             level=L.level_index,
             iter=step.status.iter,
@@ -252,6 +258,7 @@ class DefaultHooks(hooks):
         )
         self.add_to_stats(
             process=step.status.slot,
+            process_sweeper=L.sweep.rank,
             time=L.time,
             level=-1,
             iter=step.status.iter,
@@ -261,6 +268,7 @@ class DefaultHooks(hooks):
         )
         self.add_to_stats(
             process=step.status.slot,
+            process_sweeper=L.sweep.rank,
             time=L.time,
             level=L.level_index,
             iter=-1,
@@ -272,7 +280,14 @@ class DefaultHooks(hooks):
         # record the recomputed quantities at weird positions to make sure there is only one value for each step
         for t in [L.time, L.time + L.dt]:
             self.add_to_stats(
-                process=-1, time=t, level=-1, iter=-1, sweep=-1, type='_recomputed', value=step.status.get('restart')
+                process=-1,
+                time=t,
+                level=-1,
+                iter=-1,
+                sweep=-1,
+                type='_recomputed',
+                value=step.status.get('restart'),
+                process_sweeper=-1,
             )
 
     def post_predict(self, step, level_number):
@@ -290,6 +305,7 @@ class DefaultHooks(hooks):
 
         self.add_to_stats(
             process=step.status.slot,
+            process_sweeper=L.sweep.rank,
             time=L.time,
             level=L.level_index,
             iter=step.status.iter,
@@ -313,6 +329,7 @@ class DefaultHooks(hooks):
 
         self.add_to_stats(
             process=step.status.slot,
+            process_sweeper=L.sweep.rank,
             time=L.time,
             level=L.level_index,
             iter=step.status.iter,
@@ -335,6 +352,7 @@ class DefaultHooks(hooks):
 
         self.add_to_stats(
             process=-1,
+            process_sweeper=-1,
             time=-1,
             level=-1,
             iter=-1,

--- a/pySDC/implementations/hooks/log_embedded_error_estimate.py
+++ b/pySDC/implementations/hooks/log_embedded_error_estimate.py
@@ -18,6 +18,7 @@ class LogEmbeddedErrorEstimate(hooks):
                     value = L.status.error_embedded_estimate
                 self.add_to_stats(
                     process=step.status.slot,
+                    process_sweeper=L.sweep.rank,
                     time=L.time + L.dt,
                     level=L.level_index,
                     iter=iter,

--- a/pySDC/implementations/hooks/log_errors.py
+++ b/pySDC/implementations/hooks/log_errors.py
@@ -32,6 +32,7 @@ class LogError(hooks):
 
         self.add_to_stats(
             process=step.status.slot,
+            process_sweeper=L.sweep.rank,
             time=L.time + L.dt,
             level=L.level_index,
             iter=step.status.iter,
@@ -41,6 +42,7 @@ class LogError(hooks):
         )
         self.add_to_stats(
             process=step.status.slot,
+            process_sweeper=L.sweep.rank,
             time=L.time + L.dt,
             level=L.level_index,
             iter=step.status.iter,
@@ -69,6 +71,7 @@ class LogError(hooks):
 
         self.add_to_stats(
             process=step.status.slot,
+            process_sweeper=L.sweep.rank,
             time=L.time + L.dt,
             level=L.level_index,
             iter=step.status.iter,
@@ -176,6 +179,7 @@ class LogGlobalErrorPostRun(hooks):
 
             self.add_to_stats(
                 process=step.status.slot,
+                process_sweeper=L.sweep.rank,
                 time=self.t_last_solution,
                 level=L.level_index,
                 iter=step.status.iter,
@@ -185,6 +189,7 @@ class LogGlobalErrorPostRun(hooks):
             )
             self.add_to_stats(
                 process=step.status.slot,
+                process_sweeper=L.sweep.rank,
                 time=self.t_last_solution,
                 level=L.level_index,
                 iter=step.status.iter,

--- a/pySDC/implementations/hooks/log_extrapolated_error_estimate.py
+++ b/pySDC/implementations/hooks/log_extrapolated_error_estimate.py
@@ -24,6 +24,7 @@ class LogExtrapolationErrorEstimate(hooks):
 
         self.add_to_stats(
             process=step.status.slot,
+            process_sweeper=L.sweep.rank,
             time=L.time + L.dt,
             level=L.level_index,
             iter=step.status.iter,

--- a/pySDC/implementations/hooks/log_restarts.py
+++ b/pySDC/implementations/hooks/log_restarts.py
@@ -20,6 +20,7 @@ class LogRestarts(hooks):
 
         self.add_to_stats(
             process=step.status.slot,
+            process_sweeper=L.sweep.rank,
             time=L.time,
             level=L.level_index,
             iter=step.status.iter,

--- a/pySDC/implementations/hooks/log_work.py
+++ b/pySDC/implementations/hooks/log_work.py
@@ -45,6 +45,7 @@ class LogWork(hooks):
         for key in self.__work_last_step[step.status.slot][level_number].keys():
             self.add_to_stats(
                 process=step.status.slot,
+                process_sweeper=L.sweep.rank,
                 time=L.time + L.dt,
                 level=L.level_index,
                 iter=step.status.iter,

--- a/pySDC/implementations/sweeper_classes/generic_implicit_MPI.py
+++ b/pySDC/implementations/sweeper_classes/generic_implicit_MPI.py
@@ -30,12 +30,18 @@ class SweeperMPI(sweeper):
             self.logger.debug('Using MPI.COMM_WORLD for the communicator because none was supplied in the params.')
         super().__init__(params)
 
-        self.rank = self.params.comm.Get_rank()
-
         if self.params.comm.size != self.coll.num_nodes:
             raise NotImplementedError(
-                f'The communicator in the {type(self).__name__} sweeper needs to have one rank for each node as of now! That means we need {self.coll.num_nodes} nodes, but got {self.params.comm.size} nodes.'
+                f'The communicator in the {type(self).__name__} sweeper needs to have one rank for each node as of now! That means we need {self.coll.num_nodes} nodes, but got {self.params.comm.size} processes.'
             )
+
+    @property
+    def comm(self):
+        return self.params.comm
+
+    @property
+    def rank(self):
+        return self.comm.rank
 
     def compute_end_point(self):
         """

--- a/pySDC/projects/Resilience/hook.py
+++ b/pySDC/projects/Resilience/hook.py
@@ -30,15 +30,6 @@ class LogData(hooks):
 
         L = step.levels[level_number]
 
-        self.add_to_stats(
-            process=step.status.slot,
-            time=L.time,
-            level=L.level_index,
-            iter=step.status.iter,
-            sweep=L.status.sweep,
-            type='restart',
-            value=int(step.status.get('restart')),
-        )
         # add the following with two names because I use both in different projects -.-
         self.increment_stats(
             process=step.status.slot,

--- a/pySDC/tests/test_hooks/test_entry_class.py
+++ b/pySDC/tests/test_hooks/test_entry_class.py
@@ -1,0 +1,158 @@
+import pytest
+
+from pySDC.core.Hooks import hooks, meta_data, namedtuple
+
+# In case the starship needs manual override of the reentry sequence, we set a code for unlocking manual controls.
+# Because humans may go crazy, or worse, deflect to the enemy when they enter space, we can't tell them the code, or how
+# the flight is progressing for that matter. Hence, the weather data on convection in the atmosphere is locked with the
+# same code.
+convection_meta_data = {
+    **meta_data,
+    'unlock_manual_controls': None,
+}
+Entry = namedtuple('Entry', convection_meta_data.keys())
+
+
+class convection_hook(hooks):
+    meta_data = convection_meta_data
+    entry = Entry
+    starship = 'vostok'
+
+    def post_step(self, step, level_number):
+        """
+        Log the amount of convection, but lock it with a special code that we will definitely not tell Yuri...
+
+        Args:
+            step (pySDC.Step.step): the current step
+            level_number (int): the current level number
+
+        Returns:
+            None
+        """
+        L = step.levels[level_number]
+        self.add_to_stats(
+            process=step.status.slot,
+            time=L.time + L.dt,
+            level=L.level_index,
+            iter=step.status.iter,
+            sweep=L.status.sweep,
+            type='convection',
+            value=L.uend[0],
+            unlock_manual_controls=125 if self.starship == 'vostok' else None,
+        )
+
+
+def run_Lorenz(useMPI):
+    from pySDC.implementations.hooks.log_work import LogWork
+    from pySDC.implementations.sweeper_classes.generic_implicit import generic_implicit
+    from pySDC.implementations.problem_classes.Lorenz import LorenzAttractor
+    from pySDC.helpers.stats_helper import get_sorted
+
+    num_steps = 4
+
+    # initialize level parameters
+    level_params = {}
+    level_params['dt'] = 1e-2
+    level_params['restol'] = -1
+
+    # initialize sweeper parameters
+    sweeper_params = {}
+    sweeper_params['quad_type'] = 'RADAU-RIGHT'
+    sweeper_params['num_nodes'] = 1
+    sweeper_params['QI'] = 'IE'
+
+    problem_params = {}
+
+    # initialize step parameters
+    step_params = {}
+    step_params['maxiter'] = 1
+
+    # initialize controller parameters
+    controller_params = {}
+    controller_params['logger_level'] = 30
+    controller_params['hook_class'] = convection_hook
+    controller_params['mssdc_jac'] = False
+
+    # fill description dictionary for easy step instantiation
+    description = {}
+    description['problem_class'] = LorenzAttractor
+    description['problem_params'] = problem_params
+    description['sweeper_class'] = generic_implicit
+    description['sweeper_params'] = sweeper_params
+    description['level_params'] = level_params
+    description['step_params'] = step_params
+
+    # set time parameters
+    t0 = 0.0
+
+    # instantiate controller
+    if useMPI:
+        from mpi4py import MPI
+        from pySDC.implementations.controller_classes.controller_MPI import controller_MPI
+
+        comm = MPI.COMM_WORLD
+
+        controller = controller_MPI(controller_params=controller_params, description=description, comm=comm)
+        P = controller.S.levels[0].prob
+    else:
+        from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
+
+        comm = None
+        controller = controller_nonMPI(
+            num_procs=num_steps, controller_params=controller_params, description=description
+        )
+        P = controller.MS[0].levels[0].prob
+    uinit = P.u_exact(t0)
+
+    uend, stats = controller.run(u0=uinit, t0=t0, Tend=num_steps * level_params['dt'])
+
+    from pySDC.helpers.stats_helper import get_list_of_types
+
+    expected = -1
+    for code in [None, 0, 125]:
+        for type in ['residual_post_step', 'convection']:
+            res = get_sorted(stats, type=type, unlock_manual_controls=code, comm=comm)
+            if type == 'residual_post_step':
+                expected = num_steps if code is None else 0
+            if type == 'convection':
+                expected = num_steps if code in [None, 125] else 0  # hmmm... security doesn't seem too good...
+
+            assert (
+                len(res) == expected
+            ), f'Unexpected number of entries in stats for type {type} and code {code}! Got {len(res)}, but expected {expected}.'
+
+    return None
+
+
+@pytest.mark.base
+def test_entry_class():
+    run_Lorenz(False)
+
+
+@pytest.mark.mpi4py
+def test_entry_class_MPI():
+    import os
+    import subprocess
+
+    num_procs = 4
+
+    # Set python path once
+    my_env = os.environ.copy()
+    my_env['PYTHONPATH'] = '../../..:.'
+    my_env['COVERAGE_PROCESS_START'] = 'pyproject.toml'
+
+    cmd = f"mpirun -np {num_procs} python {__file__}".split()
+
+    p = subprocess.Popen(cmd, env=my_env, cwd=".")
+
+    p.wait()
+    assert p.returncode == 0, 'ERROR: did not get return code 0, got %s with %2i processes' % (
+        p.returncode,
+        num_procs,
+    )
+
+
+if __name__ == "__main__":
+    import sys
+
+    run_Lorenz(True)

--- a/pySDC/tests/test_hooks/test_entry_class.py
+++ b/pySDC/tests/test_hooks/test_entry_class.py
@@ -42,7 +42,7 @@ class convection_hook(hooks):
         )
 
 
-def run_Lorenz(useMPI):
+def win_space_race(useMPI):
     from pySDC.implementations.hooks.log_work import LogWork
     from pySDC.implementations.sweeper_classes.generic_implicit import generic_implicit
     from pySDC.implementations.problem_classes.Lorenz import LorenzAttractor
@@ -126,7 +126,7 @@ def run_Lorenz(useMPI):
 
 @pytest.mark.base
 def test_entry_class():
-    run_Lorenz(False)
+    win_space_race(False)
 
 
 @pytest.mark.mpi4py
@@ -155,4 +155,4 @@ def test_entry_class_MPI():
 if __name__ == "__main__":
     import sys
 
-    run_Lorenz(True)
+    win_space_race(True)


### PR DESCRIPTION
The meta data was not sufficient for multiple processes in the sweeper. I added this, but also it is now customisable, as the test shows. The implementation seems a bit weird because the `Entry` class is outside of the class definition. This I had to do because otherwise I would get pickling errors when gathering stats across an MPI communicator in `filter_stats`.
While this more abstract interface is not necessarily more easy to deal with, you can, for instance, add another meta entry for a space rank or whatever might turn out useful in the future.

I neat side effect of this is that `type` and `iter` are only used as strings, so the python internal functions of the same name are not overwritten as before.