### PR TITLE
Split long project tests into different environments such that they run concurrently

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.8', '3.9', '3.10']
-        env: ['base', 'fenics', 'mpi4py', 'petsc']
+        env: ['base', 'fenics', 'mpi4py', 'petsc', 'DAE', 'PinTSimE', 'parallelSDC_reloaded', 'Resilience']
 
     defaults:
       run:

--- a/etc/environment-DAE.yml
+++ b/etc/environment-DAE.yml
@@ -1,0 +1,17 @@
+name: pySDC
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - numpy
+  - scipy>=0.17.1
+  - matplotlib>=3.0
+  - sympy>=1.0
+  - numba>=0.35
+  - dill>=0.2.6
+  - pytest
+  - pytest-benchmark
+  - pytest-timeout
+  - pytest-order
+  - coverage[toml]
+  - sphinx

--- a/etc/environment-PinTSimE.yml
+++ b/etc/environment-PinTSimE.yml
@@ -1,0 +1,17 @@
+name: pySDC
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - numpy
+  - scipy>=0.17.1
+  - matplotlib>=3.0
+  - sympy>=1.0
+  - numba>=0.35
+  - dill>=0.2.6
+  - pytest
+  - pytest-benchmark
+  - pytest-timeout
+  - pytest-order
+  - coverage[toml]
+  - sphinx

--- a/etc/environment-Resilience.yml
+++ b/etc/environment-Resilience.yml
@@ -1,0 +1,17 @@
+name: pySDC
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - numpy
+  - scipy>=0.17.1
+  - matplotlib>=3.0
+  - sympy>=1.0
+  - numba>=0.35
+  - dill>=0.2.6
+  - pytest
+  - pytest-benchmark
+  - pytest-timeout
+  - pytest-order
+  - coverage[toml]
+  - sphinx

--- a/etc/environment-parallelSDC_reloaded.yml
+++ b/etc/environment-parallelSDC_reloaded.yml
@@ -1,0 +1,17 @@
+name: pySDC
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - numpy
+  - scipy>=0.17.1
+  - matplotlib>=3.0
+  - sympy>=1.0
+  - numba>=0.35
+  - dill>=0.2.6
+  - pytest
+  - pytest-benchmark
+  - pytest-timeout
+  - pytest-order
+  - coverage[toml]
+  - sphinx

--- a/pySDC/tests/test_projects/test_DAE/test_DAEMesh.py
+++ b/pySDC/tests/test_projects/test_DAE/test_DAEMesh.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 @pytest.mark.parametrize('shape', [(6,), (4, 6), (4, 6, 8)])
 def testInitialization(shape):
     """
@@ -20,7 +20,7 @@ def testInitialization(shape):
     assert len(mesh.components) == len(mesh), 'ERROR: Mesh does not contain two component arrays!'
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 def testInitializationGivenMesh():
     """
     Tests if for a given mesh the initialization results in the same mesh.
@@ -42,7 +42,7 @@ def testInitializationGivenMesh():
     ), 'ERROR: Components in initialized meshes do not match!'
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 @pytest.mark.parametrize('shape', [(6,), (4, 6), (4, 6, 8)])
 def testArrayUFuncOperator(shape):
     """

--- a/pySDC/tests/test_projects/test_DAE/test_HookClass_DAE.py
+++ b/pySDC/tests/test_projects/test_DAE/test_HookClass_DAE.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 @pytest.mark.parametrize('M', [2, 3, 4])
 def testHookClassDiffAlgComps(M):
     """

--- a/pySDC/tests/test_projects/test_DAE/test_SemiImplicitDAE.py
+++ b/pySDC/tests/test_projects/test_DAE/test_SemiImplicitDAE.py
@@ -46,7 +46,7 @@ def getTestSetup(problem, sweeper, hook_class):
     return description, controller_params
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 @pytest.mark.parametrize('initial_guess', ['spread', 'zero', 'random'])
 def testPredict(initial_guess):
     r"""
@@ -104,7 +104,7 @@ def testPredict(initial_guess):
         assert all(abs(fRandomItem) > 0.0 for fRandomItem in fRandom), "Gradient needs to be spreaded as zero!"
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 @pytest.mark.parametrize('residual_type', ['full_abs', 'last_abs', 'full_rel', 'last_rel', 'else'])
 def testComputeResidual(residual_type):
     r"""
