### PR TITLE
Ported Gray-Scott to generic MPI FFT

### DIFF
--- a/pySDC/implementations/problem_classes/GrayScott_MPIFFT.py
+++ b/pySDC/implementations/problem_classes/GrayScott_MPIFFT.py
@@ -4,13 +4,14 @@ from mpi4py import MPI
 from mpi4py_fft import PFFT
 
 from pySDC.core.Errors import ProblemError
-from pySDC.core.Problem import ptype
+from pySDC.core.Problem import ptype, WorkCounter
 from pySDC.implementations.datatype_classes.mesh import mesh, imex_mesh, comp2_mesh
+from pySDC.implementations.problem_classes.generic_MPIFFT_Laplacian import IMEX_Laplacian_MPIFFT
 
 from mpi4py_fft import newDistArray
 
 
-class grayscott_imex_diffusion(ptype):
+class grayscott_imex_diffusion(IMEX_Laplacian_MPIFFT):
     r"""
     The Gray-Scott system [1]_ describes a reaction-diffusion process of two substances :math:`u` and :math:`v`,
     where they diffuse over time. During the reaction :math:`u` is used up with overall decay rate :math:`B`,
@@ -71,68 +72,17 @@ class grayscott_imex_diffusion(ptype):
     .. [3] https://www.chebfun.org/examples/pde/GrayScott.html
     """
 
-    dtype_u = mesh
-    dtype_f = imex_mesh
+    def __init__(self, Du=1.0, Dv=0.01, A=0.09, B=0.086, **kwargs):
+        kwargs['L'] = 2.0
+        super().__init__(dtype='d', alpha=1.0, x0=-kwargs['L'] / 2.0, **kwargs)
 
-    def __init__(self, nvars=None, Du=1.0, Dv=0.01, A=0.09, B=0.086, spectral=None, L=2.0, comm=MPI.COMM_WORLD):
-        """Initialization routine"""
-        nvars = (127, 127) if nvars is None else nvars
-        if not (isinstance(nvars, tuple) and len(nvars) > 1):
-            raise ProblemError('Need at least two dimensions')
+        # prepare the array with two components
+        shape = (2,) + (self.init[0])
+        self.iU = 0
+        self.iV = 1
+        self.init = (shape, self.comm, np.dtype('float'))
 
