### PR TITLE
Added `solve_system` to all DAE problem classes

### DIFF
--- a/pySDC/projects/DAE/misc/ProblemDAE.py
+++ b/pySDC/projects/DAE/misc/ProblemDAE.py
@@ -1,25 +1,64 @@
 import numpy as np
+from scipy.optimize import root
 
-from pySDC.core.Problem import ptype
+from pySDC.core.Problem import ptype, WorkCounter
 from pySDC.implementations.datatype_classes.mesh import mesh
 
 
 class ptype_dae(ptype):
-    """
-    Interface class for DAE problems. Ensures that all parameters are passed that are needed by DAE sweepers
+    r"""
+    This class implements a generic DAE class and illustrates the interface class for DAE problems.
+    It ensures that all parameters are passed that are needed by DAE sweepers.
+
+    Parameters
+    ----------
+    nvars : int
+        Number of unknowns of the problem class.
+    newton_tol : float
+        Tolerance for the nonlinear solver.
+
+    Attributes
+    ----------
+    work_counters : WorkCounter
+        Counts the work, here the number of function calls during the nonlinear solve is logged.
     """
 
     dtype_u = mesh
     dtype_f = mesh
 
     def __init__(self, nvars, newton_tol):
-        """
-        Initialization routine
-
-        Args:
-            problem_params (dict): custom parameters for the example
-            dtype_u: mesh data type (will be passed parent class)
-            dtype_f: mesh data type (will be passed parent class)
-        """
+        """Initialization routine"""
         super().__init__((nvars, None, np.dtype('float64')))
         self._makeAttributeAndRegister('nvars', 'newton_tol', localVars=locals(), readOnly=True)
+
+        self.work_counters['newton'] = WorkCounter()
+
+    def solve_system(self, impl_sys, u0, t):
+        r"""
+        Solver for nonlinear implicit system (defined in sweeper).
+
+        Parameters
+        ----------
+        impl_sys : callable
+            Implicit system to be solved.
+        u0 : dtype_u
+            Initial guess for solver.
+        t : float
+            Current time :math:`t`.
+
+        Returns
+        -------
+        me : dtype_u
+            Numerical solution.
+        """
+
+        me = self.dtype_u(self.init)
+        opt = root(
+            impl_sys,
+            u0,
+            method='hybr',
+            tol=self.newton_tol,
+        )
+        me[:] = opt.x
+        self.work_counters['newton'].niter += opt.nfev
+        return me

--- a/pySDC/projects/DAE/misc/ProblemDAE.py
+++ b/pySDC/projects/DAE/misc/ProblemDAE.py
@@ -20,7 +20,9 @@ class ptype_dae(ptype):
     Attributes
     ----------
     work_counters : WorkCounter
-        Counts the work, here the number of function calls during the nonlinear solve is logged.
+        Counts the work, here the number of function calls during the nonlinear solve is logged and stored
+        in work_counters['newton']. The number of each function class of the right-hand side is then stored
+        in work_counters['rhs']
     """
 
     dtype_u = mesh
@@ -32,6 +34,7 @@ class ptype_dae(ptype):
         self._makeAttributeAndRegister('nvars', 'newton_tol', localVars=locals(), readOnly=True)
 
         self.work_counters['newton'] = WorkCounter()
