### PR TITLE
Change partition of JUWELS

### DIFF
--- a/etc/juwels_benchmark.sh
+++ b/etc/juwels_benchmark.sh
@@ -2,7 +2,7 @@
 #SBATCH --account=cstma
 #SBATCH --nodes=1
 #SBATCH --time=00:10:00
-#SBATCH --partition=devel
+#SBATCH --partition=batch
 #SBATCH --output=sbatch.out
 #SBATCH --error=sbatch.err
 

--- a/etc/juwels_cupy.sh
+++ b/etc/juwels_cupy.sh
@@ -2,7 +2,7 @@
 #SBATCH --account=cstma
 #SBATCH --nodes=1
 #SBATCH --time=00:10:00
-#SBATCH --partition=develgpus
+#SBATCH --partition=gpus
 #SBATCH --output=sbatch.out
 #SBATCH --error=sbatch.err
 


### PR DESCRIPTION
As the nodes of development partitions are not up-and-running yet.

Therefore, the CI-Jobs shall use the "regular" partitions. Can be reverted later, once the development partitions are back online