@@ -162,7 +162,7 @@ def testComputeResidual(residual_type):
         assert L.status.residual == resNormRef[-1] / abs(uRef)
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 @pytest.mark.parametrize('quad_type', ['RADAU-RIGHT', 'RADAU-LEFT'])
 def testComputeEndpoint(quad_type):
     r"""
@@ -210,7 +210,7 @@ def testComputeEndpoint(quad_type):
         assert np.isclose(L.u[-1], L.uend), "Endpoint is not computed correctly!"
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 @pytest.mark.parametrize('M', [2, 3])
 def testCompareResults(M):
     r"""
@@ -260,7 +260,7 @@ def testCompareResults(M):
     assert np.allclose(errSI, errFI), "Errors does not match!"
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 @pytest.mark.parametrize('case', [0, 1])
 @pytest.mark.parametrize('M', [2, 3])
 @pytest.mark.parametrize('QI', ['IE', 'LU'])

--- a/pySDC/tests/test_projects/test_DAE/test_convergence.py
+++ b/pySDC/tests/test_projects/test_DAE/test_convergence.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 def test_main():
     from pySDC.projects.DAE.run.run_convergence_test import setup, run
 

--- a/pySDC/tests/test_projects/test_DAE/test_fully_implicit_DAE.py
+++ b/pySDC/tests/test_projects/test_DAE/test_fully_implicit_DAE.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 def test_predict_main():
     from pySDC.projects.DAE.problems.simple_DAE import simple_dae_1
     from pySDC.projects.DAE.sweepers.fully_implicit_DAE import fully_implicit_DAE
@@ -63,7 +63,7 @@ def test_predict_main():
         assert abs(L.f[i + 1]) > 0.0
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 def test_residual_main():
     from pySDC.projects.DAE.problems.simple_DAE import simple_dae_1
     from pySDC.projects.DAE.sweepers.fully_implicit_DAE import fully_implicit_DAE
@@ -149,7 +149,7 @@ def test_residual_main():
     assert L.status.residual == ref_norm[-1] / abs(L.u[0]), "ERROR: incorrect norm used"
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 def test_compute_end_point_main():
     from pySDC.projects.DAE.problems.simple_DAE import simple_dae_1
     from pySDC.projects.DAE.sweepers.fully_implicit_DAE import fully_implicit_DAE

--- a/pySDC/tests/test_projects/test_DAE/test_iteration.py
+++ b/pySDC/tests/test_projects/test_DAE/test_iteration.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 def test_main():
     from pySDC.projects.DAE.run.run_iteration_test import setup, run
 

--- a/pySDC/tests/test_projects/test_DAE/test_playground.py
+++ b/pySDC/tests/test_projects/test_DAE/test_playground.py
@@ -2,14 +2,14 @@ import pytest
 import warnings
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 def test_problematic_main():
     from pySDC.projects.DAE.run.fully_implicit_dae_playground import main
 
     main()
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 def test_synch_gen_playground_main():
     from pySDC.projects.DAE.run.synchronous_machine_playground import main
 

--- a/pySDC/tests/test_projects/test_DAE/test_problems.py
+++ b/pySDC/tests/test_projects/test_DAE/test_problems.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 def test_pendulum_u_exact_main():
     from pySDC.projects.DAE.problems.simple_DAE import pendulum_2d
 
@@ -18,7 +18,7 @@ def test_pendulum_u_exact_main():
     assert np.isclose(abs(u_test), 0.0)
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 def test_one_transistor_amplifier_u_exact_main():
     from pySDC.projects.DAE.problems.transistor_amplifier import one_transistor_amplifier
 
@@ -33,7 +33,7 @@ def test_one_transistor_amplifier_u_exact_main():
     assert np.array_equal(abs(u_test), 0.0)
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 def test_two_transistor_amplifier_u_exact_main():
     from pySDC.projects.DAE.problems.transistor_amplifier import two_transistor_amplifier
 
@@ -51,7 +51,7 @@ def test_two_transistor_amplifier_u_exact_main():
 #
 #   Explicit test for the pendulum example
 #
-@pytest.mark.base
+@pytest.mark.DAE
 def test_pendulum_main():
     from pySDC.projects.DAE.problems.simple_DAE import pendulum_2d
     from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