-        # Creating FFT structure
-        self.ndim = len(nvars)
-        axes = tuple(range(self.ndim))
-        self.fft = PFFT(
-            comm,
-            list(nvars),
-            axes=axes,
-            dtype=np.float64,
-            collapse=True,
-            backend='fftw',
-        )
-
-        # get test data to figure out type and dimensions
-        tmp_u = newDistArray(self.fft, spectral)
-
-        # add two components to contain field and temperature
-        self.ncomp = 2
-        sizes = tmp_u.shape + (self.ncomp,)
-
-        # invoke super init, passing the communicator and the local dimensions as init
-        super().__init__(init=(sizes, comm, tmp_u.dtype))
-        self._makeAttributeAndRegister(
-            'nvars', 'Du', 'Dv', 'A', 'B', 'spectral', 'L', 'comm', localVars=locals(), readOnly=True
-        )
-
-        L = np.array([self.L] * self.ndim, dtype=float)
-
-        # get local mesh
-        X = np.ogrid[self.fft.local_slice(False)]
-        N = self.fft.global_shape()
-        for i in range(len(N)):
-            X[i] = -L[i] / 2 + (X[i] * L[i] / N[i])
-        self.X = [np.broadcast_to(x, self.fft.shape(False)) for x in X]
-
-        # get local wavenumbers and Laplace operator
-        s = self.fft.local_slice()
-        N = self.fft.global_shape()
-        k = [np.fft.fftfreq(n, 1.0 / n).astype(int) for n in N[:-1]]
-        k.append(np.fft.rfftfreq(N[-1], 1.0 / N[-1]).astype(int))
-        K = [ki[si] for ki, si in zip(k, s)]
-        Ks = np.meshgrid(*K, indexing='ij', sparse=True)
-        Lp = 2 * np.pi / L
-        for i in range(self.ndim):
-            Ks[i] = (Ks[i] * Lp[i]).astype(float)
-        K = [np.broadcast_to(k, self.fft.shape(True)) for k in Ks]
-        K = np.array(K).astype(float)
-        self.K2 = np.sum(K * K, 0, dtype=float)
-        self.Ku = -self.K2 * self.Du
-        self.Kv = -self.K2 * self.Dv
-
-        # Need this for diagnostics
-        self.dx = self.L / nvars[0]
-        self.dy = self.L / nvars[1]
+        self._makeAttributeAndRegister('Du', 'Dv', 'A', 'B', localVars=locals(), readOnly=True)
 
     def eval_f(self, u, t):
         """
@@ -153,28 +103,36 @@ class grayscott_imex_diffusion(ptype):
 
         f = self.dtype_f(self.init)
 
+        for i, alpha in zip([self.iU, self.iV], [self.Du, self.Dv]):
+            f.impl[i, ...] = self._eval_Laplacian(u[i], f.impl[i], alpha=alpha)
+
         if self.spectral:
-            f.impl[..., 0] = self.Ku * u[..., 0]
-            f.impl[..., 1] = self.Kv * u[..., 1]
             tmpu = newDistArray(self.fft, False)
             tmpv = newDistArray(self.fft, False)
-            tmpu[:] = self.fft.backward(u[..., 0], tmpu)
-            tmpv[:] = self.fft.backward(u[..., 1], tmpv)
-            tmpfu = -tmpu * tmpv**2 + self.A * (1 - tmpu)
-            tmpfv = tmpu * tmpv**2 - self.B * tmpv
-            f.expl[..., 0] = self.fft.forward(tmpfu)
-            f.expl[..., 1] = self.fft.forward(tmpfv)
+            tmpu[:] = self.fft.backward(u[0, ...], tmpu)
+            tmpv[:] = self.fft.backward(u[1, ...], tmpv)
+            _u = [tmpu, tmpv]
+            tmpu[:] = self._eval_explicit_part_u(_u, t, tmpu)
+            tmpv[:] = self._eval_explicit_part_v(_u, t, tmpv)
+
+            f.expl[0, ...] = self.fft.forward(tmpu)
+            f.expl[1, ...] = self.fft.forward(tmpv)
 
         else:
-            u_hat = self.fft.forward(u[..., 0])
-            lap_u_hat = self.Ku * u_hat
-            f.impl[..., 0] = self.fft.backward(lap_u_hat, f.impl[..., 0])
-            u_hat = self.fft.forward(u[..., 1])
-            lap_u_hat = self.Kv * u_hat
-            f.impl[..., 1] = self.fft.backward(lap_u_hat, f.impl[..., 1])
-            f.expl[..., 0] = -u[..., 0] * u[..., 1] ** 2 + self.A * (1 - u[..., 0])
-            f.expl[..., 1] = u[..., 0] * u[..., 1] ** 2 - self.B * u[..., 1]
+            f.expl[self.iU] = self._eval_explicit_part_u(u, t, f.expl[self.iU])
+            f.expl[self.iV] = self._eval_explicit_part_v(u, t, f.expl[self.iV])
 
+        self.work_counters['rhs']()
+        return f
+
+    def _eval_explicit_part_u(self, u, t, f):
+        iU, iV = self.iU, self.iV
+        f[:] = -u[iU] * u[iV] ** 2 + self.A * (1 - u[self.iU])
+        return f
+
+    def _eval_explicit_part_v(self, u, t, f):
+        iU, iV = self.iU, self.iV
+        f[:] = u[iU] * u[iV] ** 2 - self.B * u[self.iV]
         return f
 
     def solve_system(self, rhs, factor, u0, t):
@@ -199,17 +157,9 @@ class grayscott_imex_diffusion(ptype):
         """
 
         me = self.dtype_u(self.init)
-        if self.spectral:
-            me[..., 0] = rhs[..., 0] / (1.0 - factor * self.Ku)
-            me[..., 1] = rhs[..., 1] / (1.0 - factor * self.Kv)
 
-        else:
-            rhs_hat = self.fft.forward(rhs[..., 0])
-            rhs_hat /= 1.0 - factor * self.Ku
-            me[..., 0] = self.fft.backward(rhs_hat, me[..., 0])
-            rhs_hat = self.fft.forward(rhs[..., 1])
-            rhs_hat /= 1.0 - factor * self.Kv
-            me[..., 1] = self.fft.backward(rhs_hat, me[..., 1])
+        for i, alpha in zip([self.iU, self.iV], [self.Du, self.Dv]):
+            me[i, ...] = self._invert_Laplacian(me[i], factor, rhs[i], alpha=alpha)
 
         return me
 