+        self.work_counters['rhs'] = WorkCounter()
 
     def solve_system(self, impl_sys, u0, t):
         r"""

--- a/pySDC/projects/DAE/problems/simple_DAE.py
+++ b/pySDC/projects/DAE/problems/simple_DAE.py
@@ -1,7 +1,6 @@
 import warnings
 import numpy as np
 from scipy.interpolate import interp1d
-from scipy.optimize import root
 
 from pySDC.projects.DAE.misc.ProblemDAE import ptype_dae
 from pySDC.core.Problem import WorkCounter
@@ -38,8 +37,7 @@ class pendulum_2d(ptype_dae):
     ----------
     work_counters : WorkCounter
         Counts the work, i.e., number of function calls of right-hand side is called and stored in
-        ``work_counters['rhs']``, the number of function calls of the Newton-like solver is stored in
-        ``work_counters['newton']``.
+        ``work_counters['rhs']``.
 
     References
     ----------
@@ -57,7 +55,6 @@ class pendulum_2d(ptype_dae):
         # solution = data[:, 1:]
         # self.u_ref = interp1d(t, solution, kind='cubic', axis=0, fill_value='extrapolate')
         self.t_end = 0.0
-        self.work_counters['newton'] = WorkCounter()
         self.work_counters['rhs'] = WorkCounter()
 
     def eval_f(self, u, du, t):
@@ -85,36 +82,6 @@ class pendulum_2d(ptype_dae):
         f[:] = (du[0] - u[2], du[1] - u[3], du[2] + u[4] * u[0], du[3] + u[4] * u[1] + g, u[0] ** 2 + u[1] ** 2 - 1)
         self.work_counters['rhs']()
         return f
-
-    def solve_system(self, impl_sys, u0, t):
-        r"""
-        Solver for nonlinear implicit system (defined in sweeper).
-
-        Parameters
-        ----------
-        impl_sys : callable
-            Implicit system to be solved.
-        u0 : dtype_u
-            Initial guess for solver.
-        t : float
-            Current time :math:`t`.
-
-        Returns
-        -------
-        me : dtype_u
-            Numerical solution.
-        """
-
-        me = self.dtype_u(self.init)
-        opt = root(
-            impl_sys,
-            u0,
-            method='hybr',
-            tol=self.newton_tol,
-        )
-        me[:] = opt.x
-        self.work_counters['newton'].niter += opt.nfev
-        return me
 
     def u_exact(self, t):
         """
@@ -177,8 +144,7 @@ class simple_dae_1(ptype_dae):
     ----------
     work_counters : WorkCounter
         Counts the work, i.e., number of function calls of right-hand side is called and stored in
-        ``work_counters['rhs']``, the number of function calls of the Newton-like solver is stored in
-        ``work_counters['newton']``.
+        ``work_counters['rhs']``.
 
     References
     ----------
@@ -190,7 +156,6 @@ class simple_dae_1(ptype_dae):
         """Initialization routine"""
         super().__init__(nvars, newton_tol)
 
-        self.work_counters['newton'] = WorkCounter()
         self.work_counters['rhs'] = WorkCounter()
 
     def eval_f(self, u, du, t):
@@ -221,36 +186,6 @@ class simple_dae_1(ptype_dae):
         )
         self.work_counters['rhs']()
         return f
-
-    def solve_system(self, impl_sys, u0, t):
-        r"""
-        Solver for nonlinear implicit system (defined in sweeper).
-
-        Parameters
-        ----------
-        impl_sys : callable
-            Implicit system to be solved.
-        u0 : dtype_u
-            Initial guess for solver.
-        t : float
-            Current time :math:`t`.
-
-        Returns
-        -------
-        me : dtype_u
-            Numerical solution.
-        """
-
-        me = self.dtype_u(self.init)
-        opt = root(
-            impl_sys,
-            u0,
-            method='hybr',
-            tol=self.newton_tol,
-        )
-        me[:] = opt.x
-        self.work_counters['newton'].niter += opt.nfev
-        return me
 
     def u_exact(self, t):
         """
@@ -297,8 +232,7 @@ class problematic_f(ptype_dae):
         Specific parameter of the problem.
     work_counters : WorkCounter
         Counts the work, i.e., number of function calls of right-hand side is called and stored in
-        ``work_counters['rhs']``, the number of function calls of the Newton-like solver is stored in
-        ``work_counters['newton']``.
+        ``work_counters['rhs']``
 
     References
     ----------
@@ -312,7 +246,6 @@ class problematic_f(ptype_dae):
         self._makeAttributeAndRegister('eta', localVars=locals())
 
         self.work_counters['rhs'] = WorkCounter()
-        self.work_counters['newton'] = WorkCounter()
 
     def eval_f(self, u, du, t):
         r"""
@@ -339,36 +272,6 @@ class problematic_f(ptype_dae):
         )
         self.work_counters['rhs']()
         return f
