### PR TITLE
Tweaks for `FrozenClass`

### DIFF
--- a/pySDC/core/Level.py
+++ b/pySDC/core/Level.py
@@ -21,8 +21,7 @@ class _Pars(FrozenClass):
 class _Status(FrozenClass):
     """
     This class carries the status of the level. All variables that the core SDC / PFASST functionality depend on are
-    initialized here, while the convergence controllers are allowed to add more variables in a controlled fashion
-    later on using the `add_variable` function.
+    initialized here.
     """
 
     def __init__(self):

--- a/pySDC/core/Step.py
+++ b/pySDC/core/Step.py
@@ -20,8 +20,7 @@ class _Pars(FrozenClass):
 class _Status(FrozenClass):
     """
     This class carries the status of the step. All variables that the core SDC / PFASST functionality depend on are
-    initialized here, while the convergence controllers are allowed to add more variables in a controlled fashion
-    later on using the `add_variable` function.
+    initialized here.
     """
 
     def __init__(self):

--- a/pySDC/helpers/pysdc_helper.py
+++ b/pySDC/helpers/pysdc_helper.py
@@ -6,6 +6,8 @@ class FrozenClass(object):
         __isfrozen: Flag to freeze a class
     """
 
+    attrs = []
+
     __isfrozen = False
 
     def __setattr__(self, key, value):
@@ -18,9 +20,26 @@ class FrozenClass(object):
         """
 
         # check if attribute exists and if class is frozen
-        if self.__isfrozen and not hasattr(self, key):
-            raise TypeError("%r is a frozen class" % self)
+        if self.__isfrozen and not (key in self.attrs or hasattr(self, key)):
+            raise TypeError(
+                f'{type(self).__name__!r} is a frozen class with attributes {self.attrs}, cannot modify attribute {key!r}'
+            )
+
         object.__setattr__(self, key, value)
+        type(self).add_attr(key)
+
+    @classmethod
+    def add_attr(cls, key, raise_error_if_exists=False):
+        """
+        Add a key to the allowed attributes of this class.
+
+        Args:
+            key (str): The key to add
+            raise_error_if_exists (bool): Raise an error if the attribute already exists in the class
+        """
+        if key in cls.attrs and raise_error_if_exists:
+            raise TypeError(f'Attribute {key!r} already exists in {cls.__name__}!')
+        cls.attrs += [key]
 
     def _freeze(self):
         """

--- a/pySDC/helpers/pysdc_helper.py
+++ b/pySDC/helpers/pysdc_helper.py
@@ -59,3 +59,9 @@ class FrozenClass(object):
             __dict__.get(key, default)
         """
         return self.__dict__.get(key, default)
+
+    def __dir__(self):
+        """
+        My hope is that some editors can use this for dynamic autocompletion.
+        """
+        return super().__dir__() + self.attrs

--- a/pySDC/helpers/pysdc_helper.py
+++ b/pySDC/helpers/pysdc_helper.py
@@ -31,6 +31,8 @@ class FrozenClass(object):
         """
         if key in self.attrs:
             return None
+        else:
+            super().__getattr__(key)
 
     @classmethod
     def add_attr(cls, key, raise_error_if_exists=False):
@@ -66,6 +68,6 @@ class FrozenClass(object):
 
     def __dir__(self):
         """
-        My hope is that some editors can use this for dynamic autocompletion. Mine can't atm.
+        My hope is that some editors can use this for dynamic autocompletion.
         """
         return super().__dir__() + self.attrs

--- a/pySDC/helpers/pysdc_helper.py
+++ b/pySDC/helpers/pysdc_helper.py
@@ -21,12 +21,16 @@ class FrozenClass(object):
 
         # check if attribute exists and if class is frozen
         if self.__isfrozen and not (key in self.attrs or hasattr(self, key)):
-            raise TypeError(
-                f'{type(self).__name__!r} is a frozen class with attributes {self.attrs}, cannot modify attribute {key!r}'
-            )
+            raise TypeError(f'{type(self).__name__!r} is a frozen class, cannot add attribute {key!r}')
 
         object.__setattr__(self, key, value)
-        type(self).add_attr(key)
+
+    def __getattr__(self, key):
+        """
+        This is needed in case the variables have not been initialized after adding.
+        """
+        if key in self.attrs:
+            return None
 
     @classmethod
     def add_attr(cls, key, raise_error_if_exists=False):
@@ -62,6 +66,6 @@ class FrozenClass(object):
 
     def __dir__(self):
         """
-        My hope is that some editors can use this for dynamic autocompletion.
+        My hope is that some editors can use this for dynamic autocompletion. Mine can't atm.
         """
         return super().__dir__() + self.attrs

--- a/pySDC/implementations/convergence_controller_classes/basic_restarting.py
+++ b/pySDC/implementations/convergence_controller_classes/basic_restarting.py
@@ -76,36 +76,26 @@ class BasicRestarting(ConvergenceController):
 
         return {**defaults, **super().setup(controller, params, description, **kwargs)}
 
-    def setup_status_variables(self, controller, **kwargs):
+    def setup_status_variables(self, *args, **kwargs):
         """
         Add status variables for whether to restart now and how many times the step has been restarted in a row to the
         Steps
 
