### PR TITLE
Generic MPI FFT class

### DIFF
--- a/pySDC/implementations/problem_classes/Brusselator.py
+++ b/pySDC/implementations/problem_classes/Brusselator.py
@@ -2,7 +2,6 @@ import numpy as np
 from mpi4py import MPI
 
 from pySDC.implementations.problem_classes.generic_MPIFFT_Laplacian import IMEX_Laplacian_MPIFFT
-from pySDC.implementations.datatype_classes.mesh import mesh, imex_mesh
 
 
 class Brusselator(IMEX_Laplacian_MPIFFT):
@@ -22,9 +21,6 @@ class Brusselator(IMEX_Laplacian_MPIFFT):
     ----------
     .. [1] https://link.springer.com/book/10.1007/978-3-642-05221-7
     """
-
-    dtype_u = mesh
-    dtype_f = imex_mesh
 
     def __init__(self, alpha=0.1, **kwargs):
         """Initialization routine"""

--- a/pySDC/implementations/problem_classes/NonlinearSchroedinger_MPIFFT.py
+++ b/pySDC/implementations/problem_classes/NonlinearSchroedinger_MPIFFT.py
@@ -59,7 +59,8 @@ class nonlinearschroedinger_imex(IMEX_Laplacian_MPIFFT):
         self._makeAttributeAndRegister('c', localVars=locals(), readOnly=True)
 
     def _eval_explicit_part(self, u, t, f_expl):
-        return self.ndim * self.c * 2j * self.xp.absolute(u) ** 2 * u
+        f_expl[:] = self.ndim * self.c * 2j * self.xp.absolute(u) ** 2 * u
+        return f_expl
 
     def u_exact(self, t, **kwargs):
         r"""

--- a/pySDC/implementations/problem_classes/NonlinearSchroedinger_MPIFFT.py
+++ b/pySDC/implementations/problem_classes/NonlinearSchroedinger_MPIFFT.py
@@ -59,7 +59,7 @@ class nonlinearschroedinger_imex(IMEX_Laplacian_MPIFFT):
         self._makeAttributeAndRegister('c', localVars=locals(), readOnly=True)
 
     def _eval_explicit_part(self, u, t, f_expl):
-        return self.ndim * self.c * 2j * np.absolute(u) ** 2 * u
+        return self.ndim * self.c * 2j * self.xp.absolute(u) ** 2 * u
 
     def u_exact(self, t, **kwargs):
         r"""
@@ -83,9 +83,9 @@ class nonlinearschroedinger_imex(IMEX_Laplacian_MPIFFT):
         def nls_exact_1D(t, x, c):
             ae = 1.0 / np.sqrt(2.0) * np.exp(1j * t)
             if c != 0:
-                u = ae * ((np.cosh(t) + 1j * np.sinh(t)) / (np.cosh(t) - 1.0 / np.sqrt(2.0) * np.cos(x)) - 1.0)
+                u = ae * ((np.cosh(t) + 1j * np.sinh(t)) / (np.cosh(t) - 1.0 / np.sqrt(2.0) * self.xp.cos(x)) - 1.0)
             else:
-                u = np.sin(x) * np.exp(-t * 1j)
+                u = self.xp.sin(x) * np.exp(-t * 1j)
 
             return u
 
@@ -146,13 +146,13 @@ class nonlinearschroedinger_fully_implicit(nonlinearschroedinger_imex):
 
         if self.spectral:
             tmp = self.fft.backward(u)
-            tmpf = self.ndim * self.c * 2j * np.absolute(tmp) ** 2 * tmp
+            tmpf = self.ndim * self.c * 2j * self.xp.absolute(tmp) ** 2 * tmp
             f[:] = -self.K2 * 1j * u + self.fft.forward(tmpf)
 
         else:
             u_hat = self.fft.forward(u)
             lap_u_hat = -self.K2 * 1j * u_hat
-            f[:] = self.fft.backward(lap_u_hat) + self.ndim * self.c * 2j * np.absolute(u) ** 2 * u
+            f[:] = self.fft.backward(lap_u_hat) + self.ndim * self.c * 2j * self.xp.absolute(u) ** 2 * u
 
         self.work_counters['rhs']()
         return f

--- a/pySDC/implementations/problem_classes/NonlinearSchroedinger_MPIFFT.py
+++ b/pySDC/implementations/problem_classes/NonlinearSchroedinger_MPIFFT.py
@@ -4,8 +4,8 @@ from scipy.optimize.nonlin import NoConvergence
 
 from pySDC.core.Errors import ProblemError
 from pySDC.core.Problem import WorkCounter
-from pySDC.implementations.datatype_classes.mesh import mesh, imex_mesh
 from pySDC.implementations.problem_classes.generic_MPIFFT_Laplacian import IMEX_Laplacian_MPIFFT
+from pySDC.implementations.datatype_classes.mesh import mesh
 
 
 class nonlinearschroedinger_imex(IMEX_Laplacian_MPIFFT):
@@ -46,9 +46,6 @@ class nonlinearschroedinger_imex(IMEX_Laplacian_MPIFFT):
     .. [1] Lisandro Dalcin, Mikael Mortensen, David E. Keyes. Fast parallel multidimensional FFT using advanced MPI.
         Journal of Parallel and Distributed Computing (2019).
     """