@@ -235,18 +185,12 @@ class grayscott_imex_diffusion(ptype):
         # This assumes that the box is [-L/2, L/2]^2
         if self.spectral:
             tmp = 1.0 - np.exp(-80.0 * ((self.X[0] + 0.05) ** 2 + (self.X[1] + 0.02) ** 2))
-            me[..., 0] = self.fft.forward(tmp)
+            me[0, ...] = self.fft.forward(tmp)
             tmp = np.exp(-80.0 * ((self.X[0] - 0.05) ** 2 + (self.X[1] - 0.02) ** 2))
-            me[..., 1] = self.fft.forward(tmp)
+            me[1, ...] = self.fft.forward(tmp)
         else:
-            me[..., 0] = 1.0 - np.exp(-80.0 * ((self.X[0] + 0.05) ** 2 + (self.X[1] + 0.02) ** 2))
-            me[..., 1] = np.exp(-80.0 * ((self.X[0] - 0.05) ** 2 + (self.X[1] - 0.02) ** 2))
-
-        # tmpu = np.load('data/u_0001.npy')
-        # tmpv = np.load('data/v_0001.npy')
-        #
-        # me[..., 0] = self.fft.forward(tmpu)
-        # me[..., 1] = self.fft.forward(tmpv)
+            me[0, ...] = 1.0 - np.exp(-80.0 * ((self.X[0] + 0.05) ** 2 + (self.X[1] + 0.02) ** 2))
+            me[1, ...] = np.exp(-80.0 * ((self.X[0] - 0.05) ** 2 + (self.X[1] - 0.02) ** 2))
 
         return me
 
@@ -272,12 +216,34 @@ class grayscott_imex_linear(grayscott_imex_diffusion):
     part is computed in an explicit way).
     """
 
-    def __init__(self, nvars=None, Du=1.0, Dv=0.01, A=0.09, B=0.086, spectral=None, L=2.0, comm=MPI.COMM_WORLD):
-        """Initialization routine"""
-        nvars = (127, 127) if nvars is None else nvars
-        super().__init__(nvars, Du, Dv, A, B, spectral, L, comm)
-        self.Ku -= self.A
-        self.Kv -= self.B
+    def _eval_Laplacian(self, u, f_impl, alpha=None, A=0.0):
+        alpha = alpha if alpha else self.alpha
+        if self.spectral:
+            f_impl[:] = (-alpha * self.K2 - A) * u
+        else:
+            u_hat = self.fft.forward(u)
+            lap_u_hat = (-alpha * self.K2 - A) * u_hat
+            f_impl[:] = self.fft.backward(lap_u_hat, f_impl)
+        return f_impl
+
+    def _invert_Laplacian(self, me, factor, rhs, alpha=None, A=0.0):
+        if self.spectral:
+            me[:] = rhs / (1.0 + factor * (alpha * self.K2 + A))
+
+        else:
+            rhs_hat = self.fft.forward(rhs)
+            rhs_hat /= 1.0 + factor * (alpha * self.K2 + A)
+            me[:] = self.fft.backward(rhs_hat)
+        return me
+
+    def solve_system(self, rhs, factor, u0, t):
+
+        me = self.dtype_u(self.init)
+
+        for i, alpha, A in zip([self.iU, self.iV], [self.Du, self.Dv], [self.A, self.B]):
+            me[i, ...] = self._invert_Laplacian(me[i], factor, rhs[i], alpha=alpha, A=A)
+
+        return me
 
     def eval_f(self, u, t):
         """
@@ -298,28 +264,36 @@ class grayscott_imex_linear(grayscott_imex_diffusion):
 
         f = self.dtype_f(self.init)
 
+        for i, alpha, A in zip([self.iU, self.iV], [self.Du, self.Dv], [self.A, self.B]):
+            f.impl[i, ...] = self._eval_Laplacian(u[i], f.impl[i], alpha=alpha, A=A)
+
         if self.spectral:
-            f.impl[..., 0] = self.Ku * u[..., 0]
-            f.impl[..., 1] = self.Kv * u[..., 1]
             tmpu = newDistArray(self.fft, False)
             tmpv = newDistArray(self.fft, False)
