### PR TITLE
Ported `IMEX_Laplacian_MPIFFT`, `fft_to_fft` and `MultiComponentMesh` to GPU

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ prepare_JUWELS:
     - pip install -e .
     - pip install pytest-benchmark coverage
     - git clone https://github.com/brownbaerchen/mpi4py-fft.git ../mpi4py_fft
-    - FFTW_LIBRARY_DIR="/p/software/juwels/stages/2024/software/FFTW/3.3.10-GCC-12.3.0/lib64" pip install -e ../mpi4py_fft/.
+    - FFTW_LIBRARY_DIR="/p/software/juwels/stages/2024/software/FFTW/3.3.10-GCC-12.3.0/lib64" pip install --force-reinstall -e ../mpi4py_fft/.
 
 
 test_JUWELS:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,15 +31,11 @@ prepare_JUWELS:
     - module load CuPy
     - pip install -e .
     - pip install pytest-benchmark coverage
-    - export current_dir=$(pwd)
-    - mkdir -p ../mpi4py_fft
-    - cd ../mpi4py_fft
-    - git init
-    - git remote add fork https://github.com/brownbaerchen/mpi4py-fft.git
-    - git fetch fork
-    - git checkout fork/cupy_implementation
+    - git submodule add -f https://github.com/brownbaerchen/mpi4py-fft.git
+    - cd mpi4py_fft
+    - git checkout cupy_implementation
     - FFTW_LIBRARY_DIR="/p/software/juwels/stages/2024/software/FFTW/3.3.10-GCC-12.3.0/lib64" pip install --force-reinstall -e .
-    - cd $current_dir
+    - cd ../
 
 
 test_JUWELS:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ prepare_JUWELS:
     - git init
     - git remote add fork https://github.com/brownbaerchen/mpi4py-fft.git
     - git fetch fork
-    - git checkout fork/master
+    - git checkout fork/cupy_implementation
     - FFTW_LIBRARY_DIR="/p/software/juwels/stages/2024/software/FFTW/3.3.10-GCC-12.3.0/lib64" pip install --force-reinstall -e .
     - cd $current_dir
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,6 @@ prepare_JUWELS:
     - shell
   script:
     - mkdir -p benchmarks
-    # load the latest Python module (currently 3.11)
     - module --force purge
     - module load Stages/2024
     - module load GCC
@@ -32,6 +31,8 @@ prepare_JUWELS:
     - module load CuPy
     - pip install -e .
     - pip install pytest-benchmark coverage
+    - git clone https://github.com/brownbaerchen/mpi4py-fft.git ../
+    - FFTW_LIBRARY_DIR="/p/software/juwels/stages/2024/software/FFTW/3.3.10-GCC-12.3.0/lib64" pip install -e ../mpi4py_fft/.
 
 
 test_JUWELS:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,11 +31,6 @@ prepare_JUWELS:
     - module load CuPy
     - pip install -e .
     - pip install pytest-benchmark coverage
-    - git submodule add -f https://github.com/brownbaerchen/mpi4py-fft.git
-    - cd mpi4py-fft
-    - git checkout cupy_implementation
-    - FFTW_LIBRARY_DIR="/p/software/juwels/stages/2024/software/FFTW/3.3.10-GCC-12.3.0/lib64" pip install --force-reinstall -e .
-    - cd ../
 
 
 test_JUWELS:
@@ -68,7 +63,11 @@ test_JUWELS:
     - module load mpi4py
     - module load SciPy-Stack
     - module load CuPy
-    - FFTW_LIBRARY_DIR="/p/software/juwels/stages/2024/software/FFTW/3.3.10-GCC-12.3.0/lib64" pip install --force-reinstall -e ./mpi4py-fft
+    - git submodule add -f https://github.com/brownbaerchen/mpi4py-fft.git
+    - cd mpi4py-fft
+    - git checkout cupy_implementation
+    - FFTW_LIBRARY_DIR="/p/software/juwels/stages/2024/software/FFTW/3.3.10-GCC-12.3.0/lib64" pip install --force-reinstall -e .
+    - cd ../
   script:
     # - touch benchmarks/output.json
     - echo $SYSTEMNAME

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,7 +68,7 @@ test_JUWELS:
     - module load mpi4py
     - module load SciPy-Stack
     - module load CuPy
-    - FFTW_LIBRARY_DIR="/p/software/juwels/stages/2024/software/FFTW/3.3.10-GCC-12.3.0/lib64" pip install --force-reinstall -e mpi4py-fft/.
+    - FFTW_LIBRARY_DIR="/p/software/juwels/stages/2024/software/FFTW/3.3.10-GCC-12.3.0/lib64" pip install --force-reinstall -e ./mpi4py-fft
   script:
     # - touch benchmarks/output.json
     - echo $SYSTEMNAME

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ prepare_JUWELS:
     - pip install -e .
     - pip install pytest-benchmark coverage
     - git submodule add -f https://github.com/brownbaerchen/mpi4py-fft.git
-    - cd mpi4py_fft
+    - cd mpi4py-fft
     - git checkout cupy_implementation
     - FFTW_LIBRARY_DIR="/p/software/juwels/stages/2024/software/FFTW/3.3.10-GCC-12.3.0/lib64" pip install --force-reinstall -e .
     - cd ../

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ prepare_JUWELS:
     - module load CuPy
     - pip install -e .
     - pip install pytest-benchmark coverage