-
-    dtype_u = mesh
-    dtype_f = imex_mesh
 
     def __init__(self, c=1.0, **kwargs):
         """Initialization routine"""

--- a/pySDC/implementations/problem_classes/NonlinearSchroedinger_MPIFFT.py
+++ b/pySDC/implementations/problem_classes/NonlinearSchroedinger_MPIFFT.py
@@ -1,16 +1,11 @@
 import numpy as np
-from scipy.optimize import newton_krylov, root
+from scipy.optimize import newton_krylov
 from scipy.optimize.nonlin import NoConvergence
-import scipy.sparse as sp
-from mpi4py import MPI
-from mpi4py_fft import PFFT
 
 from pySDC.core.Errors import ProblemError
-from pySDC.core.Problem import ptype, WorkCounter
+from pySDC.core.Problem import WorkCounter
 from pySDC.implementations.datatype_classes.mesh import mesh, imex_mesh
 from pySDC.implementations.problem_classes.generic_MPIFFT_Laplacian import IMEX_Laplacian_MPIFFT
-
-from mpi4py_fft import newDistArray
 
 
 class nonlinearschroedinger_imex(IMEX_Laplacian_MPIFFT):

--- a/pySDC/implementations/problem_classes/NonlinearSchroedinger_MPIFFT.py
+++ b/pySDC/implementations/problem_classes/NonlinearSchroedinger_MPIFFT.py
@@ -8,11 +8,12 @@ from mpi4py_fft import PFFT
 from pySDC.core.Errors import ProblemError
 from pySDC.core.Problem import ptype, WorkCounter
 from pySDC.implementations.datatype_classes.mesh import mesh, imex_mesh
+from pySDC.implementations.problem_classes.generic_MPIFFT_Laplacian import IMEX_Laplacian_MPIFFT
 
 from mpi4py_fft import newDistArray
 
 
