### PR TITLE
Error estimate based on interpolation inside the collocation problem

### DIFF
--- a/pySDC/implementations/convergence_controller_classes/estimate_interpolation_error.py
+++ b/pySDC/implementations/convergence_controller_classes/estimate_interpolation_error.py
@@ -1,0 +1,153 @@
+import numpy as np
+
+from pySDC.core.Lagrange import LagrangeApproximation
+from pySDC.core.ConvergenceController import ConvergenceController, Status
+from pySDC.core.Collocation import CollBase
+
+
+class EstimateInterpolationError(ConvergenceController):
+    """
+    Estimate the local error by using all but one collocation node in a polynomial interpolation to that node.
+    While the converged collocation problem with M nodes gives a order M approximation to this point, the interpolation
+    gives only an order M-1 approximation. Hence, we have two solutions with different order, and we know their order.
+    That is to say this gives an error estimate that is order M. Keep in mind that the collocation problem should be
+    converged for this and has order up to 2M. Still, the lower order method can be used for time step selection, for
+    instance.
+    By default, we interpolate to the second to last node.
+    """
+
+    def setup(self, controller, params, description, **kwargs):
+        """
+        Args:
+            controller (pySDC.Controller.controller): The controller
+            params (dict): The params passed for this specific convergence controller
+            description (dict): The description object used to instantiate the controller
+
+        Returns:
+            (dict): The updated params dictionary
+        """
+        from pySDC.implementations.hooks.log_embedded_error_estimate import LogEmbeddedErrorEstimate
+        from pySDC.implementations.convergence_controller_classes.check_convergence import CheckConvergence
+
+        defaults = {
+            'control_order': -75,
+            'estimate_on_node': description['sweeper_params'].get('num_nodes', 2) - 1,
+        }
+        self.comm = description['sweeper_params'].get('comm', None)
+
+        if self.comm:
+            from mpi4py import MPI
+
+            self.prepare_MPI_datatypes()
+            self.MPI_SUM = MPI.SUM
+
+        controller.add_hook(LogEmbeddedErrorEstimate)
+        self.check_convergence = CheckConvergence.check_convergence
+
+        return {**defaults, **super().setup(controller, params, description, **kwargs)}
+
+    def reset_status_variables(self, controller, **kwargs):
+        """
+        Add variable for embedded error
+
+        Args:
+            controller (pySDC.Controller): The controller
+
+        Returns:
+            None
+        """
+        if 'comm' in kwargs.keys():
+            steps = [controller.S]
+        else:
+            if 'active_slots' in kwargs.keys():
+                steps = [controller.MS[i] for i in kwargs['active_slots']]
+            else:
+                steps = controller.MS
+
+        where = ["levels", "status"]
+        for S in steps:
+            self.add_variable(S, name='error_embedded_estimate', where=where, init=None)
+
+    def matmul(self, A, b):
+        """
+        Matrix vector multiplication, possibly MPI parallel.
+        The parallel implementation performs a reduce operation in every row of the matrix. While communicating the
+        entire vector once could reduce the number of communications, this way we never need to store the entire vector
+        on any specific rank.
+
+        Args:
+            A (2d np.ndarray): Matrix
+            b (list): Vector
+
+        Returns:
+            List: Axb
+        """
+        if self.comm:
+            res = [A[i, 0] * b[0] if b[i] is not None else None for i in range(A.shape[0])]
+            buf = b[0] * 0.0
+            for i in range(0, A.shape[0]):
+                index = self.comm.rank + (1 if self.comm.rank < self.params.estimate_on_node - 1 else 0)
+                send_buf = (
+                    (A[i, index] * b[index])
+                    if self.comm.rank != self.params.estimate_on_node - 1
+                    else np.zeros_like(res[0])
+                )
+                self.comm.Allreduce(send_buf, buf, op=self.MPI_SUM)
+                res[i] += buf
+            return res
+        else:
+            return A @ np.asarray(b)
+
+    def post_iteration_processing(self, controller, S, **kwargs):
+        """
+        Estimate the error
+
+        Args:
+            controller (pySDC.Controller.controller): The controller
+            S (pySDC.Step.step): The current step
+
+        Returns:
+            None
+        """
+
+        if self.check_convergence(S):
+            L = S.levels[0]
+            coll = L.sweep.coll
+            nodes = coll.nodes
+            estimate_on_node = self.params.estimate_on_node
+
+            interpolator = LagrangeApproximation(
+                points=[0] + [nodes[i - 1] for i in range(1, coll.num_nodes + 1) if i != estimate_on_node]
+            )
+            interpolation_matrix = interpolator.getInterpolationMatrix([nodes[estimate_on_node - 1]])
+            u = [
+                L.u[i].flatten() if L.u[i] is not None else L.u[i]
+                for i in range(coll.num_nodes + 1)
+                if i != estimate_on_node
+            ]
+            u_inter = self.matmul(interpolation_matrix, u)[0].reshape(L.prob.init[0])
+
+            if self.comm:
+                buf = np.array(abs(u_inter - L.u[estimate_on_node]) if self.comm.rank == estimate_on_node - 1 else 0.0)
+                self.comm.Bcast(buf, root=estimate_on_node - 1)
+                L.status.error_embedded_estimate = buf
+            else:
+                L.status.error_embedded_estimate = abs(u_inter - L.u[estimate_on_node])
+
+    def check_parameters(self, controller, params, description, **kwargs):
+        """
+        Check if we allow the scheme to solve the collocation problems to convergence.
+
+        Args:
+            controller (pySDC.Controller): The controller
+            params (dict): The params passed for this specific convergence controller
+            description (dict): The description object used to instantiate the controller
+
+        Returns:
+            bool: Whether the parameters are compatible
+            str: The error message
+        """
+        if description['sweeper_params'].get('num_nodes', 0) < 2:
+            return False, 'Need at least two collocation nodes to interpolate to one!'
+
+        return True, ""