@@ -109,7 +109,7 @@ def test_pendulum_main():
     assert np.isclose(err, 0.0, atol=1e-4), "Error too large."
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 def test_one_transistor_amplifier_main():
     from pySDC.projects.DAE.problems.transistor_amplifier import one_transistor_amplifier
     from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
@@ -168,7 +168,7 @@ def test_one_transistor_amplifier_main():
     assert np.isclose(err, 0.0, atol=1e-4), "Error too large."
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 def test_two_transistor_amplifier_main():
     from pySDC.projects.DAE.problems.transistor_amplifier import two_transistor_amplifier
     from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
@@ -236,7 +236,7 @@ def test_two_transistor_amplifier_main():
     assert np.isclose(err, 0.0, atol=1e-4), "Error too large."
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 def test_synchgen_infinite_bus_main():
     from pySDC.projects.DAE.problems.synchronous_machine import synchronous_machine_infinite_bus
     from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
@@ -313,7 +313,7 @@ def test_synchgen_infinite_bus_main():
     assert np.isclose(err, 0.0, atol=1e-4), "Error too large."
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 def test_DiscontinuousTestDAE_singularity():
     """
     Test if the event occurs at the correct time and proves if the right-hand side has with the correct values at the event.
@@ -361,7 +361,7 @@ def test_DiscontinuousTestDAE_singularity():
     ), f"ERROR: Right-hand side after event does not match! Expected {(7 * np.sqrt(51), 0.0)}, got {(f_after_event.diff[0], f_after_event.alg[0])}"
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 @pytest.mark.parametrize('M', [2, 3, 4, 5])
 def test_DiscontinuousTestDAE_SDC(M):
     """
@@ -427,7 +427,7 @@ def test_DiscontinuousTestDAE_SDC(M):
     assert err < err_tol[M], f"ERROR: Error is too large! Expected {err_tol[M]=}, got {err=}"
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 @pytest.mark.parametrize('M', [3, 4, 5])
 def test_DiscontinuousTestDAE_SDC_detection(M):
     """
@@ -521,7 +521,7 @@ def test_DiscontinuousTestDAE_SDC_detection(M):
     ), f"ERROR for M={M}: Event error is too large! Expected {event_err_tol[M]=}, got {event_err=}"
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 def test_WSCC9_evaluation():
     r"""
     Test for WSCC9 bus test case. The class is written for components :math:`m = 3`, :math:`n = 9`.
@@ -547,7 +547,7 @@ def test_WSCC9_evaluation():
     assert len(f.diff) == nvars and len(f.alg) == nvars, 'Shape of f does not match with shape it is supposed to be!'
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 def test_WSCC9_update_YBus():
     """
     Test if YBus is updated at time 0.05. For this SDC performs one time step.
@@ -612,7 +612,7 @@ def test_WSCC9_update_YBus():
     ), 'YBus after line outage does not match with the one it should supposed to!'
 
 
-@pytest.mark.base
+@pytest.mark.DAE
 def test_WSCC9_SDC_detection():
     """
     Test if state function states a root.
@@ -692,7 +692,7 @@ def test_WSCC9_SDC_detection():
     ), f'Found event does not match a threshold! Got {t_switch=}'
 
 
-# @pytest.mark.base
+# @pytest.mark.DAE
 # def test_WSCC9_SDC_detection():
 #     """
 #     Test for one SDC run with event detection if the found event is close to the exact value and if the global error

--- a/pySDC/tests/test_projects/test_parallelSDC_reloaded.py
+++ b/pySDC/tests/test_projects/test_parallelSDC_reloaded.py
@@ -9,7 +9,7 @@ import sys
 import pytest
 
 