-            tmpu[:] = self.fft.backward(u[..., 0], tmpu)
-            tmpv[:] = self.fft.backward(u[..., 1], tmpv)
-            tmpfu = -tmpu * tmpv**2 + self.A
-            tmpfv = tmpu * tmpv**2
-            f.expl[..., 0] = self.fft.forward(tmpfu)
-            f.expl[..., 1] = self.fft.forward(tmpfv)
+            tmpu[:] = self.fft.backward(u[0, ...], tmpu)
+            tmpv[:] = self.fft.backward(u[1, ...], tmpv)
+            _u = [tmpu, tmpv]
+            tmpu[:] = self._eval_explicit_part_u(_u, t, tmpu)
+            tmpv[:] = self._eval_explicit_part_v(_u, t, tmpv)
+
+            f.expl[self.iU, ...] = self.fft.forward(tmpu)
+            f.expl[self.iV, ...] = self.fft.forward(tmpv)
 
         else:
-            u_hat = self.fft.forward(u[..., 0])
-            lap_u_hat = self.Ku * u_hat
-            f.impl[..., 0] = self.fft.backward(lap_u_hat, f.impl[..., 0])
-            u_hat = self.fft.forward(u[..., 1])
-            lap_u_hat = self.Kv * u_hat
-            f.impl[..., 1] = self.fft.backward(lap_u_hat, f.impl[..., 1])
-            f.expl[..., 0] = -u[..., 0] * u[..., 1] ** 2 + self.A
-            f.expl[..., 1] = u[..., 0] * u[..., 1] ** 2
+            f.expl[self.iU] = self._eval_explicit_part_u(u, t, f.expl[self.iU])
+            f.expl[self.iV] = self._eval_explicit_part_v(u, t, f.expl[self.iV])
 
+        self.work_counters['rhs']()
+        return f
+
+    def _eval_explicit_part_u(self, u, t, f):
+        iU, iV = self.iU, self.iV
+        f[:] = -u[iU] * u[iV] ** 2 + self.A
+        return f
+
+    def _eval_explicit_part_v(self, u, t, f):
+        iU, iV = self.iU, self.iV
+        f[:] = u[iU] * u[iV] ** 2
         return f
 
 
@@ -387,22 +361,18 @@ class grayscott_mi_diffusion(grayscott_imex_diffusion):
 
     def __init__(
         self,
-        nvars=None,
-        Du=1.0,
-        Dv=0.01,
-        A=0.09,
-        B=0.086,
-        spectral=None,
         newton_maxiter=100,
         newton_tol=1e-12,
-        L=2.0,
-        comm=MPI.COMM_WORLD,
+        **kwargs,
     ):
         """Initialization routine"""
-        nvars = (127, 127) if nvars is None else nvars
-        super().__init__(nvars, Du, Dv, A, B, spectral, L, comm)
+        super().__init__(**kwargs)
         # This may not run in parallel yet..
         assert self.comm.Get_size() == 1