--- a/pySDC/tests/test_convergence_controllers/test_interpolation_error.py
+++ b/pySDC/tests/test_convergence_controllers/test_interpolation_error.py
@@ -1,0 +1,225 @@
+import pytest
+
+
+def get_controller(dt, num_nodes, quad_type, useMPI):
+    """
+    Runs a single advection problem with certain parameters
+
+    Args:
+        dt (float): Step size
+        num_nodes (int): Number of nodes
+        quad_type (str): Type of quadrature
+        useMPI (bool): Whether or not to use MPI
+
+    Returns:
+       (dict): Stats object generated during the run
+       (pySDC.Controller.controller): Controller used in the run
+    """
+    from pySDC.implementations.problem_classes.polynomial_test_problem import polynomial_testequation
+    from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
+    from pySDC.implementations.convergence_controller_classes.estimate_interpolation_error import (
+        EstimateInterpolationError,
+    )
+
+    if useMPI:
+        from pySDC.implementations.sweeper_classes.generic_implicit_MPI import generic_implicit_MPI as sweeper_class
+        from mpi4py import MPI
+
+        comm = MPI.COMM_WORLD
+    else:
+        from pySDC.implementations.sweeper_classes.generic_implicit import generic_implicit as sweeper_class
+
+        comm = None
+
+    # initialize level parameters
+    level_params = {}
+    level_params['dt'] = dt
+    level_params['restol'] = 1.0
+
+    # initialize sweeper parameters
+    sweeper_params = {}
+    sweeper_params['quad_type'] = quad_type
+    sweeper_params['num_nodes'] = num_nodes
+    sweeper_params['comm'] = comm
+
+    problem_params = {'degree': 12}
+
+    # initialize step parameters
+    step_params = {}
+    step_params['maxiter'] = 0
+
+    # initialize controller parameters
+    controller_params = {}
+    controller_params['logger_level'] = 30
+    controller_params['mssdc_jac'] = False
+
+    # fill description dictionary for easy step instantiation
+    description = {}
+    description['problem_class'] = polynomial_testequation
+    description['problem_params'] = problem_params
+    description['sweeper_class'] = sweeper_class
+    description['sweeper_params'] = sweeper_params
+    description['level_params'] = level_params
+    description['step_params'] = step_params
+    description['convergence_controllers'] = {EstimateInterpolationError: {}}
+
+    controller = controller_nonMPI(num_procs=1, controller_params=controller_params, description=description)
+    return controller
+
+
+def single_test(**kwargs):
+    """
+    Run a single test where the solution is replaced by a polynomial and the nodes are changed.
+    Because we know the polynomial going in, we can check if the interpolation based change was
+    exact. If the solution is not a polynomial or a polynomial of higher degree then the number
+    of nodes, the change in nodes does add some error, of course, but here it is on the order of
+    machine precision.
+    """
+    import numpy as np
+
+    args = {
+        'num_nodes': 3,
+        'quad_type': 'RADAU-RIGHT',
+        'useMPI': False,
+        'dt': 1.0,
+        **kwargs,
+    }
+
+    # prepare variables
+    controller = get_controller(**args)
+    step = controller.MS[0]
+    level = step.levels[0]
+    prob = level.prob
+    cont = controller.convergence_controllers[
+        np.arange(len(controller.convergence_controllers))[
+            [type(me).__name__ == 'EstimateInterpolationError' for me in controller.convergence_controllers]
+        ][0]
+    ]
+    nodes = np.append([0], level.sweep.coll.nodes)
+
+    # initialize variables
+    step.status.slot = 0
+    step.status.iter = 1
+    level.status.time = 0.0
+    level.status.residual = 0.0
+    level.u[0] = prob.u_exact(t=0)
+    level.sweep.predict()
+
+    for i in range(len(level.u)):
+        if level.u[i] is not None:
+            level.u[i][:] = prob.u_exact(nodes[i] * level.dt)
+
+    # perform the interpolation
+    cont.reset_status_variables(controller)
+    cont.post_iteration_processing(controller, step)
+    error = level.status.error_embedded_estimate
+
+    return error
+
+
+def multiple_runs(dts, **kwargs):
+    """
+    Make multiple runs of a specific problem and record vital error information
+
+    Args:
+        dts (list): The step sizes to run with
+        num_nodes (int): Number of nodes
+        quad_type (str): Type of nodes
+
+    Returns:
+        dict: Errors for multiple runs
+        int: Order of the collocation problem
+    """
+    from pySDC.helpers.stats_helper import get_sorted
+
+    res = {}
+
+    for dt in dts:
+        res[dt] = {}
+        res[dt]['e'] = single_test(dt=dt, **kwargs)
+
+    return res
+
+
+def check_order(dts, **kwargs):
+    """
+    Check the order by calling `multiple_runs` and then `plot_and_compute_order`.
+
+    Args:
+        dts (list): The step sizes to run with
+        num_nodes (int): Number of nodes
+        quad_type (str): Type of nodes
+    """
+    import numpy as np
+
+    res = multiple_runs(dts, **kwargs)
+    dts = np.array(list(res.keys()))
+    keys = list(res[dts[0]].keys())
+
+    expected_order = {
+        'e': kwargs['num_nodes'],
+    }
+
+    for key in keys:
+        errors = np.array([res[dt][key] for dt in dts])
+
+        mask = np.logical_and(errors < 1e-0, errors > 1e-10)
+        order = np.log(errors[mask][1:] / errors[mask][:-1]) / np.log(dts[mask][1:] / dts[mask][:-1])
+
+        assert np.isclose(
+            np.mean(order), expected_order[key], atol=0.5
+        ), f'Expected order {expected_order[key]} for {key}, but got {np.mean(order):.2e}!'
+
+
+@pytest.mark.base
+@pytest.mark.parametrize('num_nodes', [2, 3, 4, 5])
+@pytest.mark.parametrize('quad_type', ['RADAU-RIGHT', 'GAUSS'])
+def test_interpolation_error(num_nodes, quad_type):
+    import numpy as np
+
+    kwargs = {
+        'num_nodes': num_nodes,
+        'quad_type': quad_type,
+        'useMPI': False,
+    }
+    steps = np.logspace(-1, -4, 20)
+    check_order(steps, **kwargs)
+
+
+@pytest.mark.mpi4py
+@pytest.mark.parametrize('num_nodes', [2, 5])
+@pytest.mark.parametrize('quad_type', ['RADAU-RIGHT'])
+def test_interpolation_error_MPI(num_nodes, quad_type):
+    import subprocess
+    import os
+
+    # Set python path once
+    my_env = os.environ.copy()
+    my_env['PYTHONPATH'] = '../../..:.'
+    my_env['COVERAGE_PROCESS_START'] = 'pyproject.toml'
+
+    cmd = f"mpirun -np {num_nodes} python {__file__} {num_nodes} {quad_type}".split()
+
+    p = subprocess.Popen(cmd, env=my_env, cwd=".")
+
+    p.wait()
+    assert p.returncode == 0, 'ERROR: did not get return code 0, got %s with %2i processes' % (
+        p.returncode,
+        num_nodes,
+    )
+
+
+if __name__ == "__main__":
+    import sys
+    import numpy as np
+
+    steps = np.logspace(-1, -4, 20)
+
+    if len(sys.argv) > 1:
+        kwargs = {
+            'num_nodes': int(sys.argv[1]),
+            'quad_type': sys.argv[2],
+        }
+        check_order(steps, useMPI=True, **kwargs)
+    else:
+        check_order(steps, useMPI=False, num_nodes=3, quad_type='RADAU-RIGHT')