-class nonlinearschroedinger_imex(ptype):
+class nonlinearschroedinger_imex(IMEX_Laplacian_MPIFFT):
     r"""
     Example implementing the :math:`N`-dimensional nonlinear Schrödinger equation with periodic boundary conditions
 
@@ -54,127 +55,16 @@ class nonlinearschroedinger_imex(ptype):
     dtype_u = mesh
     dtype_f = imex_mesh
 
-    def __init__(self, nvars=None, spectral=False, L=2 * np.pi, c=1.0, comm=MPI.COMM_WORLD):
+    def __init__(self, c=1.0, **kwargs):
         """Initialization routine"""
-
-        if nvars is None:
-            nvars = (128, 128)
-
-        if not L == 2.0 * np.pi:
-            raise ProblemError(f'Setup not implemented, L has to be 2pi, got {L}')
+        super().__init__(L=2 * np.pi, alpha=1j, dtype='D', **kwargs)
 
         if not (c == 0.0 or c == 1.0):
             raise ProblemError(f'Setup not implemented, c has to be 0 or 1, got {c}')
+        self._makeAttributeAndRegister('c', localVars=locals(), readOnly=True)
 
-        if not (isinstance(nvars, tuple) and len(nvars) > 1):
-            raise ProblemError('Need at least two dimensions')
-
-        # Creating FFT structure
-        self.ndim = len(nvars)
-        axes = tuple(range(self.ndim))
-        self.fft = PFFT(comm, list(nvars), axes=axes, dtype=np.complex128, collapse=True)
-
-        # get test data to figure out type and dimensions
-        tmp_u = newDistArray(self.fft, spectral)
-
-        L = np.array([L] * self.ndim, dtype=float)
-
-        # invoke super init, passing the communicator and the local dimensions as init
-        super(nonlinearschroedinger_imex, self).__init__(init=(tmp_u.shape, comm, tmp_u.dtype))
-        self._makeAttributeAndRegister('nvars', 'spectral', 'L', 'c', 'comm', localVars=locals(), readOnly=True)
-
-        # get local mesh
-        X = np.ogrid[self.fft.local_slice(False)]
-        N = self.fft.global_shape()
-        for i in range(len(N)):
-            X[i] = X[i] * self.L[i] / N[i]
-        self.X = [np.broadcast_to(x, self.fft.shape(False)) for x in X]
-
-        # get local wavenumbers and Laplace operator
-        s = self.fft.local_slice()
-        N = self.fft.global_shape()
-        k = [np.fft.fftfreq(n, 1.0 / n).astype(int) for n in N]
-        K = [ki[si] for ki, si in zip(k, s)]
-        Ks = np.meshgrid(*K, indexing='ij', sparse=True)
-        Lp = 2 * np.pi / self.L
-        for i in range(self.ndim):
-            Ks[i] = (Ks[i] * Lp[i]).astype(float)
-        K = [np.broadcast_to(k, self.fft.shape(True)) for k in Ks]
-        K = np.array(K).astype(float)
-        self.K2 = np.sum(K * K, 0, dtype=float)
-
-        # Need this for diagnostics
-        self.dx = self.L / nvars[0]
-        self.dy = self.L / nvars[1]
-
-        # work counters
-        self.work_counters['rhs'] = WorkCounter()
-
-    def eval_f(self, u, t):
-        """
-        Routine to evaluate the right-hand side of the problem.
-
-        Parameters
-        ----------
-        u : dtype_u
-            Current values of the numerical solution.
-        t : float
-            Current time at which the numerical solution is computed.
-
-        Returns
-        -------
-        f : dtype_f
-            The right-hand side of the problem.
-        """
-
-        f = self.dtype_f(self.init)
-
-        if self.spectral:
-            f.impl = -self.K2 * 1j * u
-            tmp = self.fft.backward(u)
-            tmpf = self.ndim * self.c * 2j * np.absolute(tmp) ** 2 * tmp
-            f.expl[:] = self.fft.forward(tmpf)
-
-        else:
-            u_hat = self.fft.forward(u)
-            lap_u_hat = -self.K2 * 1j * u_hat
-            f.impl[:] = self.fft.backward(lap_u_hat, f.impl)
-            f.expl = self.ndim * self.c * 2j * np.absolute(u) ** 2 * u
-
-        self.work_counters['rhs']()
-        return f
-
-    def solve_system(self, rhs, factor, u0, t):
-        """
-        Simple FFT solver for the diffusion part.
-
-        Parameters
-        ----------
-        rhs : dtype_f
-            Right-hand side for the linear system.
-        factor : float
-            Abbrev. for the node-to-node stepsize (or any other factor required).
-        u0 : dtype_u
-            Initial guess for the iterative solver (not used here so far).
-        t : float
-            Current time (e.g. for time-dependent BCs).
-
-        Returns
-        -------
-        me : dtype_u
-            The solution as mesh.
-        """
-
-        if self.spectral:
-            me = rhs / (1.0 + factor * self.K2 * 1j)
-
-        else:
-            me = self.dtype_u(self.init)
-            rhs_hat = self.fft.forward(rhs)
-            rhs_hat /= 1.0 + factor * self.K2 * 1j
-            me[:] = self.fft.backward(rhs_hat)
-
-        return me
+    def _eval_explicit_part(self, u, t, f_expl):
+        return self.ndim * self.c * 2j * np.absolute(u) ** 2 * u
 
     def u_exact(self, t, **kwargs):
         r"""

--- a/pySDC/implementations/problem_classes/generic_MPIFFT_Laplacian.py
+++ b/pySDC/implementations/problem_classes/generic_MPIFFT_Laplacian.py
@@ -91,8 +91,8 @@ class IMEX_Laplacian_MPIFFT(ptype):
         self.K2 = self.xp.sum(K * K, 0, dtype=float)  # Laplacian in spectral space
 
         # Need this for diagnostics
-        self.dx = self.L / nvars[0]
-        self.dy = self.L / nvars[1]
+        self.dx = self.L[0] / nvars[0]
+        self.dy = self.L[1] / nvars[1]
 
         # work counters
         self.work_counters['rhs'] = WorkCounter()
@@ -120,8 +120,8 @@ class IMEX_Laplacian_MPIFFT(ptype):
 
         if self.spectral:
             tmp = self.fft.backward(u)
-            tmpf = self._eval_explicit_part(tmp, t, tmp)
-            f.expl[:] = self.fft.forward(tmpf)
+            tmp[:] = self._eval_explicit_part(tmp, t, tmp)
+            f.expl[:] = self.fft.forward(tmp)
 
         else:
             f.expl[:] = self._eval_explicit_part(u, t, f.expl)

