### PR TITLE
Refactor of `update_nodes`

### DIFF
--- a/pySDC/implementations/sweeper_classes/generic_implicit.py
+++ b/pySDC/implementations/sweeper_classes/generic_implicit.py
@@ -97,9 +97,9 @@ class generic_implicit(sweeper):
         Returns:
             list of dtype_u: containing the integral as values
         """
-        rhs = self.initialize_right_hand_side_buffer()
-        self.add_matrix_times_f_evaluations_to(self.coll.Qmat, rhs)
-        return rhs
+        integral = self.initialize_right_hand_side_buffer()
+        self.add_matrix_times_f_evaluations_to(self.coll.Qmat, integral)
+        return integral
 
     def compute_end_point(self):
         """

--- a/pySDC/implementations/sweeper_classes/generic_implicit.py
+++ b/pySDC/implementations/sweeper_classes/generic_implicit.py
@@ -20,33 +20,9 @@ class generic_implicit(sweeper):
         if 'QI' not in params:
             params['QI'] = 'IE'
 
-        # call parent's initialization routine
         super().__init__(params)
 
-        # get QI matrix
         self.QI = self.get_Qdelta_implicit(self.coll, qd_type=self.params.QI)
-
-    def integrate(self):
-        """
-        Integrates the right-hand side
-
-        Returns:
-            list of dtype_u: containing the integral as values
-        """
-
-        L = self.level
-        P = L.prob
-
-        me = []
-
-        # integrate RHS over all collocation nodes
-        for m in range(1, self.coll.num_nodes + 1):
-            # new instance of dtype_u, initialize values with 0
-            me.append(P.dtype_u(P.init, val=0.0))
-            for j in range(1, self.coll.num_nodes + 1):
-                me[-1] += L.dt * self.coll.Qmat[m, j] * L.f[j]
-
-        return me
 
     def update_nodes(self):
         """
@@ -55,50 +31,75 @@ class generic_implicit(sweeper):
         Returns:
             None
         """
-
-        L = self.level
-        P = L.prob
-
-        # only if the level has been touched before
-        assert L.status.unlocked
-
-        # get number of collocation nodes for easier access
         M = self.coll.num_nodes
 
-        # gather all terms which are known already (e.g. from the previous iteration)
-        # this corresponds to u0 + QF(u^k) - QdF(u^k) + tau
+        # only if the level has been touched before
+        assert self.level.status.unlocked
 
-        # get QF(u^k)
-        integral = self.integrate()
-        for m in range(M):
-            # get -QdF(u^k)_m
-            for j in range(1, M + 1):
-                integral[m] -= L.dt * self.QI[m + 1, j] * L.f[j]
+        rhs = self.build_right_hand_side()
 
-            # add initial value
-            integral[m] += L.u[0]
-            # add tau if associated
-            if L.tau[m] is not None:
-                integral[m] += L.tau[m]
-
-        # do the sweep
         for m in range(0, M):
-            # build rhs, consisting of the known values from above and new values from previous nodes (at k+1)
-            rhs = P.dtype_u(integral[m])
-            for j in range(1, m + 1):
-                rhs += L.dt * self.QI[m + 1, j] * L.f[j]
+            self.sweep(rhs, m)
 
-            # implicit solve with prefactor stemming from the diagonal of Qd
-            L.u[m + 1] = P.solve_system(
-                rhs, L.dt * self.QI[m + 1, m + 1], L.u[m + 1], L.time + L.dt * self.coll.nodes[m]
-            )
-            # update function values
-            L.f[m + 1] = P.eval_f(L.u[m + 1], L.time + L.dt * self.coll.nodes[m])
-
-        # indicate presence of new values at this level
-        L.status.updated = True
+        self.level.status.updated = True
 
         return None
