### PR TITLE
Removed cupy-tests until they are fixed

### DIFF
--- a/.github/workflows/gitlab_ci.yml
+++ b/.github/workflows/gitlab_ci.yml
@@ -5,6 +5,7 @@ name: Mirror to Gitlab to trigger CI
 on:
   push:
   pull_request_target:
+    types: [opened, synchronize, reopened, labeled]
   schedule:
     - cron: '1 5 2 * *'
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,7 +47,7 @@ test_JUWELS:
     - shell
   parallel:
     matrix:
-      - SHELL_SCRIPT: ['benchmark', 'cupy']
+      - SHELL_SCRIPT: ['benchmark']
   artifacts:
     when: always
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,7 +47,7 @@ test_JUWELS:
     - shell
   parallel:
     matrix:
-      - SHELL_SCRIPT: ['benchmark']
+      - SHELL_SCRIPT: ['benchmark', 'cupy']
   artifacts:
     when: always
     paths:

--- a/pySDC/tests/test_sweepers/test_MPI_sweeper.py
+++ b/pySDC/tests/test_sweepers/test_MPI_sweeper.py
@@ -152,7 +152,8 @@ def test_sweeper(num_nodes, quad_type, residual_type, imex, initGuess, launch=Tr
     individual_test(num_nodes, quad_type, residual_type, imex, initGuess, useNCCL=False, launch=launch)
 
 
-# @pytest.mark.cupy
+@pytest.mark.cupy
+@pytest.mark.skip(reason="We haven\'t figured out how to run tests on the cluster with multiple processes yet.")
 @pytest.mark.parametrize("num_nodes", [2])
 @pytest.mark.parametrize("quad_type", ['GAUSS', 'RADAU-RIGHT'])
 @pytest.mark.parametrize("residual_type", ['last_abs', 'full_rel'])

--- a/pySDC/tests/test_sweepers/test_MPI_sweeper.py
+++ b/pySDC/tests/test_sweepers/test_MPI_sweeper.py
@@ -152,7 +152,7 @@ def test_sweeper(num_nodes, quad_type, residual_type, imex, initGuess, launch=Tr
     individual_test(num_nodes, quad_type, residual_type, imex, initGuess, useNCCL=False, launch=launch)
 
 
-@pytest.mark.cupy
+# @pytest.mark.cupy
 @pytest.mark.parametrize("num_nodes", [2])
 @pytest.mark.parametrize("quad_type", ['GAUSS', 'RADAU-RIGHT'])
 @pytest.mark.parametrize("residual_type", ['last_abs', 'full_rel'])


### PR DESCRIPTION
As I cannot push to master (which makes sense), this PR removes the cupy-test in gitlab, so that CI now succeeds again. Then failures can be detected easier.

Once, the cupy-tests are fixed, the updated code shall be merged in master and also the tests will be added again.