+        self.work_counters['newton'] = WorkCounter()
+        self.Ku = -self.Du * self.K2
+        self.Kv = -self.Dv * self.K2
+        self._makeAttributeAndRegister('newton_maxiter', 'newton_tol', localVars=locals(), readOnly=False)
 
     def eval_f(self, u, t):
         """
@@ -424,27 +394,28 @@ class grayscott_mi_diffusion(grayscott_imex_diffusion):
         f = self.dtype_f(self.init)
 
         if self.spectral:
-            f.comp1[..., 0] = self.Ku * u[..., 0]
-            f.comp1[..., 1] = self.Kv * u[..., 1]
+            f.comp1[0, ...] = self.Ku * u[0, ...]
+            f.comp1[1, ...] = self.Kv * u[1, ...]
             tmpu = newDistArray(self.fft, False)
             tmpv = newDistArray(self.fft, False)
-            tmpu[:] = self.fft.backward(u[..., 0], tmpu)
-            tmpv[:] = self.fft.backward(u[..., 1], tmpv)
+            tmpu[:] = self.fft.backward(u[0, ...], tmpu)
+            tmpv[:] = self.fft.backward(u[1, ...], tmpv)
             tmpfu = -tmpu * tmpv**2 + self.A * (1 - tmpu)
             tmpfv = tmpu * tmpv**2 - self.B * tmpv
-            f.comp2[..., 0] = self.fft.forward(tmpfu)
-            f.comp2[..., 1] = self.fft.forward(tmpfv)
+            f.comp2[0, ...] = self.fft.forward(tmpfu)
+            f.comp2[1, ...] = self.fft.forward(tmpfv)
 
         else:
-            u_hat = self.fft.forward(u[..., 0])
+            u_hat = self.fft.forward(u[0, ...])
             lap_u_hat = self.Ku * u_hat
-            f.comp1[..., 0] = self.fft.backward(lap_u_hat, f.comp1[..., 0])
-            u_hat = self.fft.forward(u[..., 1])
+            f.comp1[0, ...] = self.fft.backward(lap_u_hat, f.comp1[0, ...])
+            u_hat = self.fft.forward(u[1, ...])
             lap_u_hat = self.Kv * u_hat
-            f.comp1[..., 1] = self.fft.backward(lap_u_hat, f.comp1[..., 1])
-            f.comp2[..., 0] = -u[..., 0] * u[..., 1] ** 2 + self.A * (1 - u[..., 0])
-            f.comp2[..., 1] = u[..., 0] * u[..., 1] ** 2 - self.B * u[..., 1]
+            f.comp1[1, ...] = self.fft.backward(lap_u_hat, f.comp1[1, ...])
+            f.comp2[0, ...] = -u[0, ...] * u[1, ...] ** 2 + self.A * (1 - u[0, ...])
+            f.comp2[1, ...] = u[0, ...] * u[1, ...] ** 2 - self.B * u[1, ...]
 
+        self.work_counters['rhs']()
         return f
 
     def solve_system_1(self, rhs, factor, u0, t):
@@ -468,7 +439,7 @@ class grayscott_mi_diffusion(grayscott_imex_diffusion):
             The solution as mesh.
         """
 
-        me = super(grayscott_mi_diffusion, self).solve_system(rhs, factor, u0, t)
+        me = super().solve_system(rhs, factor, u0, t)
         return me
 
     def solve_system_2(self, rhs, factor, u0, t):
@@ -496,18 +467,18 @@ class grayscott_mi_diffusion(grayscott_imex_diffusion):
         if self.spectral:
             tmpu = newDistArray(self.fft, False)
             tmpv = newDistArray(self.fft, False)
-            tmpu[:] = self.fft.backward(u[..., 0], tmpu)
-            tmpv[:] = self.fft.backward(u[..., 1], tmpv)
+            tmpu[:] = self.fft.backward(u[0, ...], tmpu)
+            tmpv[:] = self.fft.backward(u[1, ...], tmpv)
             tmprhsu = newDistArray(self.fft, False)
             tmprhsv = newDistArray(self.fft, False)
-            tmprhsu[:] = self.fft.backward(rhs[..., 0], tmprhsu)
-            tmprhsv[:] = self.fft.backward(rhs[..., 1], tmprhsv)
+            tmprhsu[:] = self.fft.backward(rhs[0, ...], tmprhsu)
+            tmprhsv[:] = self.fft.backward(rhs[1, ...], tmprhsv)
 
         else:
-            tmpu = u[..., 0]
-            tmpv = u[..., 1]
-            tmprhsu = rhs[..., 0]
-            tmprhsv = rhs[..., 1]
+            tmpu = u[0, ...]
+            tmpv = u[1, ...]
+            tmprhsu = rhs[0, ...]
+            tmprhsv = rhs[1, ...]
 
         # start newton iteration
         n = 0
@@ -549,6 +520,7 @@ class grayscott_mi_diffusion(grayscott_imex_diffusion):
 
             # increase iteration count
             n += 1
+            self.work_counters['newton']()
 
         if np.isnan(res) and self.stop_at_nan:
             raise ProblemError('Newton got nan after %i iterations, aborting...' % n)
@@ -558,15 +530,13 @@ class grayscott_mi_diffusion(grayscott_imex_diffusion):
         if n == self.newton_maxiter:
             self.logger.warning('Newton did not converge after %i iterations, error is %s' % (n, res))
 
-        # self.newton_ncalls += 1
-        # self.newton_itercount += n
         me = self.dtype_u(self.init)
         if self.spectral:
-            me[..., 0] = self.fft.forward(tmpu)
-            me[..., 1] = self.fft.forward(tmpv)
+            me[0, ...] = self.fft.forward(tmpu)
+            me[1, ...] = self.fft.forward(tmpv)
         else:
-            me[..., 0] = tmpu
-            me[..., 1] = tmpv
+            me[0, ...] = tmpu
+            me[1, ...] = tmpv
         return me
 
 
@@ -595,22 +565,18 @@ class grayscott_mi_linear(grayscott_imex_linear):
 
     def __init__(
         self,
-        nvars=None,
-        Du=1.0,
-        Dv=0.01,
-        A=0.09,
-        B=0.086,
-        spectral=None,
         newton_maxiter=100,
         newton_tol=1e-12,
-        L=2.0,
-        comm=MPI.COMM_WORLD,
+        **kwargs,
     ):
         """Initialization routine"""
-        nvars = (127, 127) if nvars is None else nvars
-        super().__init__(nvars, Du, Dv, A, B, spectral, L, comm)
+        super().__init__(**kwargs)
         # This may not run in parallel yet..
         assert self.comm.Get_size() == 1
+        self.work_counters['newton'] = WorkCounter()
+        self.Ku = -self.Du * self.K2 - self.A
+        self.Kv = -self.Dv * self.K2 - self.B
+        self._makeAttributeAndRegister('newton_maxiter', 'newton_tol', localVars=locals(), readOnly=False)
 
     def eval_f(self, u, t):
         """
@@ -632,27 +598,28 @@ class grayscott_mi_linear(grayscott_imex_linear):
         f = self.dtype_f(self.init)
 
         if self.spectral:
-            f.comp1[..., 0] = self.Ku * u[..., 0]
-            f.comp1[..., 1] = self.Kv * u[..., 1]
+            f.comp1[0, ...] = self.Ku * u[0, ...]
+            f.comp1[1, ...] = self.Kv * u[1, ...]
             tmpu = newDistArray(self.fft, False)
             tmpv = newDistArray(self.fft, False)
-            tmpu[:] = self.fft.backward(u[..., 0], tmpu)
-            tmpv[:] = self.fft.backward(u[..., 1], tmpv)
+            tmpu[:] = self.fft.backward(u[0, ...], tmpu)
+            tmpv[:] = self.fft.backward(u[1, ...], tmpv)
             tmpfu = -tmpu * tmpv**2 + self.A
             tmpfv = tmpu * tmpv**2
-            f.comp2[..., 0] = self.fft.forward(tmpfu)
-            f.comp2[..., 1] = self.fft.forward(tmpfv)
+            f.comp2[0, ...] = self.fft.forward(tmpfu)
+            f.comp2[1, ...] = self.fft.forward(tmpfv)
 
         else:
-            u_hat = self.fft.forward(u[..., 0])
+            u_hat = self.fft.forward(u[0, ...])
             lap_u_hat = self.Ku * u_hat
-            f.comp1[..., 0] = self.fft.backward(lap_u_hat, f.comp1[..., 0])
-            u_hat = self.fft.forward(u[..., 1])
+            f.comp1[0, ...] = self.fft.backward(lap_u_hat, f.comp1[0, ...])
+            u_hat = self.fft.forward(u[1, ...])
             lap_u_hat = self.Kv * u_hat
-            f.comp1[..., 1] = self.fft.backward(lap_u_hat, f.comp1[..., 1])
-            f.comp2[..., 0] = -u[..., 0] * u[..., 1] ** 2 + self.A
-            f.comp2[..., 1] = u[..., 0] * u[..., 1] ** 2
+            f.comp1[1, ...] = self.fft.backward(lap_u_hat, f.comp1[1, ...])
+            f.comp2[0, ...] = -u[0, ...] * u[1, ...] ** 2 + self.A
+            f.comp2[1, ...] = u[0, ...] * u[1, ...] ** 2
 
+        self.work_counters['rhs']()
         return f
 
     def solve_system_1(self, rhs, factor, u0, t):
@@ -704,18 +671,18 @@ class grayscott_mi_linear(grayscott_imex_linear):
         if self.spectral:
             tmpu = newDistArray(self.fft, False)
             tmpv = newDistArray(self.fft, False)
-            tmpu[:] = self.fft.backward(u[..., 0], tmpu)
-            tmpv[:] = self.fft.backward(u[..., 1], tmpv)
+            tmpu[:] = self.fft.backward(u[0, ...], tmpu)
+            tmpv[:] = self.fft.backward(u[1, ...], tmpv)
             tmprhsu = newDistArray(self.fft, False)
             tmprhsv = newDistArray(self.fft, False)
-            tmprhsu[:] = self.fft.backward(rhs[..., 0], tmprhsu)
-            tmprhsv[:] = self.fft.backward(rhs[..., 1], tmprhsv)
+            tmprhsu[:] = self.fft.backward(rhs[0, ...], tmprhsu)
+            tmprhsv[:] = self.fft.backward(rhs[1, ...], tmprhsv)
 
         else:
-            tmpu = u[..., 0]
-            tmpv = u[..., 1]
-            tmprhsu = rhs[..., 0]
-            tmprhsv = rhs[..., 1]
+            tmpu = u[0, ...]
+            tmpv = u[1, ...]
+            tmprhsu = rhs[0, ...]
+            tmprhsv = rhs[1, ...]
 
         # start newton iteration
         n = 0
@@ -757,6 +724,7 @@ class grayscott_mi_linear(grayscott_imex_linear):
 
             # increase iteration count
             n += 1
+            self.work_counters['newton']()
 
         if np.isnan(res) and self.stop_at_nan:
             raise ProblemError('Newton got nan after %i iterations, aborting...' % n)
@@ -766,13 +734,11 @@ class grayscott_mi_linear(grayscott_imex_linear):
         if n == self.newton_maxiter:
             self.logger.warning('Newton did not converge after %i iterations, error is %s' % (n, res))
 
-        # self.newton_ncalls += 1
-        # self.newton_itercount += n
         me = self.dtype_u(self.init)
         if self.spectral:
-            me[..., 0] = self.fft.forward(tmpu)
-            me[..., 1] = self.fft.forward(tmpv)
+            me[0, ...] = self.fft.forward(tmpu)
+            me[1, ...] = self.fft.forward(tmpv)
         else:
-            me[..., 0] = tmpu
-            me[..., 1] = tmpv
+            me[0, ...] = tmpu
+            me[1, ...] = tmpv
         return me

--- a/pySDC/implementations/problem_classes/generic_MPIFFT_Laplacian.py
+++ b/pySDC/implementations/problem_classes/generic_MPIFFT_Laplacian.py
@@ -47,7 +47,7 @@ class IMEX_Laplacian_MPIFFT(ptype):
 
     xp = np
 
-    def __init__(self, nvars=None, spectral=False, L=2 * np.pi, alpha=1.0, comm=MPI.COMM_WORLD, dtype='d'):
+    def __init__(self, nvars=None, spectral=False, L=2 * np.pi, alpha=1.0, comm=MPI.COMM_WORLD, dtype='d', x0=0.0):
         """Initialization routine"""
 
         if nvars is None:
@@ -68,13 +68,15 @@ class IMEX_Laplacian_MPIFFT(ptype):
 
         # invoke super init, passing the communicator and the local dimensions as init
         super().__init__(init=(tmp_u.shape, comm, tmp_u.dtype))
-        self._makeAttributeAndRegister('nvars', 'spectral', 'L', 'alpha', 'comm', localVars=locals(), readOnly=True)
+        self._makeAttributeAndRegister(
+            'nvars', 'spectral', 'L', 'alpha', 'comm', 'x0', localVars=locals(), readOnly=True
+        )
 
         # get local mesh
         X = self.xp.ogrid[self.fft.local_slice(False)]
         N = self.fft.global_shape()
         for i in range(len(N)):
-            X[i] = X[i] * self.L[i] / N[i]
+            X[i] = x0 + (X[i] * L[i] / N[i])
         self.X = [self.xp.broadcast_to(x, self.fft.shape(False)) for x in X]
 
         # get local wavenumbers and Laplace operator
@@ -129,12 +131,13 @@ class IMEX_Laplacian_MPIFFT(ptype):
         self.work_counters['rhs']()
         return f
 
-    def _eval_Laplacian(self, u, f_impl):
+    def _eval_Laplacian(self, u, f_impl, alpha=None):
+        alpha = alpha if alpha else self.alpha
         if self.spectral:
-            f_impl[:] = -self.alpha * self.K2 * u
+            f_impl[:] = -alpha * self.K2 * u
         else:
             u_hat = self.fft.forward(u)
-            lap_u_hat = -self.alpha * self.K2 * u_hat
+            lap_u_hat = -alpha * self.K2 * u_hat
             f_impl[:] = self.fft.backward(lap_u_hat, f_impl)
         return f_impl
 
@@ -166,12 +169,13 @@ class IMEX_Laplacian_MPIFFT(ptype):
 
         return me
 
-    def _invert_Laplacian(self, me, factor, rhs):
+    def _invert_Laplacian(self, me, factor, rhs, alpha=None):
+        alpha = alpha if alpha else self.alpha
         if self.spectral:
-            me[:] = rhs / (1.0 + factor * self.alpha * self.K2)
+            me[:] = rhs / (1.0 + factor * alpha * self.K2)
 
         else:
             rhs_hat = self.fft.forward(rhs)
-            rhs_hat /= 1.0 + factor * self.alpha * self.K2
+            rhs_hat /= 1.0 + factor * alpha * self.K2
             me[:] = self.fft.backward(rhs_hat)
         return me

--- a/pySDC/tests/test_problems/test_GrayScottMPIFFT.py
+++ b/pySDC/tests/test_problems/test_GrayScottMPIFFT.py
@@ -1,0 +1,58 @@
+import pytest
+
+
+@pytest.mark.mpi4py
+@pytest.mark.parametrize('name', ['imex_diffusion', 'imex_linear', 'mi_diffusion', 'mi_linear'])
+@pytest.mark.parametrize('spectral', [True, False])
+def test_GrayScottMPIFFT(name, spectral):
+    """
+    Test the implementation of the Gray-Scott problem by doing an Euler step forward and then an explicit Euler step
+    backward to compute something akin to an error. We check that the "local error" has order 2.
+
+    Keep
+    """
+    if name == 'imex_diffusion':
+        from pySDC.implementations.problem_classes.GrayScott_MPIFFT import grayscott_imex_diffusion as problem_class
+    elif name == 'imex_linear':
+        from pySDC.implementations.problem_classes.GrayScott_MPIFFT import grayscott_imex_linear as problem_class
+    elif name == 'mi_diffusion':
+        from pySDC.implementations.problem_classes.GrayScott_MPIFFT import grayscott_mi_diffusion as problem_class
+    elif name == 'mi_linear':
+        from pySDC.implementations.problem_classes.GrayScott_MPIFFT import grayscott_mi_linear as problem_class
+    import numpy as np
+
+    prob = problem_class(spectral=spectral, nvars=(127,) * 2)
+
+    dts = np.logspace(-3, -7, 15)
+    errors = []
+
+    for dt in dts:
+
+        u0 = prob.u_exact(0)
+        f0 = prob.eval_f(u0, 0)
+
+        # do an IMEX or multi implicit Euler step forward
+        if 'solve_system_2' in dir(prob):
+            _u = prob.solve_system_1(u0, dt, u0, 0)
+            u1 = prob.solve_system_2(_u, dt, _u, 0)
+        else:
+            u1 = prob.solve_system(u0 + dt * f0.expl, dt, u0, 0)
+
+        # do an explicit Euler step backward
+        f1 = prob.eval_f(u1, dt)
+        u02 = u1 - dt * (np.sum(f1, axis=0))
+        errors += [abs(u0 - u02)]
+
+    errors = np.array(errors)
+    dts = np.array(dts)
+    order = np.log(errors[1:] / errors[:-1]) / np.log(dts[1:] / dts[:-1])
+    mean_order = np.median(order)
+
+    assert np.isclose(np.median(order), 2, atol=1e-2), f'Expected order 2, but got {mean_order}'
+    assert prob.work_counters['rhs'].niter == len(errors) * 2
+    if 'newton' in prob.work_counters.keys():
+        assert prob.work_counters['newton'].niter > 0
+
+
+if __name__ == '__main__':
+    test_GrayScottMPIFFT('imex_diffusion', False)


### PR DESCRIPTION
This PR includes a couple minor changes:
 - Reversal of indices for $u$ and $v$ variables in Gray-Scott. AFAIK, they are now contiguous, which I recon gives better performance
 - Gray-Scott inherits from generic MPI FFT class. I use this to port all classes that inherit from this to GPU simultaneously
 - Test for Gray-Scott: The test is not perfect, but checks that the solvers are at least somewhat consistent. Previously, there were no tests at all.
 - Minor fixes for Allen-Cahn