-
-    def solve_system(self, impl_sys, u0, t):
-        r"""
-        Solver for nonlinear implicit system (defined in sweeper).
-
-        Parameters
-        ----------
-        impl_sys : callable
-            Implicit system to be solved.
-        u0 : dtype_u
-            Initial guess for solver.
-        t : float
-            Current time :math:`t`.
-
-        Returns
-        -------
-        me : dtype_u
-            Numerical solution.
-        """
-
-        me = self.dtype_u(self.init)
-        opt = root(
-            impl_sys,
-            u0,
-            method='hybr',
-            tol=self.newton_tol,
-        )
-        me[:] = opt.x
-        self.work_counters['newton'].niter += opt.nfev
-        return me
 
     def u_exact(self, t):
         """

--- a/pySDC/projects/DAE/problems/simple_DAE.py
+++ b/pySDC/projects/DAE/problems/simple_DAE.py
@@ -3,7 +3,6 @@ import numpy as np
 from scipy.interpolate import interp1d
 
 from pySDC.projects.DAE.misc.ProblemDAE import ptype_dae
-from pySDC.core.Problem import WorkCounter
 
 
 class pendulum_2d(ptype_dae):
@@ -33,11 +32,6 @@ class pendulum_2d(ptype_dae):
     ----------
     t_end: float
         The end time at which the reference solution is determined.
-    Attributes
-    ----------
-    work_counters : WorkCounter
-        Counts the work, i.e., number of function calls of right-hand side is called and stored in
-        ``work_counters['rhs']``.
 
     References
     ----------
@@ -55,7 +49,6 @@ class pendulum_2d(ptype_dae):
         # solution = data[:, 1:]
         # self.u_ref = interp1d(t, solution, kind='cubic', axis=0, fill_value='extrapolate')
         self.t_end = 0.0
-        self.work_counters['rhs'] = WorkCounter()
 
     def eval_f(self, u, du, t):
         r"""
@@ -140,23 +133,11 @@ class simple_dae_1(ptype_dae):
     newton_tol : float
         Tolerance for Newton solver.
 
-    Attributes
-    ----------
-    work_counters : WorkCounter
-        Counts the work, i.e., number of function calls of right-hand side is called and stored in
-        ``work_counters['rhs']``.
-
     References
     ----------
     .. [1] U. Ascher, L. R. Petzold. Computer method for ordinary differential equations and differential-algebraic
         equations. Society for Industrial and Applied Mathematics (1998).
     """
-
-    def __init__(self, nvars, newton_tol):
-        """Initialization routine"""
-        super().__init__(nvars, newton_tol)
-
-        self.work_counters['rhs'] = WorkCounter()
 
     def eval_f(self, u, du, t):
         r"""
@@ -230,9 +211,6 @@ class problematic_f(ptype_dae):
     ----------
     eta : float
         Specific parameter of the problem.
-    work_counters : WorkCounter
-        Counts the work, i.e., number of function calls of right-hand side is called and stored in
-        ``work_counters['rhs']``
 
     References
     ----------
@@ -244,8 +222,6 @@ class problematic_f(ptype_dae):
         """Initialization routine"""
         super().__init__(nvars, newton_tol)
         self._makeAttributeAndRegister('eta', localVars=locals())
-
-        self.work_counters['rhs'] = WorkCounter()
 
     def eval_f(self, u, du, t):
         r"""

--- a/pySDC/projects/DAE/problems/synchronous_machine.py
+++ b/pySDC/projects/DAE/problems/synchronous_machine.py
@@ -1,7 +1,6 @@
 import numpy as np
 import warnings
 from scipy.interpolate import interp1d
-from scipy.optimize import root
 
 from pySDC.projects.DAE.misc.ProblemDAE import ptype_dae
 from pySDC.core.Problem import WorkCounter
@@ -147,8 +146,7 @@ class synchronous_machine_infinite_bus(ptype_dae):
         Defines the mechanical torque applied to the rotor shaft.
     work_counters : WorkCounter
         Counts the work, i.e., number of function calls of right-hand side is called and stored in
-        ``work_counters['rhs']``, the number of function calls of the Newton-like solver is stored in
-        ``work_counters['newton']``.
+        ``work_counters['rhs']``.
 
     References
     ----------
@@ -191,7 +189,6 @@ class synchronous_machine_infinite_bus(ptype_dae):
         self.T_m = 0.854
 
         self.work_counters['rhs'] = WorkCounter()
-        self.work_counters['newton'] = WorkCounter()
 
     def eval_f(self, u, du, t):
         r"""
@@ -268,36 +265,6 @@ class synchronous_machine_infinite_bus(ptype_dae):
         )
         self.work_counters['rhs']()
         return f
