### PR TITLE
FrozenClass performance fix

### DIFF
--- a/pySDC/helpers/pysdc_helper.py
+++ b/pySDC/helpers/pysdc_helper.py
@@ -1,3 +1,6 @@
+import logging
+
+
 class FrozenClass(object):
     """
     Helper class to freeze a class, i.e. to avoid adding more attributes
@@ -43,9 +46,15 @@ class FrozenClass(object):
             key (str): The key to add
             raise_error_if_exists (bool): Raise an error if the attribute already exists in the class
         """
-        if key in cls.attrs and raise_error_if_exists:
-            raise TypeError(f'Attribute {key!r} already exists in {cls.__name__}!')
-        cls.attrs += [key]
+        logger = logging.getLogger(cls.__name__)
+        if key in cls.attrs:
+            if raise_error_if_exists:
+                raise TypeError(f'Attribute {key!r} already exists in {cls.__name__}!')
+            else:
+                logger.debug(f'Skip adding attribute {key!r} because it already exists in {cls.__name__}!')
+        else:
+            cls.attrs += [key]
+            logger.debug(f'Added attribute {key!r} to {cls.__name__}')
 
     def _freeze(self):
         """

--- a/pySDC/tests/test_helpers/test_frozen_class.py
+++ b/pySDC/tests/test_helpers/test_frozen_class.py
@@ -21,7 +21,7 @@ def test_frozen_class():
     assert me.foo is None, 'Attribute persists after reinstantiation'
 
     me.add_attr('foo')
-    assert len(Dummy.attrs) == 1, 'Attribute was added too many times'
+    assert Dummy.attrs.count('foo') == 1, 'Attribute was added too many times'
 
     class Dummy2(FrozenClass):
         pass

--- a/pySDC/tests/test_helpers/test_frozen_class.py
+++ b/pySDC/tests/test_helpers/test_frozen_class.py
@@ -23,6 +23,14 @@ def test_frozen_class():
     me.add_attr('foo')
     assert len(Dummy.attrs) == 1, 'Attribute was added too many times'
 
+    class Dummy2(FrozenClass):
+        pass
+
+    Dummy2.add_attr('bar')
+    you = Dummy2()
+    you.bar = 5
+    assert me.bar is None, 'Attribute was set across classes'
+
 
 if __name__ == '__main__':
     test_frozen_class()

--- a/pySDC/tests/test_helpers/test_frozen_class.py
+++ b/pySDC/tests/test_helpers/test_frozen_class.py
@@ -1,0 +1,28 @@
+import pytest
+
+
+@pytest.mark.base
+def test_frozen_class():
+    from pySDC.helpers.pysdc_helper import FrozenClass
+
+    class Dummy(FrozenClass):
+        pass
+
+    me = Dummy()
+    me.add_attr('foo')
+
+    me.foo = 0
+
+    you = Dummy()
+    you.foo = 1
+    assert me.foo != you.foo, 'Attribute is shared between class instances'
+
+    me = Dummy()
+    assert me.foo is None, 'Attribute persists after reinstantiation'
+
+    me.add_attr('foo')
+    assert len(Dummy.attrs) == 1, 'Attribute was added too many times'
+
+
+if __name__ == '__main__':
+    test_frozen_class()


### PR DESCRIPTION
In #437, I made the names the classes are allowed to have a class attribute of `FrozenClass`. Turns out there are a few issues.
Some convergence controllers added attributes in every step, leading to huge lists. This caused really poor performance. This PR includes a fix for that such that attributes are only ever added once, regardless of whether it is allowed or not.

However, since the allowed attributes are a class attribute of `FrozenClass` they are shared across all derived classes. And I didn't find a quick fix for that. It's not a huge problem. Basically, you add, for instance `error_embedded_estimate` to the status class of level and then you can set `error_embedded_estimate` for the status of the step as well. It's not nice. It doesn't really enforce what the frozen classes are about. I am sure there is a simple solution for this that I am just not able to see at the moment.