-        Args:
-            controller (pySDC.Controller): The controller
-            reset (bool): Whether the function is called for the first time or to reset
-
         Returns:
             None
         """
-        where = ["S" if 'comm' in kwargs.keys() else "MS", "status"]
-        self.add_variable(controller, name='restart', where=where, init=False)
-        self.add_variable(controller, name='restarts_in_a_row', where=where, init=0)
+        self.add_status_variable_to_step('restart', False)
+        self.add_status_variable_to_step('restarts_in_a_row', 0)
 
-    def reset_status_variables(self, controller, reset=False, **kwargs):
+    def reset_status_variables(self, *args, **kwargs):
         """
         Add status variables for whether to restart now and how many times the step has been restarted in a row to the
         Steps
 
-        Args:
-            controller (pySDC.Controller): The controller
-            reset (bool): Whether the function is called for the first time or to reset
-
         Returns:
             None
         """
-        where = ["S" if 'comm' in kwargs.keys() else "MS", "status"]
-        self.reset_variable(controller, name='restart', where=where, init=False)
+        self.set_step_status_variable('restart', False)
 
     def dependencies(self, controller, description, **kwargs):
         """

--- a/pySDC/implementations/convergence_controller_classes/estimate_contraction_factor.py
+++ b/pySDC/implementations/convergence_controller_classes/estimate_contraction_factor.py
@@ -39,41 +39,17 @@ class EstimateContractionFactor(ConvergenceController):
             description=description,
         )
 
-    def setup_status_variables(self, controller, **kwargs):
+    def setup_status_variables(self, *args, **kwargs):
         """
         Add the embedded error, contraction factor and iterations to convergence variable to the status of the levels.
 
-        Args:
-            controller (pySDC.Controller): The controller
-
         Returns:
             None
         """
-        if 'comm' in kwargs.keys():
-            steps = [controller.S]
-        else:
-            if 'active_slots' in kwargs.keys():
-                steps = [controller.MS[i] for i in kwargs['active_slots']]
-            else:
-                steps = controller.MS
-        where = ["levels", "status"]
-        for S in steps:
-            self.add_variable(S, name='error_embedded_estimate_last_iter', where=where, init=None)
-            self.add_variable(S, name='contraction_factor', where=where, init=None)
-            if self.params.e_tol is not None:
-                self.add_variable(S, name='iter_to_convergence', where=where, init=None)
-
-    def reset_status_variables(self, controller, **kwargs):
-        """
-        Reinitialize new status variables for the levels.
-
-        Args:
-            controller (pySDC.controller): The controller
-
-        Returns:
-            None
-        """
-        self.setup_status_variables(controller, **kwargs)
+        self.add_status_variable_to_level('error_embedded_estimate_last_iter')
+        self.add_status_variable_to_level('contraction_factor')
+        if self.params.e_tol is not None:
+            self.add_status_variable_to_level('iter_to_convergence')
 
     def post_iteration_processing(self, controller, S, **kwargs):
         """

--- a/pySDC/implementations/convergence_controller_classes/estimate_embedded_error.py
+++ b/pySDC/implementations/convergence_controller_classes/estimate_embedded_error.py
@@ -114,19 +114,7 @@ class EstimateEmbeddedError(ConvergenceController):
         Args:
             controller (pySDC.Controller): The controller
         """
-        if 'comm' in kwargs.keys():
-            steps = [controller.S]
-        else:
-            if 'active_slots' in kwargs.keys():
-                steps = [controller.MS[i] for i in kwargs['active_slots']]
-            else:
-                steps = controller.MS
-        where = ["levels", "status"]
-        for S in steps:
-            self.add_variable(S, name='error_embedded_estimate', where=where, init=None)
-
-    def reset_status_variables(self, controller, **kwargs):
-        self.setup_status_variables(controller, **kwargs)
+        self.add_status_variable_to_level('error_embedded_estimate')
 
     def post_iteration_processing(self, controller, S, **kwargs):
         """
@@ -350,7 +338,7 @@ class EstimateEmbeddedErrorCollocation(ConvergenceController):
                     max([np.finfo(float).eps, abs(self.status.u[-1] - self.status.u[-2])]),
                 )
 
-    def setup_status_variables(self, controller, **kwargs):
+    def setup_status_variables(self, *args, **kwargs):
         """
         Add the embedded error variable to the levels and add a status variable for previous steps.
 
@@ -361,16 +349,7 @@ class EstimateEmbeddedErrorCollocation(ConvergenceController):
         self.status.u = []  # the solutions of converged collocation problems
         self.status.iter = []  # the iteration in which the solution converged
 
-        if 'comm' in kwargs.keys():
-            steps = [controller.S]
-        else:
-            if 'active_slots' in kwargs.keys():
-                steps = [controller.MS[i] for i in kwargs['active_slots']]
-            else:
-                steps = controller.MS
-        where = ["levels", "status"]
-        for S in steps:
-            self.add_variable(S, name='error_embedded_estimate_collocation', where=where, init=None)
+        self.add_status_variable_to_level('error_embedded_estimate_collocation')
 
     def reset_status_variables(self, controller, **kwargs):
         self.setup_status_variables(controller, **kwargs)