+
+    def build_right_hand_side(self):
+        rhs = self.initialize_right_hand_side_buffer()
+        self.add_Q_minus_QD_times_F(rhs)
+        self.add_initial_conditions(rhs)
+        self.add_tau_correction(rhs)
+        return rhs
+
+    def initialize_right_hand_side_buffer(self):
+        problem = self.level.prob
+
+        return [problem.dtype_u(problem.init, val=0.0) for _ in range(self.coll.num_nodes)]
+
+    def add_Q_minus_QD_times_F(self, rhs):
+        self.add_matrix_times_f_evaluations_to(self.coll.Qmat - self.QI, rhs)
+
+    def add_matrix_times_f_evaluations_to(self, matrix, rhs):
+        for m in range(1, self.coll.num_nodes + 1):
+            for j in range(1, self.coll.num_nodes + 1):
+                rhs[m - 1] += self.level.dt * matrix[m, j] * self.level.f[j]
+
+    def add_initial_conditions(self, rhs):
+        for i in range(len(rhs)):
+            rhs[i] += self.level.u[0]
+
+    def add_tau_correction(self, rhs):
+        for m in range(self.coll.num_nodes):
+            if self.level.tau[m] is not None:
+                rhs[m] += self.level.tau[m]
+
+    def sweep(self, rhs, current_node):
+        L = self.level
+        P = L.prob
+        m = current_node
+
+        self.add_new_information_from_forward_substitution(rhs, m)
+
+        L.u[m + 1] = P.solve_system(
+            rhs[m], L.dt * self.QI[m + 1, m + 1], L.u[m + 1], L.time + L.dt * self.coll.nodes[m]
+        )
+        L.f[m + 1] = P.eval_f(L.u[m + 1], L.time + L.dt * self.coll.nodes[m])
+
+    def add_new_information_from_forward_substitution(self, rhs, current_node):
+        for j in range(1, current_node + 1):
+            rhs[current_node] += self.level.dt * self.QI[current_node + 1, j] * self.level.f[j]
+
+    def integrate(self):
+        """
+        Integrates the right-hand side
+
+        Returns:
+            list of dtype_u: containing the integral as values
+        """
+        rhs = self.initialize_right_hand_side_buffer()
+        self.add_matrix_times_f_evaluations_to(self.coll.Qmat, rhs)
+        return rhs
 
     def compute_end_point(self):
         """


### PR DESCRIPTION
I started reading a book called Clean Code and decided to give some of the things I learned a shot. I refactored the `update_nodes` functions in the generic_implicit and imex_1st_order sweepers. Feel free to reject this. What constitutes good code is subjective after all and I can see how someone could find the current version more readable than what I suggest.

The principles I tried to apply are mainly:
 - Forgo comments in favour of expressive function and variable names
 - Make small functions that do as little as possible 

A benefit gained from the abstraction of small functions is that the imex sweeper can be shortened significantly. Of course, this comes at the expense of difficulty to understand abstract code. You cannot really understand what the imex sweeper does without considering the above level of abstraction. On the other hand, the differences to the generic implicit sweeper become much more clear as you don't really need to implement any shared functionality.
If you like these changes, I would apply them to some of the other sweepers as well and I believe that the explicit sweeper or the RK sweeper can be shortened significantly as well. In this case, it would be worth considering moving some changes to the core sweeper module.

At first I didn't want to start refactoring existing code. However, I may have to start taking memory a bit more seriously and this is a side effect of these changes. Memory usage is indeed reduced because the current implementation generates a right hand side for the problem to solve from a copy of the "integral" at the respective node. In this PR, I want to change that to construct a right hand side vector from the integral and so on and directly pass this to the solver.
Another side effect is gained efficiency because I suggest to compute $(Q-Q_\Delta)F$ instead of $QF - Q_\Delta F$ as in the current implementation. I actually have a separate copy of these sweepers in my project folder right now which implement this already. By refactoring some other stuff a bit more, I could get rid of them and we could have the more efficient implementation as default.

Please do comment! Do you like this style of coding or do you like a different level of abstraction that generates more self-contained files? Do you require comments and docstrings? Again, I don't claim to have objectively improved the prettiness of the code in this PR.

While we're on the topic of more expressive naming, I suggest to rename a few things, for instance
 - `integrate` -> `integrate_right_hand_side`
 - `solve_system` -> `Euler_step`
 - `description` -> `configuration`
 - remove "classes" in the path to implementations, i.e. `pySDC.implementations.sweepers.generic_implicit` etc.
 - ...
How do you feel about such things? 