-    - git clone https://github.com/brownbaerchen/mpi4py-fft.git ../
+    - git clone https://github.com/brownbaerchen/mpi4py-fft.git ../mpi4py_fft
     - FFTW_LIBRARY_DIR="/p/software/juwels/stages/2024/software/FFTW/3.3.10-GCC-12.3.0/lib64" pip install -e ../mpi4py_fft/.
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,8 +31,15 @@ prepare_JUWELS:
     - module load CuPy
     - pip install -e .
     - pip install pytest-benchmark coverage
-    - git clone https://github.com/brownbaerchen/mpi4py-fft.git ../mpi4py_fft
-    - FFTW_LIBRARY_DIR="/p/software/juwels/stages/2024/software/FFTW/3.3.10-GCC-12.3.0/lib64" pip install --force-reinstall -e ../mpi4py_fft/.
+    - export current_dir=$(pwd)
+    - mkdir ../mpi4py_fft
+    - cd ../mpi4py_fft
+    - git init
+    - git remote add fork https://github.com/brownbaerchen/mpi4py-fft.git
+    - git fetch fork
+    - git checkout fork/master
+    - FFTW_LIBRARY_DIR="/p/software/juwels/stages/2024/software/FFTW/3.3.10-GCC-12.3.0/lib64" pip install --force-reinstall -e .
+    - cd $current_dir
 
 
 test_JUWELS:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ prepare_JUWELS:
     - pip install -e .
     - pip install pytest-benchmark coverage
     - export current_dir=$(pwd)
-    - mkdir ../mpi4py_fft
+    - mkdir -p ../mpi4py_fft
     - cd ../mpi4py_fft
     - git init
     - git remote add fork https://github.com/brownbaerchen/mpi4py-fft.git

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,7 +60,6 @@ test_JUWELS:
       - sbatch.out
   before_script:
     - mkdir -p benchmarks
-    # load the latest Python module (currently 3.11)
     - module --force purge
     - module load Stages/2024
     - module load GCC
@@ -69,6 +68,7 @@ test_JUWELS:
     - module load mpi4py
     - module load SciPy-Stack
     - module load CuPy
+    - FFTW_LIBRARY_DIR="/p/software/juwels/stages/2024/software/FFTW/3.3.10-GCC-12.3.0/lib64" pip install --force-reinstall -e mpi4py-fft/.
   script:
     # - touch benchmarks/output.json
     - echo $SYSTEMNAME

--- a/pySDC/implementations/transfer_classes/TransferMesh_MPIFFT.py
+++ b/pySDC/implementations/transfer_classes/TransferMesh_MPIFFT.py
@@ -32,6 +32,12 @@ class fft_to_fft(space_transfer):
         self.ratio = [int(nf / nc) for nf, nc in zip(Nf, Nc)]
         axes = tuple(range(len(Nf)))
 
+        fft_args = {}
+        useGPU = 'cupy' in self.fine_prob.dtype_u.__name__.lower()
+        if useGPU:
+            fft_args['backend'] = 'cupy'
+            fft_args['comm_backend'] = 'NCCL'
+
         self.fft_pad = PFFT(
             self.coarse_prob.comm,
             Nc,
@@ -39,6 +45,7 @@ class fft_to_fft(space_transfer):
             axes=axes,
             dtype=self.coarse_prob.fft.dtype(False),
             slab=True,
+            **fft_args,
         )
 
     def restrict(self, F):

--- a/pySDC/implementations/transfer_classes/TransferMesh_MPIFFT.py
+++ b/pySDC/implementations/transfer_classes/TransferMesh_MPIFFT.py
@@ -1,6 +1,5 @@
 from pySDC.core.Errors import TransferError
 from pySDC.core.SpaceTransfer import space_transfer
-from pySDC.implementations.datatype_classes.mesh import mesh, imex_mesh
 from mpi4py_fft import PFFT, newDistArray
 
 
@@ -77,7 +76,7 @@ class fft_to_fft(space_transfer):
         if hasattr(type(F), 'components'):
             for comp in F.components:
                 _restrict(F.__getattr__(comp), G.__getattr__(comp))
-        elif type(F).__name__ == 'mesh':
+        elif type(F).__name__ in ['mesh', 'cupy_mesh']:
             _restrict(F, G)
         else:
             raise TransferError('Wrong data type for restriction, got %s' % type(F))
@@ -121,7 +120,7 @@ class fft_to_fft(space_transfer):
         if hasattr(type(F), 'components'):
             for comp in F.components:
                 _prolong(G.__getattr__(comp), F.__getattr__(comp))
-        elif type(G).__name__ == 'mesh':
+        elif type(G).__name__ in ['mesh', 'cupy_mesh']:
             _prolong(G, F)
 
         else:


### PR DESCRIPTION
Because the GPU port of mpi4py-fft is still not merged and I don't see it happening anytime soon, I install my fork in the pipeline now. For some reason it didn't work when I put in the `prepare_juwels` job. Maybe someone knows what I did wrong  and has a suggestion such that it doesn't need to be reinstalled in the matrix job (which may be flaky again...).
This is not great, but without knowing what I am doing, I can't find a better solution...

This should be all that is needed to do very large space-time-time parallel PFASSTER runs on GPUs btw.