-
-    def solve_system(self, impl_sys, u0, t):
-        r"""
-        Solver for nonlinear implicit system (defined in sweeper).
-
-        Parameters
-        ----------
-        impl_sys : callable
-            Implicit system to be solved.
-        u0 : dtype_u
-            Initial guess for solver.
-        t : float
-            Current time :math:`t`.
-
-        Returns
-        -------
-        me : dtype_u
-            Numerical solution.
-        """
-
-        me = self.dtype_u(self.init)
-        opt = root(
-            impl_sys,
-            u0,
-            method='hybr',
-            tol=self.newton_tol,
-        )
-        me[:] = opt.x
-        self.work_counters['newton'].niter += opt.nfev
-        return me
 
     def u_exact(self, t):
         """

--- a/pySDC/projects/DAE/problems/synchronous_machine.py
+++ b/pySDC/projects/DAE/problems/synchronous_machine.py
@@ -3,7 +3,6 @@ import warnings
 from scipy.interpolate import interp1d
 
 from pySDC.projects.DAE.misc.ProblemDAE import ptype_dae
-from pySDC.core.Problem import WorkCounter
 from pySDC.implementations.datatype_classes.mesh import mesh
 
 
@@ -144,9 +143,6 @@ class synchronous_machine_infinite_bus(ptype_dae):
         Voltage at the field winding.
     T_m: float
         Defines the mechanical torque applied to the rotor shaft.
-    work_counters : WorkCounter
-        Counts the work, i.e., number of function calls of right-hand side is called and stored in
-        ``work_counters['rhs']``.
 
     References
     ----------
@@ -187,8 +183,6 @@ class synchronous_machine_infinite_bus(ptype_dae):
         # These are modelled as constants. Intuition: permanent magnet as rotor
         self.v_F = 8.736809687330562e-4
         self.T_m = 0.854
-
-        self.work_counters['rhs'] = WorkCounter()
 
     def eval_f(self, u, du, t):
         r"""

--- a/pySDC/projects/DAE/problems/transistor_amplifier.py
+++ b/pySDC/projects/DAE/problems/transistor_amplifier.py
@@ -1,6 +1,5 @@
 import warnings
 import numpy as np
-from scipy.optimize import root
 from scipy.interpolate import interp1d
 
 from pySDC.projects.DAE.misc.ProblemDAE import ptype_dae
@@ -58,8 +57,7 @@ class one_transistor_amplifier(ptype_dae):
         The end time at which the reference solution is determined.
     work_counters : WorkCounter
         Counts the work, i.e., number of function calls of right-hand side is called and stored in
-        ``work_counters['rhs']``, the number of function calls of the Newton-like solver is stored in
-        ``work_counters['newton']``.
+        ``work_counters['rhs']``.
 
     References
     ----------
@@ -79,7 +77,6 @@ class one_transistor_amplifier(ptype_dae):
         self.t_end = 0.0
 
         self.work_counters['rhs'] = WorkCounter()
-        self.work_counters['newton'] = WorkCounter()
 
     def eval_f(self, u, du, t):
         r"""
@@ -115,36 +112,6 @@ class one_transistor_amplifier(ptype_dae):
         )
         self.work_counters['rhs']()
         return f
-
-    def solve_system(self, impl_sys, u0, t):
-        r"""
-        Solver for nonlinear implicit system (defined in sweeper).
-
-        Parameters
-        ----------
-        impl_sys : callable
-            Implicit system to be solved.
-        u0 : dtype_u
-            Initial guess for solver.
-        t : float
-            Current time :math:`t`.
-
-        Returns
-        -------
-        me : dtype_u
-            Numerical solution.
-        """
-
-        me = self.dtype_u(self.init)
-        opt = root(
-            impl_sys,
-            u0,
-            method='hybr',
-            tol=self.newton_tol,
-        )
-        me[:] = opt.x
-        self.work_counters['newton'].niter += opt.nfev
-        return me
 
     def u_exact(self, t):
         """
@@ -229,8 +196,7 @@ class two_transistor_amplifier(ptype_dae):
         The end time at which the reference solution is determined.
     work_counters : WorkCounter
         Counts the work, i.e., number of function calls of right-hand side is called and stored in
-        ``work_counters['rhs']``, the number of function calls of the Newton-like solver is stored in
-        ``work_counters['newton']``.
+        ``work_counters['rhs']``.
 
     References
     ----------
@@ -250,7 +216,6 @@ class two_transistor_amplifier(ptype_dae):
         self.t_end = 0.0
 
         self.work_counters['rhs'] = WorkCounter()