-@pytest.mark.base
+@pytest.mark.parallelSDC_reloaded
 @pytest.mark.parametrize(
     "sName",
     [
@@ -25,7 +25,7 @@ def test_script(sName):
         raise ImportError(f"error when executing {sName}.py : {e}")
 
 
-@pytest.mark.base
+@pytest.mark.parallelSDC_reloaded
 @pytest.mark.parametrize("sType", ["setup", "accuracy"])
 @pytest.mark.parametrize(
     "pName",
@@ -47,7 +47,7 @@ def test_playgrounds(pName, sType):
         raise ImportError(f"error when executing {pName}_{sType}.py : {e}")
 
 
-@pytest.mark.base
+@pytest.mark.parallelSDC_reloaded
 def test_script_fig01_conv():
     from pySDC.projects.parallelSDC_reloaded.scripts import fig01_conv
 
@@ -61,7 +61,7 @@ def test_script_fig01_conv():
     ]
 
 
-@pytest.mark.base
+@pytest.mark.parallelSDC_reloaded
 def test_script_fig02_stab():
     from pySDC.projects.parallelSDC_reloaded.scripts import fig02_stab
 
@@ -75,7 +75,7 @@ def test_script_fig02_stab():
     ]
 
 
-@pytest.mark.base
+@pytest.mark.parallelSDC_reloaded
 def test_script_fig03_lorenz():
     from pySDC.projects.parallelSDC_reloaded.scripts import fig03_lorenz
 
@@ -88,7 +88,7 @@ def test_script_fig03_lorenz():
     ]
 
 
-@pytest.mark.base
+@pytest.mark.parallelSDC_reloaded
 def test_script_fig04_protheroRobinson():
     from pySDC.projects.parallelSDC_reloaded.scripts import fig04_protheroRobinson
 
@@ -100,7 +100,7 @@ def test_script_fig04_protheroRobinson():
     ]
 
 
-@pytest.mark.base
+@pytest.mark.parallelSDC_reloaded
 def test_script_fig05_allenCahn():
     # Test fails for python < 3.8, so avoid it
     if sys.version_info.minor < 8:

--- a/pySDC/tests/test_projects/test_pintsime/test_SwitchEstimator.py
+++ b/pySDC/tests/test_projects/test_pintsime/test_SwitchEstimator.py
@@ -16,7 +16,7 @@ def getParamsRun():
     return restol, alpha, maxiter, max_restarts, useA, useSE, exact_event_time_avail
 
 
-@pytest.mark.base
+@pytest.mark.PinTSimE
 def testExactDummyProblem():
     r"""
     Test for dummy problems. The test verifies that the dummy problems exactly returns the dynamics of
@@ -61,7 +61,7 @@ def testExactDummyProblem():
     assert np.allclose(fExactOdeEvent, fOdeEvent), "Right-hand sides at event do not match!"
 
 
-@pytest.mark.base
+@pytest.mark.PinTSimE
 @pytest.mark.parametrize('quad_type', ['LOBATTO', 'RADAU-RIGHT'])
 def testAdaptInterpolationInfo(quad_type):
     r"""
@@ -162,7 +162,7 @@ def testAdaptInterpolationInfo(quad_type):
         ), f'Number of values on interpolation axis does not match. Expected {num_nodes + 1=}, got {len(t_interp)}'
 
 
-@pytest.mark.base
+@pytest.mark.PinTSimE
 @pytest.mark.parametrize('num_nodes', [3, 4, 5])
 def testDetectionBoundary(num_nodes):
     """
@@ -230,7 +230,7 @@ def testDetectionBoundary(num_nodes):
     assert sum_restarts == 0, 'Event occurs at boundary, but restart(s) are executed anyway!'
 
 
-@pytest.mark.base
+@pytest.mark.PinTSimE
 @pytest.mark.parametrize('tol', [10 ** (-m) for m in range(8, 13)])
 @pytest.mark.parametrize('num_nodes', [3, 4, 5])
 @pytest.mark.parametrize('quad_type', ['LOBATTO', 'RADAU-RIGHT'])
@@ -310,7 +310,7 @@ def testDetectionODE(tol, num_nodes, quad_type):
     assert np.isclose(event_err, 0, atol=1.2e-11), f'Event time error {event_err=} is not small enough!'
 
 
-@pytest.mark.base
+@pytest.mark.PinTSimE
 @pytest.mark.parametrize('num_nodes', [3, 4, 5])
 def testDetectionDAE(num_nodes):
     r"""

--- a/pySDC/tests/test_projects/test_pintsime/test_battery_model.py
+++ b/pySDC/tests/test_projects/test_pintsime/test_battery_model.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.base
+@pytest.mark.PinTSimE
 def test_main():
     from pySDC.projects.PinTSimE.battery_model import main
 