--- a/pySDC/implementations/convergence_controller_classes/estimate_embedded_error.py
+++ b/pySDC/implementations/convergence_controller_classes/estimate_embedded_error.py
@@ -350,6 +350,3 @@ class EstimateEmbeddedErrorCollocation(ConvergenceController):
         self.status.iter = []  # the iteration in which the solution converged
 
         self.add_status_variable_to_level('error_embedded_estimate_collocation')
-
-    def reset_status_variables(self, controller, **kwargs):
-        self.setup_status_variables(controller, **kwargs)

--- a/pySDC/implementations/convergence_controller_classes/estimate_extrapolation_error.py
+++ b/pySDC/implementations/convergence_controller_classes/estimate_extrapolation_error.py
@@ -87,26 +87,14 @@ class EstimateExtrapolationErrorBase(ConvergenceController):
         self.reset_status_variables(controller, **kwargs)
         return None
 
-    def reset_status_variables(self, controller, **kwargs):
+    def add_status_variables(self, *args, **kwargs):
         """
         Add variable for extrapolated error
-
-        Args:
-            controller (pySDC.Controller): The controller
 
         Returns:
             None
         """
-        if 'comm' in kwargs.keys():
-            steps = [controller.S]
-        else:
-            if 'active_slots' in kwargs.keys():
-                steps = [controller.MS[i] for i in kwargs['active_slots']]
-            else:
-                steps = controller.MS
-        where = ["levels", "status"]
-        for S in steps:
-            self.add_variable(S, name='error_extrapolation_estimate', where=where, init=None)
+        self.add_status_variable_to_level('error_extrapolation_estimate')
 
     def check_parameters(self, controller, params, description, **kwargs):
         """

--- a/pySDC/implementations/convergence_controller_classes/estimate_extrapolation_error.py
+++ b/pySDC/implementations/convergence_controller_classes/estimate_extrapolation_error.py
@@ -84,16 +84,6 @@ class EstimateExtrapolationErrorBase(ConvergenceController):
         self.coeff.u = [None] * self.params.n
         self.coeff.f = [0.0] * self.params.n
 
-        self.reset_status_variables(controller, **kwargs)
-        return None
-
-    def add_status_variables(self, *args, **kwargs):
-        """
-        Add variable for extrapolated error
-
-        Returns:
-            None
-        """
         self.add_status_variable_to_level('error_extrapolation_estimate')
 
     def check_parameters(self, controller, params, description, **kwargs):

--- a/pySDC/implementations/convergence_controller_classes/estimate_polynomial_error.py
+++ b/pySDC/implementations/convergence_controller_classes/estimate_polynomial_error.py
@@ -1,8 +1,7 @@
 import numpy as np
 
 from pySDC.core.Lagrange import LagrangeApproximation
-from pySDC.core.ConvergenceController import ConvergenceController, Status
-from pySDC.core.Collocation import CollBase
+from pySDC.core.ConvergenceController import ConvergenceController
 
 
 class EstimatePolynomialError(ConvergenceController):
@@ -62,28 +61,15 @@ class EstimatePolynomialError(ConvergenceController):
 
         return defaults
 
-    def reset_status_variables(self, controller, **kwargs):
+    def reset_status_variables(self, *args, **kwargs):
         """
         Add variable for embedded error
-
-        Args:
-            controller (pySDC.Controller): The controller
 
         Returns:
             None
         """
-        if 'comm' in kwargs.keys():
-            steps = [controller.S]
-        else:
-            if 'active_slots' in kwargs.keys():
-                steps = [controller.MS[i] for i in kwargs['active_slots']]
-            else:
-                steps = controller.MS
-
-        where = ["levels", "status"]
-        for S in steps:
-            self.add_variable(S, name='error_embedded_estimate', where=where, init=None)
-            self.add_variable(S, name='order_embedded_estimate', where=where, init=None)
+        self.add_status_variable_to_level('error_embedded_estimate')
+        self.add_status_variable_to_level('order_embedded_estimate')
 
     def matmul(self, A, b):
         """


### PR DESCRIPTION
The idea behind `FrozenClass` is to allow to add and change only certain variables in order to prevent bugs from typos.
These are used in `status` objects, for instance. But we want to allow users to add status variables, without having a huge list of every variable anyone has ever used hardcoded in there.

In this PR, I fix a truly horribly BS solution that I implemented when I didn't know class attributes. I wrote a very complicated function that loops through all objects and bypasses the `__set_attr__` functions by using `__dict__`.
The new solution uses a class attribute for `FrozenClass` and derived classes, which carries a list of the allowed variables. This can easily be appended, of course, but it cannot be confused with simple assignment.
This should also give slightly better performance because the variables have to be added to the class only once, whereas they had to be added to each object before.

I did not do this too thoroughly. Basically, I refactored until the tests passed. I am sure there is some BS left in the convergence controllers related to this. But this I want to do when I have more time for refactoring. I just felt that the current version is too bad to leave as is.