-        self.work_counters['newton'] = WorkCounter()
 
     def eval_f(self, u, du, t):
         r"""
@@ -289,36 +254,6 @@ class two_transistor_amplifier(ptype_dae):
         )
         self.work_counters['rhs']()
         return f
-
-    def solve_system(self, impl_sys, u0, t):
-        r"""
-        Solver for nonlinear implicit system (defined in sweeper).
-
-        Parameters
-        ----------
-        impl_sys : callable
-            Implicit system to be solved.
-        u0 : dtype_u
-            Initial guess for solver.
-        t : float
-            Current time :math:`t`.
-
-        Returns
-        -------
-        me : dtype_u
-            Numerical solution.
-        """
-
-        me = self.dtype_u(self.init)
-        opt = root(
-            impl_sys,
-            u0,
-            method='hybr',
-            tol=self.newton_tol,
-        )
-        me[:] = opt.x
-        self.work_counters['newton'].niter += opt.nfev
-        return me
 
     def u_exact(self, t):
         """

--- a/pySDC/projects/DAE/problems/transistor_amplifier.py
+++ b/pySDC/projects/DAE/problems/transistor_amplifier.py
@@ -3,7 +3,6 @@ import numpy as np
 from scipy.interpolate import interp1d
 
 from pySDC.projects.DAE.misc.ProblemDAE import ptype_dae
-from pySDC.core.Problem import WorkCounter
 
 
 # Helper function
@@ -55,9 +54,6 @@ class one_transistor_amplifier(ptype_dae):
     ----------
     t_end: float
         The end time at which the reference solution is determined.
-    work_counters : WorkCounter
-        Counts the work, i.e., number of function calls of right-hand side is called and stored in
-        ``work_counters['rhs']``.
 
     References
     ----------
@@ -75,8 +71,6 @@ class one_transistor_amplifier(ptype_dae):
         # y = data[:, 1:-1]
         # self.u_ref = interp1d(x, y, kind='cubic', axis=0, fill_value='extrapolate')
         self.t_end = 0.0
-
-        self.work_counters['rhs'] = WorkCounter()
 
     def eval_f(self, u, du, t):
         r"""
@@ -194,9 +188,6 @@ class two_transistor_amplifier(ptype_dae):
     ----------
     t_end: float
         The end time at which the reference solution is determined.
-    work_counters : WorkCounter
-        Counts the work, i.e., number of function calls of right-hand side is called and stored in
-        ``work_counters['rhs']``.
 
     References
     ----------
@@ -214,8 +205,6 @@ class two_transistor_amplifier(ptype_dae):
         # y = data[:, 1:-1]
         # self.u_ref = interp1d(x, y, kind='cubic', axis=0, fill_value='extrapolate')
         self.t_end = 0.0
-
-        self.work_counters['rhs'] = WorkCounter()
 
     def eval_f(self, u, du, t):
         r"""

--- a/pySDC/projects/DAE/sweepers/fully_implicit_DAE.py
+++ b/pySDC/projects/DAE/sweepers/fully_implicit_DAE.py
@@ -142,7 +142,7 @@ class fully_implicit_DAE(sweeper):
             u_new = P.solve_system(implSystem, L.f[m], L.time + L.dt * self.coll.nodes[m - 1])
 
             # update gradient (recall L.f is being used to store the gradient)
-            L.f[m][:] = u_new  # opt.x
+            L.f[m][:] = u_new
 
         # Update solution approximation
         integral = self.integrate()


### PR DESCRIPTION
Currently, the `fully_implicit_DAE` sweeper solves all DAE problems in the same way, i.e., using `scipy.optimize.root(f, x0, method='hybr')`. Since it could be useful to choose the solver problem dependent, a `solve_system` method is added to all DAE classes as this is already the case for all implemented ODE/PDE classes in `pySDC`. The implicit system is defined in the sweeper anyway, because this nonlinear system does not change (since it is the collocation problem to be solved).

So no magic here in this PR, I only moved these two line
```
opt = root(impl_sys, u0, method='hybr', tol=self.newton_tol)
me[:] = opt.x
```
Now, the problem classes still uses the same solver, but for the future, also different solver could be implemented and no one has to take care to change the sweeper itself every time.
to the problem classes.

Now, also `WorkCounters` are used to count the work which is also useful to get some statistics about the calls of the right-hand side and the calls of the right-hand side during the solve (because for `hybr` no callback is available and also no iterations needed for the solve can be found..). 