--- a/pySDC/tests/test_projects/test_pintsime/test_buck_model.py
+++ b/pySDC/tests/test_projects/test_pintsime/test_buck_model.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.base
+@pytest.mark.PinTSimE
 def test_main():
     from pySDC.projects.PinTSimE.buck_model import main
 

--- a/pySDC/tests/test_projects/test_pintsime/test_discontinuous_test_ODE.py
+++ b/pySDC/tests/test_projects/test_pintsime/test_discontinuous_test_ODE.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.base
+@pytest.mark.PinTSimE
 def test_main():
     from pySDC.projects.PinTSimE.discontinuous_test_ODE import main
 

--- a/pySDC/tests/test_projects/test_pintsime/test_estimation_check.py
+++ b/pySDC/tests/test_projects/test_pintsime/test_estimation_check.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.base
+@pytest.mark.PinTSimE
 def test_main():
     from pySDC.projects.PinTSimE.estimation_check import run_estimation_check
 

--- a/pySDC/tests/test_projects/test_pintsime/test_piline_model.py
+++ b/pySDC/tests/test_projects/test_pintsime/test_piline_model.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.base
+@pytest.mark.PinTSimE
 def test_main():
     from pySDC.projects.PinTSimE.piline_model import main
 

--- a/pySDC/tests/test_projects/test_resilience/test_FD_eigenvalues.py
+++ b/pySDC/tests/test_projects/test_resilience/test_FD_eigenvalues.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.base
+@pytest.mark.Resilience
 @pytest.mark.parametrize("equation", ['heat', 'advection'])
 def test_FD_eigenvalues(equation):
     """

--- a/pySDC/tests/test_projects/test_resilience/test_Lorenz.py
+++ b/pySDC/tests/test_projects/test_resilience/test_Lorenz.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.base
+@pytest.mark.Resilience
 def test_main():
     from pySDC.projects.Resilience.Lorenz import main
 

--- a/pySDC/tests/test_projects/test_resilience/test_adaptive_collocation.py
+++ b/pySDC/tests/test_projects/test_resilience/test_adaptive_collocation.py
@@ -1,21 +1,21 @@
 import pytest
 
 
-@pytest.mark.base
+@pytest.mark.Resilience
 def test_adaptivity_collocation():
     from pySDC.projects.Resilience.collocation_adaptivity import adaptivity_collocation
 
     adaptivity_collocation(plotting=False)
 
 
-@pytest.mark.base
+@pytest.mark.Resilience
 def test_error_estimate_order():
     from pySDC.projects.Resilience.collocation_adaptivity import order_stuff, run_advection
 
     order_stuff(run_advection)
 
 
-@pytest.mark.base
+@pytest.mark.Resilience
 def test_adaptive_collocation():
     from pySDC.projects.Resilience.collocation_adaptivity import compare_adaptive_collocation, run_vdp
 

--- a/pySDC/tests/test_projects/test_resilience/test_efficient_sweepers.py
+++ b/pySDC/tests/test_projects/test_resilience/test_efficient_sweepers.py
@@ -134,7 +134,7 @@ def run_Schroedinger(efficient=False, num_procs=1, skip_residual_computation=Fal
     return stats
 
 
-@pytest.mark.base
+@pytest.mark.Resilience
 def test_generic_implicit_efficient(skip_residual_computation=False):
     stats_normal = run_Lorenz(efficient=False, skip_residual_computation=skip_residual_computation)
     stats_efficient = run_Lorenz(efficient=True, skip_residual_computation=skip_residual_computation)
@@ -142,7 +142,7 @@ def test_generic_implicit_efficient(skip_residual_computation=False):
     assert_benefit(stats_normal, stats_efficient)
 
 
-@pytest.mark.base
+@pytest.mark.Resilience
 def test_residual_skipping():
     stats_normal = run_Lorenz(efficient=True, skip_residual_computation=False)
     stats_efficient = run_Lorenz(efficient=True, skip_residual_computation=True)

--- a/pySDC/tests/test_projects/test_resilience/test_fault_injection.py
+++ b/pySDC/tests/test_projects/test_resilience/test_fault_injection.py
@@ -18,7 +18,7 @@ def get_random_float():
     return rand
 
 
-@pytest.mark.base
+@pytest.mark.Resilience
 def test_float_conversion():
     """
     Method to test the float conversion by converting to bytes and back and by flipping bits where we know what the