--- a/pySDC/implementations/problem_classes/generic_MPIFFT_Laplacian.py
+++ b/pySDC/implementations/problem_classes/generic_MPIFFT_Laplacian.py
@@ -1,0 +1,175 @@
+import numpy as np
+from mpi4py import MPI
+from mpi4py_fft import PFFT
+
+from pySDC.core.Errors import ProblemError
+from pySDC.core.Problem import ptype, WorkCounter
+from pySDC.implementations.datatype_classes.mesh import mesh, imex_mesh
+
+from mpi4py_fft import newDistArray
+
+
+class IMEX_Laplacian_MPIFFT(ptype):
+    r"""
+    Generic base class for IMEX problems using a spectral method to solve the Laplacian implicitly and a possible rest
+    explicitly. The FFTs are done with``mpi4py-fft`` [1]_.
+
+    Parameters
+    ----------
+    nvars : tuple, optional
+        Spatial resolution
+    spectral : bool, optional
+        If True, the solution is computed in spectral space.
+    L : float, optional
+        Denotes the period of the function to be approximated for the Fourier transform.
+    alpha : float, optional
+        Multiplicative factor before the Laplacian
+    comm : MPI.COMM_World
+        Communicator for parallelisation.
+
+    Attributes
+    ----------
+    fft : PFFT
+        Object for parallel FFT transforms.
+    X : mesh-grid
+        Grid coordinates in real space.
+    K2 : matrix
+        Laplace operator in spectral space.
+
+    References
+    ----------
+    .. [1] Lisandro Dalcin, Mikael Mortensen, David E. Keyes. Fast parallel multidimensional FFT using advanced MPI.
+        Journal of Parallel and Distributed Computing (2019).
+    """
+
+    dtype_u = mesh
+    dtype_f = imex_mesh
+
+    def __init__(self, nvars=None, spectral=False, L=2 * np.pi, alpha=1.0, comm=MPI.COMM_WORLD, dtype='d'):
+        """Initialization routine"""
+
+        if nvars is None:
+            nvars = (128, 128)
+
+        if not (isinstance(nvars, tuple) and len(nvars) > 1):
+            raise ProblemError('Need at least two dimensions for distributed FFTs')
+
+        # Creating FFT structure
+        self.ndim = len(nvars)
+        axes = tuple(range(self.ndim))
+        self.fft = PFFT(comm, list(nvars), axes=axes, dtype=dtype, collapse=True)
+
+        # get test data to figure out type and dimensions
+        tmp_u = newDistArray(self.fft, spectral)
+
+        L = np.array([L] * self.ndim, dtype=float)
+
+        # invoke super init, passing the communicator and the local dimensions as init
+        super().__init__(init=(tmp_u.shape, comm, tmp_u.dtype))
+        self._makeAttributeAndRegister('nvars', 'spectral', 'L', 'alpha', 'comm', localVars=locals(), readOnly=True)
+
+        # get local mesh
+        X = np.ogrid[self.fft.local_slice(False)]
+        N = self.fft.global_shape()
+        for i in range(len(N)):
+            X[i] = X[i] * self.L[i] / N[i]
+        self.X = [np.broadcast_to(x, self.fft.shape(False)) for x in X]
+
+        # get local wavenumbers and Laplace operator
+        s = self.fft.local_slice()
+        N = self.fft.global_shape()
+        k = [np.fft.fftfreq(n, 1.0 / n).astype(int) for n in N]
+        K = [ki[si] for ki, si in zip(k, s)]
+        Ks = np.meshgrid(*K, indexing='ij', sparse=True)
+        Lp = 2 * np.pi / self.L
+        for i in range(self.ndim):
+            Ks[i] = (Ks[i] * Lp[i]).astype(float)
+        K = [np.broadcast_to(k, self.fft.shape(True)) for k in Ks]
+        K = np.array(K).astype(float)
+        self.K2 = np.sum(K * K, 0, dtype=float)  # Laplacian in spectral space
+
+        # Need this for diagnostics
+        self.dx = self.L / nvars[0]
+        self.dy = self.L / nvars[1]
+
+        # work counters
+        self.work_counters['rhs'] = WorkCounter()
+
+    def eval_f(self, u, t):
+        """
+        Routine to evaluate the right-hand side of the problem.
+
+        Parameters
+        ----------
+        u : dtype_u
+            Current values of the numerical solution.
+        t : float
+            Current time at which the numerical solution is computed.
+
+        Returns
+        -------
+        f : dtype_f
+            The right-hand side of the problem.
+        """
+
+        f = self.dtype_f(self.init)
+
+        f.impl[:] = self._eval_Laplacian(u, f.impl)
+
+        if self.spectral:
+            tmp = self.fft.backward(u)
+            tmpf = self._eval_explicit_part(u, tmp)
+            f.expl[:] = self.fft.forward(tmpf)
+
+        else:
+            f.expl[:] = self._eval_explicit_part(u, t, f.expl)
+
+        self.work_counters['rhs']()
+        return f
+
+    def _eval_Laplacian(self, u, f_impl):
+        if self.spectral:
+            f_impl[:] = -self.alpha * self.K2 * u
+        else:
+            u_hat = self.fft.forward(u)
+            lap_u_hat = -self.alpha * self.K2 * u_hat
+            f_impl[:] = self.fft.backward(lap_u_hat, f_impl)
+        return f_impl
+
+    def _eval_explicit_part(self, u, t, f_expl):
+        return f_expl
+
+    def solve_system(self, rhs, factor, u0, t):
+        """
+        Simple FFT solver for the diffusion part.
+
+        Parameters
+        ----------
+        rhs : dtype_f
+            Right-hand side for the linear system.
+        factor : float
+            Abbrev. for the node-to-node stepsize (or any other factor required).
+        u0 : dtype_u
+            Initial guess for the iterative solver (not used here so far).
+        t : float
+            Current time (e.g. for time-dependent BCs).
+
+        Returns
+        -------
+        me : dtype_u
+            The solution as mesh.
+        """
+        me = self.dtype_u(self.init)
+        me[:] = self._invert_Laplacian(me, factor, rhs)
+
+        return me
+
+    def _invert_Laplacian(self, me, factor, rhs):
+        if self.spectral:
+            me[:] = rhs / (1.0 + factor * self.alpha * self.K2)
+
+        else:
+            rhs_hat = self.fft.forward(rhs)
+            rhs_hat /= 1.0 + factor * self.alpha * self.K2
+            me[:] = self.fft.backward(rhs_hat)
+        return me