### PR DESCRIPTION
The solution to the collocation problem is an order $M$ polynomial that we can evaluate wherever we want by means of interpolation. This is specific to SDC and hence I have to find it cool. 
If we use $M-1$ collocation nodes of a converged collocation problem with $M$ nodes, we get an order $M-1$ polynomial. The result is not the same as the solution to a colocation problem with $M-1$ nodes, but both are valid polynomial approximations of the solution of order $M-1$, only using different quadrature points. Equidistant nodes work, Radau points work, whatever. They just give different properties regarding stability and and accuracy of the end point. If we choose any $M-1$ points other than the end point, if possible, we give up the super convergence. But we don't need that.
We can instead interpolate to the node we did not use and get a order $M-1$ approximation to that node, which we can compare to the order $M$ approximation given by the solution of the converged colocation problem to obtain an error estimate of the lower order polynomial, which is order $M$.
Sound familiar? We have been doing "embedded" SDC by doing $2M-1$ iterations with Gauß-Radau-Right quadrature and used the increment of the last iteration to obtain an error estimate of the $2M-2$ order second to last sweep. (Order 2M-1).
And now we can do adaptivity. Preliminary numerical results suggest that this works well. The major advantage is that we can do whatever we want to arrive at a converged collocation problem. Inexactness and what not. Diagonal preconditioners and the likes. And this could beat RK methods.
One disadvantage is that the lower order method has a lower order than with the increment based error estimate. If we consider 3 nodes for instance, we get an order 5(4) scheme with the increment, but a 5(2) scheme with this method. Now how bad is that? I thought because we are considering local errors only, this just means the same tolerance on the lower order method will give a tighter error of higher order method. But maybe I am wrong.
Crucially, we use solutions to converged collocation problems to advance to the next step. And if we choose a sensible criterion for what convergence means numerically, we make sure that the order of the solution to the step is what we think it is. Better even than with the increment method, I guess. As far as I understand, order reduction is not observed in converged collocation problems.

The included tests compute the order of accuracy of the error estimate with respect to the exact solution of the polynomial test problem, which is a polynomial of sufficiently high order.

Below is a quick and dirty performance plot for Allen-Cahn. The blue line is using adaptivity based on this error estimate using inexactness in both the Newton and linear iterations. The orange line is increment based adaptivity and the pink one is ESDIRK5(3). Don't worry about the yellow line. It is using a different estimate of the local error based on converged collocation problems based on a Taylor expansion of the solution at the end point of the interval, also of order $M-1$.
![Figure_1](https://github.com/Parallel-in-Time/pySDC/assets/39156931/5893a1ef-da91-4e8d-a575-1405844c4b56)