@@ -53,7 +53,7 @@ def test_float_conversion():
         print(f'When flipping bits, we got nan {nan_counter} times out of {num_tests} tests')
 
 
-@pytest.mark.base
+@pytest.mark.Resilience
 def test_complex_conversion():
     """
     Test conversion of complex numbers to and from binary
@@ -72,7 +72,7 @@ def test_complex_conversion():
         ), f"Conversion between bytes and float failed for {rand_complex}: result: {res}"
 
 
-@pytest.mark.base
+@pytest.mark.Resilience
 def test_fault_injection():
     from pySDC.projects.Resilience.fault_injection import FaultInjector
 

--- a/pySDC/tests/test_projects/test_resilience/test_order.py
+++ b/pySDC/tests/test_projects/test_resilience/test_order.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.base
+@pytest.mark.Resilience
 @pytest.mark.parametrize("ks", [[2], [3], [4]])
 @pytest.mark.parametrize("serial", [True, False])
 def test_order_fixed_step_size(ks, serial):
@@ -11,7 +11,7 @@ def test_order_fixed_step_size(ks, serial):
     plot_all_errors(ax, ks, serial, Tend_fixed=1.0)
 
 
-@pytest.mark.base
+@pytest.mark.Resilience
 @pytest.mark.parametrize("ks", [[2], [3]])
 @pytest.mark.parametrize("serial", [True, False])
 def test_order_adaptive_step_size(ks, serial):

--- a/pySDC/tests/test_projects/test_resilience/test_piline.py
+++ b/pySDC/tests/test_projects/test_resilience/test_piline.py
@@ -1,14 +1,14 @@
 import pytest
 
 
-@pytest.mark.base
+@pytest.mark.Resilience
 def test_main():
     from pySDC.projects.Resilience.piline import main
 
     main()
 
 
-@pytest.mark.base
+@pytest.mark.Resilience
 def test_residual_adaptivity():
     from pySDC.projects.Resilience.piline import residual_adaptivity
 

--- a/pySDC/tests/test_projects/test_resilience/test_quench.py
+++ b/pySDC/tests/test_projects/test_resilience/test_quench.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.base
+@pytest.mark.Resilience
 @pytest.mark.parametrize('leak_type', ['linear', 'exponential'])
 def test_imex_vs_fully_implicit_quench(leak_type):
     """
@@ -12,7 +12,7 @@ def test_imex_vs_fully_implicit_quench(leak_type):
     compare_imex_full(plotting=False, leak_type=leak_type)
 
 
-@pytest.mark.base
+@pytest.mark.Resilience
 def test_crossing_time_computation():
     from pySDC.projects.Resilience.quench import run_quench, get_crossing_time
 

--- a/pySDC/tests/test_projects/test_resilience/test_strategies.py
+++ b/pySDC/tests/test_projects/test_resilience/test_strategies.py
@@ -107,7 +107,7 @@ def test_strategy_MPI(strategy_name, num_procs=1):
     single_test(strategy_name=strategy_name, useMPI=True, num_procs=num_procs)
 
 
-@pytest.mark.base
+@pytest.mark.Resilience
 @pytest.mark.parametrize('strategy_name', STRATEGY_NAMES + STRATEGY_NAMES_NONMPIONLY)
 def test_strategy_nonMPI(strategy_name, num_procs=1):
     single_test(strategy_name=strategy_name, useMPI=False, num_procs=num_procs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,10 @@ markers = [
     'cupy: tests for cupy on GPUs',
     'libpressio: tests using the libpressio library',
     'monodomain: tests the monodomain project, which requires previous compilation of c++ code',
+    'DAE: tests for the DAE project',
+    'PinTSimE: tests for the PinTSimE project',
+    'Resilience: tests for the resilience project',
+    'parallelSDC_reloaded: tests for the parallelSDC_reloaded project',
     ]
 timeout = 300
 


### PR DESCRIPTION
I got really tired of waiting so long. I just added environments for the longest running tests. Let me know if you want more or less granular. Also, the environments are the same as the base environment, since only these tests took so long. Tests needing other environments can stay there as far as I am concerned.