### PR TITLE
Fix for RK sweeper - Node changed for `BackwardEuler`

### DIFF
--- a/pySDC/implementations/sweeper_classes/Runge_Kutta.py
+++ b/pySDC/implementations/sweeper_classes/Runge_Kutta.py
@@ -470,7 +470,7 @@ class BackwardEuler(RungeKutta):
     A-stable first order method.
     """
 
-    nodes = np.array([0.0])
+    nodes = np.array([1.0])
     weights = np.array([1.0])
     matrix = np.array(
         [


### PR DESCRIPTION
One of the biggest PRs ever seen in ``pySDC``. Node for implicit Euler is changed. Since it is an implicit method it needs to be changed to 1.