--- a/pySDC/implementations/problem_classes/generic_MPIFFT_Laplacian.py
+++ b/pySDC/implementations/problem_classes/generic_MPIFFT_Laplacian.py
@@ -120,7 +120,7 @@ class IMEX_Laplacian_MPIFFT(ptype):
 
         if self.spectral:
             tmp = self.fft.backward(u)
-            tmpf = self._eval_explicit_part(u, tmp)
+            tmpf = self._eval_explicit_part(tmp, t, tmp)
             f.expl[:] = self.fft.forward(tmpf)
 
         else:

--- a/pySDC/tests/test_projects/test_AC/test_simple_forcing.py
+++ b/pySDC/tests/test_projects/test_AC/test_simple_forcing.py
@@ -5,10 +5,18 @@ import warnings
 
 
 @pytest.mark.mpi4py
-def test_main_serial():
-    from pySDC.projects.AllenCahn_Bayreuth.run_simple_forcing_verification import main, visualize_radii
+@pytest.mark.parametrize('spectral', [True, False])
+@pytest.mark.parametrize('name', ['AC-test-noforce', 'AC-test-constforce', 'AC-test-timeforce'])
+def test_main_serial(name, spectral):
+    from pySDC.projects.AllenCahn_Bayreuth.run_simple_forcing_verification import run_simulation
 
-    main()
+    run_simulation(name=name, spectral=spectral, nprocs_space=None)
+
+
+@pytest.mark.mpi4py
+def test_visualize_radii():
+    from pySDC.projects.AllenCahn_Bayreuth.run_simple_forcing_verification import visualize_radii
+
     visualize_radii()
 
 


### PR DESCRIPTION
Since the setup of the Laplacian using distributed FFTs is non-obvious and leads to a bunch of repeated code in various files, I want to setup base class for this. I have so far only ported two problem classes to this to make it easier for me to respond to feedback.

Importantly, this will allow me to port all classes derived from the base class to GPU, simply by changing the base class. I already include the `xp` class attribute for this. However, I stopped there because I need to pass NCCL as the communication backend to mpi4py-fft, which is not supported by the current API.
The plan is to merge this generic class into the main pySDC branch and then port to GPU in a separate branch that uses functionality of mpi4py-fft that is not out yet. If we get the CuPy tests to work, a possible option would be to clone my fork of mpi4py-fft and install that in the CI pipeline to get the tests going, which would allow to merge back to master.
