### PR TITLE
Playground: Residual components in DAE case when using SDC-DAE sweeper arised from epsilon-embedding

### DIFF
--- a/pySDC/playgrounds/DAE/LinearTestDAEMinion.py
+++ b/pySDC/playgrounds/DAE/LinearTestDAEMinion.py
@@ -1,0 +1,336 @@
+import numpy as np
+
+from pySDC.core.problem import WorkCounter
+from pySDC.projects.DAE.misc.ProblemDAE import ptype_dae
+from pySDC.core.errors import ProblemError
+
+
+class LinearTestDAEMinion(ptype_dae):
+    r"""
+    This class implements a linear stiff DAE problem from [1]_ that is given by
+
+    .. math::
+        \frac{d}{dt} u_1 = u_1 - u_3 + u_4,
+
+    .. math::
+        \frac{d}{dt} u_2 = -10^4 u_2 + (1 + 10^4) e^t, 
+
+    .. math::
+        \frac{d}{dt} u_3 = u_1,
+
+    .. math::
+        0 = u_1 + u_2 + u_4 - e^t
+
+    for :math:`0 < \varepsilon \ll 1`. The linear system at each node is solved by Newton's method. Note
+    that the system can also be solved directly by a linear solver.
+
+    References
+    ----------
+    .. [1] S. Bu, J. Huang, M. L. Minion. Semi-implicit Krylov deferred correction methods for differential
+           algebraic equations. Math. Comput. 81, No. 280, 2127-2157 (2012).
+    """
+
+    def __init__(self, newton_tol=1e-12):
+        """Initialization routine"""
+        super().__init__(nvars=(3, 1), newton_tol=newton_tol)
+        self._makeAttributeAndRegister('newton_tol', localVars=locals())
+        self.work_counters['rhs'] = WorkCounter()
+        self.work_counters['newton'] = WorkCounter()
+
+    def eval_f(self, u, du, t):
+        r"""
+        Routine to evaluate the implicit representation of the problem, i.e., :math:`F(u, u', t)`.
+
+        Parameters
+        ----------
+        u : dtype_u
+            Current values of the numerical solution at time t.
+        du : dtype_u
+            Current values of the derivative of the numerical solution at time t.
+        t : float
+            Current time of the numerical solution.
+
+        Returns
+        -------
+        f : dtype_f
+            The right-hand side of f (contains four components).
+        """
+
+        u1, u2, u3 = u.diff[0], u.diff[1], u.diff[2]
+        du1, du2, du3 = du.diff[0], du.diff[1], du.diff[2]
+        u4 = u.alg[0]
+
+        f = self.dtype_f(self.init)
+        f.diff[0] = u1 - u3 + u4 - du1
+        f.diff[1] = -1e4 * u2 + (1 + 1e4) * np.exp(t) - du2
+        f.diff[2] = u1 - du3
+        f.alg[0] = u1 + u2 + u4 - np.exp(t)
+
+    def u_exact(self, t):
+        r"""
+        Routine for the exact solution at time :math:`t`.
+
+        Parameters
+        ----------
+        t : float
+            Time of the exact solution.
+
+        Returns
+        -------
+        me : dtype_u
+            Exact solution.
+        """
+
+        me = self.dtype_u(self.init)
+        me.diff[0] = np.cos(t)
+        me.diff[1] = np.exp(t)
+        me.diff[2] = np.sin(t)
+        me.alg[0] = -np.cos(t)
+        return me
+
+
+class LinearTestDAEMinionConstrained(LinearTestDAEMinion):
+    r"""
+    In this class the example ``LinearTestDAEMinion`` is implemented in the way that the system to be solved on each node
+    quadrature is only applied to the differential parts. In order to solve this problem ``genericImplicitDAEConstrained``
+    needs to be used.
+
+    Note
+    ----
+    The problem is of the general form
+
+    .. math::
+        \begin{pmatrix}
+            u_1'\\
+            u_2'\\
+            u_3'\\
+            0
+        \end{pmatrix} = \begin{pmatrix}
+            1 & 0 & -1 & 1
+            0 & -10^4 & 0 & 0 \\
+            1 & 0 & 0 & 0 \\
+            1 & 1 & 0 & 1
+        \end{pmatrix}\begin{pmatrix}
+            u_1\\
+            u_2\\
+            u_3\\
+            u_4
+        \end{pmatrix} + \begin{pmatrix}
+            0 \\
+            (1 + 10^4) e^t \\
+            0 \\
+            -e^t
+        \end{pmatrix}
+
+    and it could be think about to also treat this problem in a semi-implicit way.
+    """
+
+    def __init__(self, nvars=(3, 1), newton_tol=1e-12, newton_maxiter=100, stop_at_maxiter=False, stop_at_nan=True):
+        """Initialization routine"""
+        super().__init__()
+        self._makeAttributeAndRegister('newton_tol', 'newton_maxiter', 'stop_at_maxiter', 'stop_at_nan', localVars=locals())
+        self.work_counters['newton'] = WorkCounter()
+        self.work_counters['rhs'] = WorkCounter()
+
+    def eval_f(self, u, t):
+        r"""
+        Routine to evaluate the right-hand side of the problem.
+
+        Parameters
+        ----------
+        u : dtype_u
+            Current values of the numerical solution at time t.
+        t : float
+            Current time of the numerical solution.
+
+        Returns
+        -------
+        f : dtype_f
+            The right-hand side of f (contains four components).
+        """
+
+        u1, u2, u3 = u.diff[0], u.diff[1], u.diff[2]
+        u4 = u.alg[0]
+
+        f = self.dtype_f(self.init)
+        f.diff[0] = u1 - u3 + u4
+        f.diff[1] = -1e4 * u2 + (1 + 1e4) * np.exp(t)
+        f.diff[2] = u1
+        f.alg[0] = u1 + u2 + u4 - np.exp(t)
+        return f
+
+    def solve_system(self, rhs, factor, u0, t):
+        """
+        Simple Newton solver.
+
+        Parameters
+        ----------
+        rhs : dtype_f
+            Right-hand side for the nonlinear system.
+        factor : float
+            Abbrev. for the node-to-node stepsize (or any other factor required).
+        u0 : dtype_u
+            Initial guess for the iterative solver.
+        t : float
+            Current time (required here for the BC).
+
+        Returns
+        -------
+        me : dtype_u
+            The solution as mesh.
+        """
+
+        u = self.dtype_u(u0)
+
+        # start newton iteration
+        n = 0
+        res = 99
+        while n < self.newton_maxiter:
+            u1, u2, u3 = u.diff[0], u.diff[1], u.diff[2]
+
+            f = self.eval_f(u, t)
+
+            # form the function g(u), such that the solution to the nonlinear problem is a root of g
+            g = np.array(
+                [
+                    u1 - factor * f.diff[0] - rhs.diff[0],
+                    u2 - factor * f.diff[1] - rhs.diff[1],
+                    u3 - factor * f.diff[2] - rhs.diff[2],
+                    f.alg[0],
+                ]
+            )
+
+            # if g is close to 0, then we are done
+            res = np.linalg.norm(g, np.inf)
+            if res < self.newton_tol:
+                break
+
+            # assemble dg
+            dg = np.array(
+                [
+                    [1 - factor, 0, factor, -factor],
+                    [0, 1 + factor * 1e4, 0, 0],
+                    [-factor, 0, 1, 0],
+                    [1, 1, 0, 1],
+                ]
+            )
+
+            # newton update: u1 = u0 - g/dg
+            dx = np.linalg.solve(dg, g)
+
+            u.diff[0] -= dx[0]
+            u.diff[1] -= dx[1]
+            u.diff[2] -= dx[2]
+            u.alg[0] -= dx[3]
+
+            n += 1
+            self.work_counters['newton']()
+
+        if np.isnan(res) and self.stop_at_nan:
+            raise ProblemError('Newton got nan after %i iterations, aborting...' % n)
+        elif np.isnan(res):
+            self.logger.warning('Newton got nan after %i iterations...' % n)
+
+        if n == self.newton_maxiter:
+            msg = 'Newton did not converge after %i iterations, error is %s' % (n, res)
+            if self.stop_at_maxiter:
+                raise ProblemError(msg)
+            else:
+                self.logger.warning(msg)
+
+        me = self.dtype_u(self.init)
+        me[:] = u[:]
+
+        return me
+
+
+class LinearTestDAEMinionEmbedded(LinearTestDAEMinionConstrained):
+    r"""
+    The problem in this class inherits from the example(s) above and can be solved using the embedded SDC scheme ``genericImplicitEmbedded``.
+    ``solve_system`` is constructed so that the implicit system to be solved on each node uses neither the initial condition
+    :math:`\mathbf{z}_0` nor the information of the solution to the next iteration on the left-hand side :math:`\mathbf{z}^{k+1}`. That means
+    quadrature is still applied to all parts of the problem but due to the embedding information just mentioned are not used.
+    """
+
+    def solve_system(self, rhs, factor, u0, t):
+        """
+        Simple Newton solver.
+
+        Parameters
+        ----------
+        rhs : dtype_f
+            Right-hand side for the nonlinear system.
+        factor : float
+            Abbrev. for the node-to-node stepsize (or any other factor required).
+        u0 : dtype_u
+            Initial guess for the iterative solver.
+        t : float
+            Current time (required here for the BC).
+
+        Returns
+        -------
+        me : dtype_u
+            The solution as mesh.
+        """
+
+        u = self.dtype_u(u0)
+
+        # start newton iteration
+        n = 0
+        res = 99
+        while n < self.newton_maxiter:
+            u1, u2, u3 = u.diff[0], u.diff[1], u.diff[2]
+
+            f = self.eval_f(u, t)
+
+            # form the function g(u), such that the solution to the nonlinear problem is a root of g
+            g = np.array(
+                [
+                    u1 - factor * f.diff[0] - rhs.diff[0],
+                    u2 - factor * f.diff[1] - rhs.diff[1],
+                    u3 - factor * f.diff[2] - rhs.diff[2],
+                    -factor * f.alg[0] - rhs.alg[0],
+                ]
+            )
+
+            # if g is close to 0, then we are done
+            res = np.linalg.norm(g, np.inf)
+            if res < self.newton_tol:
+                break
+
+            # assemble dg
+            dg = np.array(
+                [
+                    [1 - factor, 0, factor, -factor],
+                    [0, 1 + factor * 1e4, 0, 0],
+                    [-factor, 0, 1, 0],
+                    [-factor, -factor, 0, -factor],
+                ]
+            )
+
+            # newton update: u1 = u0 - g/dg
+            dx = np.linalg.solve(dg, g)
+
+            u.diff[0] -= dx[0]
+            u.diff[1] -= dx[1]
+            u.diff[2] -= dx[2]
+            u.alg[0] -= dx[3]
+
+            n += 1
+            self.work_counters['newton']()
+
+        if np.isnan(res) and self.stop_at_nan:
+            raise ProblemError('Newton got nan after %i iterations, aborting...' % n)
+        elif np.isnan(res):
+            self.logger.warning('Newton got nan after %i iterations...' % n)
+
+        if n == self.newton_maxiter:
+            msg = 'Newton did not converge after %i iterations, error is %s' % (n, res)
+            if self.stop_at_maxiter:
+                raise ProblemError(msg)
+            else:
+                self.logger.warning(msg)
+
+        me = self.dtype_u(self.init)
+        me[:] = u[:]
+        return me

--- a/pySDC/playgrounds/DAE/genericImplicitDAE.py
+++ b/pySDC/playgrounds/DAE/genericImplicitDAE.py
@@ -1,0 +1,373 @@
+from pySDC.implementations.sweeper_classes.generic_implicit import generic_implicit
+from pySDC.core.errors import ParameterError
+
+
+class genericImplicitConstrained(generic_implicit):
+    r"""
+    Base sweeper class for solving differential-algebraic equations of the form
+
+    .. math::
+        y' = f(y, z),
+
+    .. math::
+        0 = g(y, z).
+    
+    The SDC scheme applied to semi-explicit DAEs where no quadrature is applied to the constrains reads
+
+    .. math::
+       \mathbf{y}^{k+1} = \mathbf{y}_0 + \Delta t (\mathbf{Q} - \mathbf{Q}_\Delta)\otimes \mathbf{I}_{N_d}f(\mathbf{y}^{k}, \mathbf{z}^{k}) +
+       \Delta t \mathbf{Q}_\Delta\otimes \mathbf{I}_{N_d}f(\mathbf{y}^{k+1}, \mathbf{z}^{k+1}),
+
+    .. math::
+       \mathbf{0} = g(\mathbf{y}^{k+1}, \mathbf{z}^{k+1}).
+
+    Parameters
+    ----------
+    params : dict
+        Parameters passed to the sweeper.
+    """
+
+    def __init__(self, params):
+        """Initialization routine"""
+
+        if 'QI' not in params:
+            params['QI'] = 'IE'
+
+        # call parent's initialization routine
+        super().__init__(params)
+
+        # get QI matrix
+        self.QI = self.get_Qdelta_implicit(qd_type=self.params.QI)
+
+    def integrate(self):
+        """
+        Integrates the right-hand side. Here, only the differential variables are integrated.
+
+        Returns
+        -------
+        me : list of dtype_u
+            Containing the integral as values.
+        """
+
+        L = self.level
+        P = L.prob
+
+        me = []
+
+        # integrate RHS over all collocation nodes
+        for m in range(1, self.coll.num_nodes + 1):
+            # new instance of dtype_u, initialize values with 0
+            me.append(P.dtype_u(P.init, val=0.0))
+            for j in range(1, self.coll.num_nodes + 1):
+                me[-1].diff[:] += L.dt * self.coll.Qmat[m, j] * L.f[j].diff[:]
+
+        return me
+    
+    def update_nodes(self):
+        """
+        Update the u- and f-values at the collocation nodes -> corresponds to a single sweep over all nodes.
+        """
+
+        L = self.level
+        P = L.prob
+
+        # only if the level has been touched before
+        assert L.status.unlocked
+
+        # get number of collocation nodes for easier access
+        M = self.coll.num_nodes
+
+        # update the MIN-SR-FLEX preconditioner
+        if self.params.QI.startswith('MIN-SR-FLEX'):
+            k = L.status.sweep
+            if k > M:
+                self.params.QI = "MIN-SR-S"
+            else:
+                self.params.QI = 'MIN-SR-FLEX' + str(k)
+            self.QI = self.get_Qdelta_implicit(qd_type=self.params.QI)
+
+        # gather all terms which are known already (e.g. from the previous iteration)
+        # this corresponds to u0 + QF(u^k) - QdF(u^k) + tau
+
+        # get QF(u^k)
+        integral = self.integrate()
+        for m in range(M):
+            # get -QdF(u^k)_m
+            for j in range(1, M + 1):
+                integral[m].diff[:] -= L.dt * self.QI[m + 1, j] * L.f[j].diff[:]
+
+            # add initial value
+            integral[m].diff[:] += L.u[0].diff[:]
+            # add tau if associated
+            if L.tau[m] is not None:
+                integral[m][:] += L.tau[m].diff[:]
+
+        # do the sweep
+        for m in range(0, M):
+            # build rhs, consisting of the known values from above and new values from previous nodes (at k+1)
+            rhs = P.dtype_u(integral[m])
+            for j in range(1, m + 1):
+                rhs.diff[:] += L.dt * self.QI[m + 1, j] * L.f[j].diff[:]
+
+            # implicit solve with prefactor stemming from the diagonal of Qd
+            alpha = L.dt * self.QI[m + 1, m + 1]
+            if alpha == 0:
+                L.u[m + 1] = rhs
+            else:
+                L.u[m + 1] = P.solve_system(rhs, alpha, L.u[m + 1], L.time + L.dt * self.coll.nodes[m])
+            # update function values
+            L.f[m + 1] = P.eval_f(L.u[m + 1], L.time + L.dt * self.coll.nodes[m])
+
+        # indicate presence of new values at this level
+        L.status.updated = True
+
+        return None
+
+    def compute_residual(self, stage=''):
+        """
+        Computation of the residual using the collocation matrix Q. For the residual, collocation matrix Q
+        is only applied to the differential equations since no integration applies to the algebraic constraints.
+
+        Parameters
+        ----------
+        stage : str
+            The current stage of the step the level belongs to.
+        """
+
+        # get current level and problem description
+        L = self.level
+        P = L.prob
+
+        # Check if we want to skip the residual computation to gain performance
+        # Keep in mind that skipping any residual computation is likely to give incorrect outputs of the residual!
+        if stage in self.params.skip_residual_computation:
+            L.status.residual = 0.0 if L.status.residual is None else L.status.residual
+            return None
+
+        # check if there are new values (e.g. from a sweep)
+        # assert L.status.updated
+
+        # compute the residual for each node
+
+        # build QF(u)
+        res_norm = []
+        res = self.integrate()
+        for m in range(self.coll.num_nodes):
+            res[m].diff[:] += L.u[0].diff[:] - L.u[m + 1].diff[:]
+            # add tau if associated
+            if L.tau[m] is not None:
+                res[m].diff[:] += L.tau[m].diff[:]
+            # use abs function from data type here
+            res_norm.append(abs(res[m]))
+
+        # TODO: can this be combined with ``integrate()`` with a separate function ?!
+        res_initial = []
+        for m in range(1, self.coll.num_nodes + 1):
+            # new instance of dtype_u, initialize values with 0
+            res_initial.append(P.dtype_u(P.init, val=0.0))
+            for j in range(1, self.coll.num_nodes + 1):
+                res_initial[-1].diff[:] += L.dt * self.coll.Qmat[m, j] * P.eval_f(L.u[0], L.time + L.dt * self.coll.nodes[j - 1]).diff[:]
+
+        res_initial_norm = []
+        for m in range(self.coll.num_nodes):
+            res_initial[m].diff[:] += L.u[0].diff[:] - L.u[0].diff[:] 
+            res_initial_norm.append(abs(res_initial[m]))
+
+        # find maximal residual over the nodes
+        if L.params.residual_type == 'full_abs':
+            L.status.residual = max(res_norm)
+        elif L.params.residual_type == 'last_abs':
+            L.status.residual = res_norm[-1]
+        elif L.params.residual_type == 'full_rel':
+            L.status.residual = max(res_norm) / abs(L.u[0])
+        elif L.params.residual_type == 'last_rel':
+            L.status.residual = res_norm[-1] / abs(L.u[0])
+        elif L.params.residual_type == 'initial_rel':
+            L.status.residual = max(res_norm) / max(res_initial_norm)
+        else:
+            raise ParameterError(
+                f'residual_type = {L.params.residual_type} not implemented, choose '
+                f'full_abs, last_abs, full_rel or last_rel instead'
+            )
+
+        # indicate that the residual has seen the new values
+        L.status.updated = False
+
+        return None
+
+
+class genericImplicitEmbedded(generic_implicit):
+    r"""
+    This is a test sweeper for solving differential-algebraic equations of the form
+
+    .. math::
+        y' = f(y, z),
+
+    .. math::
+        0 = g(y, z).
+    
+    When the :math:`\varepsilon`-embedding is applied to the SDC scheme for a singular
+    perturbed problem we end up with the scheme
+
+    .. math::
+       \mathbf{y}^{k+1} = \mathbf{y}_0 + \Delta t (\mathbf{Q} - \mathbf{Q}_\Delta)\otimes \mathbf{I}_{N_d}f(\mathbf{y}^{k}, \mathbf{z}^{k}) +
+       \Delta t \mathbf{Q}_\Delta\otimes \mathbf{I}_{N_d}f(\mathbf{y}^{k+1}, \mathbf{z}^{k+1}),
+
+    .. math::
+       \mathbf{0} = \Delta t (\mathbf{Q} - \mathbf{Q}_\Delta)\otimes \mathbf{I}_{N_d}g(\mathbf{y}^{k}, \mathbf{z}^{k}) +
+       \Delta t \mathbf{Q}_\Delta\otimes \mathbf{I}_{N_a}g(\mathbf{y}^{k+1}, \mathbf{z}^{k+1}).
+
+    Parameters
+    ----------
+    params : dict
+        Parameters passed to the sweeper.
+
+    Note
+    ----
+    Deriving this scheme, only :math:`\varepsilon=0` is set in the SDC method for singular perturbed problems. In other words,
+    the scheme is embedded in the way that it can be naively applied to the corresponding DAE.
+    """
+
+    def __init__(self, params):
+        """Initialization routine"""
+
+        if 'QI' not in params:
+            params['QI'] = 'IE'
+
+        # call parent's initialization routine
+        super().__init__(params)
+
+        # get QI matrix
+        self.QI = self.get_Qdelta_implicit(qd_type=self.params.QI)
+
+    def update_nodes(self):
+        """
+        Update the u- and f-values at the collocation nodes -> corresponds to a single sweep over all nodes.
+        """
+
+        L = self.level
+        P = L.prob
+
+        # only if the level has been touched before
+        assert L.status.unlocked
+
+        # get number of collocation nodes for easier access
+        M = self.coll.num_nodes
+
+        # update the MIN-SR-FLEX preconditioner
+        if self.params.QI.startswith('MIN-SR-FLEX'):
+            k = L.status.sweep
+            if k > M:
+                self.params.QI = "MIN-SR-S"
+            else:
+                self.params.QI = 'MIN-SR-FLEX' + str(k)
+            self.QI = self.get_Qdelta_implicit(qd_type=self.params.QI)
+
+        # gather all terms which are known already (e.g. from the previous iteration)
+        # this corresponds to u0 + QF(u^k) - QdF(u^k) + tau
+
+        # get QF(u^k)
+        integral = self.integrate()
+        for m in range(M):
+            # get -QdF(u^k)_m
+            for j in range(1, M + 1):
+                integral[m][:] -= L.dt * self.QI[m + 1, j] * L.f[j][:]
+            # add initial value - here, u0 is only added to differential part
+            integral[m].diff[:] += L.u[0].diff[:]
+            # add tau if associated
+            if L.tau[m] is not None:
+                integral[m][:] += L.tau[m]
+
+        # do the sweep
+        for m in range(0, M):
+            # build rhs, consisting of the known values from above and new values from previous nodes (at k+1)
+            rhs = P.dtype_u(integral[m])
+            for j in range(1, m + 1):
+                rhs[:] += L.dt * self.QI[m + 1, j] * L.f[j][:]
+
+            # implicit solve with prefactor stemming from the diagonal of Qd
+            alpha = L.dt * self.QI[m + 1, m + 1]
+            if alpha == 0:
+                L.u[m + 1] = rhs
+            else:
+                L.u[m + 1] = P.solve_system(rhs, alpha, L.u[m + 1], L.time + L.dt * self.coll.nodes[m])
+            # update function values
+            L.f[m + 1] = P.eval_f(L.u[m + 1], L.time + L.dt * self.coll.nodes[m])
+
+        # indicate presence of new values at this level
+        L.status.updated = True
+
+        return None
+
+    def compute_residual(self, stage=''):
+        """
+        Computation of the residual using the collocation matrix Q. For all equations, quadrature is applied.
+        Note that in this embedded scheme, information of initial condition of :math:`z_0` and the current value
+        :math:`u^{k+1}` from the left-hand side is not used here.
+
+        Parameters
+        ----------
+        stage : str
+            The current stage of the step the level belongs to.
+        """
+
+        # get current level and problem description
+        L = self.level
+        P = L.prob
+
+        # Check if we want to skip the residual computation to gain performance
+        # Keep in mind that skipping any residual computation is likely to give incorrect outputs of the residual!
+        if stage in self.params.skip_residual_computation:
+            L.status.residual = 0.0 if L.status.residual is None else L.status.residual
+            return None
+
+        # check if there are new values (e.g. from a sweep)
+        # assert L.status.updated
+
+        # compute the residual for each node
+
+        # build QF(u)
+        res_norm = []
+        res = self.integrate()
+        for m in range(self.coll.num_nodes):
+            res[m].diff[:] += L.u[0].diff[:] - L.u[m + 1].diff[:]
+            # add tau if associated
+            if L.tau[m] is not None:
+                res[m][:] += L.tau[m][:]
+            # use abs function from data type here
+            res_norm.append(abs(res[m]))
+
+        # TODO: can this be combined with ``integrate()`` with a separate function ?!
+        res_initial = []
+        for m in range(1, self.coll.num_nodes + 1):
+            # new instance of dtype_u, initialize values with 0
+            res_initial.append(P.dtype_u(P.init, val=0.0))
+            for j in range(1, self.coll.num_nodes + 1):
+                res_initial[-1] += L.dt * self.coll.Qmat[m, j] * P.eval_f(L.u[0], L.time + L.dt * self.coll.nodes[j - 1])
+
+        res_initial_norm = []
+        for m in range(self.coll.num_nodes):
+            res_initial[m].diff[:] += L.u[0].diff[:] - L.u[0].diff[:] 
+            res_initial_norm.append(abs(res_initial[m]))
+
+        # find maximal residual over the nodes
+        if L.params.residual_type == 'full_abs':
+            L.status.residual = max(res_norm)
+        elif L.params.residual_type == 'last_abs':
+            L.status.residual = res_norm[-1]
+        elif L.params.residual_type == 'full_rel':
+            L.status.residual = max(res_norm) / abs(L.u[0])
+        elif L.params.residual_type == 'last_rel':
+            L.status.residual = res_norm[-1] / abs(L.u[0])
+        elif L.params.residual_type == 'initial_rel':
+            L.status.residual = max(res_norm) / max(res_initial_norm)
+        else:
+            raise ParameterError(
+                f'residual_type = {L.params.residual_type} not implemented, choose '
+                f'full_abs, last_abs, full_rel or last_rel instead'
+            )
+
+        # indicate that the residual has seen the new values
+        L.status.updated = False
+
+        return None

--- a/pySDC/playgrounds/DAE/log_residual_components.py
+++ b/pySDC/playgrounds/DAE/log_residual_components.py
@@ -1,0 +1,45 @@
+from pySDC.core.hooks import Hooks
+
+
+class LogResidualComponentsPostIter(Hooks):
+    """
+    Logs the residual of all components of the system after each iteration.
+
+    Parameters
+    ----------
+    Hooks : _type_
+        _description_
+    """
+
+    def post_iteration(self, step, level_number):
+        r"""
+        Default routine called after each step.
+
+        Parameters
+        ----------
+        step : pySDC.core.Step
+            Current step.
+        level_number : pySDC.core.level
+            Current level number.
+        """
+
+        super().post_iteration(step, level_number)
+
+        L = step.levels[level_number]
+        P = L.prob
+
+        L.sweep.compute_end_point()
+
+        L = step.levels[level_number]
+
+        L.sweep.compute_end_point()
+
+        self.add_to_stats(
+            process=step.status.slot,
+            time=L.time + L.dt,
+            level=L.level_index,
+            iter=step.status.iter,
+            sweep=L.status.sweep,
+            type='residual_comp_post_iter',
+            value=L.sweep.residual_components,
+        )

--- a/pySDC/playgrounds/DAE/residual_components.py
+++ b/pySDC/playgrounds/DAE/residual_components.py
@@ -68,7 +68,7 @@ def run(dt, restol, maxiter, M, QI, problem, sweeper, t0, Tend, hook_class):
 
     # initialize step parameters
     step_params = {
-        'maxiter': 60,
+        'maxiter': maxiter,
     }
 
     # initialize controller parameters

--- a/pySDC/playgrounds/DAE/residual_components.py
+++ b/pySDC/playgrounds/DAE/residual_components.py
@@ -1,0 +1,202 @@
+import numpy as np
+from pathlib import Path
+import matplotlib.pyplot as plt
+
+from pySDC.playgrounds.DAE.genericImplicitDAE import genericImplicitConstrained, genericImplicitEmbedded, genericImplicitOriginal
+from pySDC.playgrounds.DAE.LinearTestDAEMinion import LinearTestDAEMinionConstrained, LinearTestDAEMinionEmbedded
+from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
+
+from pySDC.playgrounds.DAE.log_residual_components import LogResidualComponentsPostIter
+
+from pySDC.helpers.stats_helper import get_sorted
+
+
+def flatten_nested_list(nested_list):
+    flattened_list = [sublist for sublist in nested_list]
+    result_list = []
+    for sublist in flattened_list:
+        extracted_elements = [element[1] for element in sublist]
+        if len(extracted_elements) > 0:
+            result_list.append([element[1] for element in sublist])
+    result_list = [element[0] for element in result_list]
+    return result_list
+
+
+def run(dt, restol, maxiter, M, QI, problem, sweeper, t0, Tend, hook_class):
+    r"""
+    It simply generates a description without any unnecessary stuff. Then, a run is simulated for a problem.
+
+    Parameters
+    dt : float
+        Time step size.
+    restol : float
+        Residual tolerance used to execute.
+    maxiter : int
+        Number of maximum iterations.
+    M : int
+        Number of collocation nodes.
+    QI : np.2darray
+        Matrix :math:`Q_\Delta`.
+    problem : pySDC.projects.DAE.misc.ptype_dae
+        Problem class to be solved.
+    sweeper : pySDC.core.Sweeper
+        Sweeper used for simulation.
+    t0 : float
+        Staring time.
+    Tend : float
+        End time
+    """
+
+    # initialize level parameters
+    level_params = {
+        'restol': restol,
+        'dt': dt,
+    }
+
+    # initialize problem parameters
+    problem_params = {
+        'newton_tol': 1e-12,
+    }
+
+    # initialize sweeper parameters
+    sweeper_params = {
+        'quad_type': 'RADAU-RIGHT',
+        'num_nodes': M,
+        'QI': QI,
+        'initial_guess': 'spread',
+    }
+
+    # initialize step parameters
+    step_params = {
+        'maxiter': 60,
+    }
+
+    # initialize controller parameters
+    controller_params = {
+        'logger_level': 30,
+        'hook_class' : hook_class
+    }
+
+    # fill description dictionary for easy step instantiation
+    description = {
+        'problem_class': problem,
+        'problem_params': problem_params,
+        'sweeper_class': sweeper,
+        'sweeper_params': sweeper_params,
+        'level_params': level_params,
+        'step_params': step_params,
+    }
+
+    # instantiate controller
+    controller = controller_nonMPI(num_procs=1, controller_params=controller_params, description=description)
+
+    t0 = t0
+    Tend = Tend
+
+    P = controller.MS[0].levels[0].prob
+    uinit = P.u_exact(t0)
+
+    Path("data").mkdir(parents=True, exist_ok=True)
+
+    # call main function to get things done...
+    _, stats = controller.run(u0=uinit, t0=t0, Tend=Tend)
+
+    return stats
+
+
+def main():
+    r"""
+    In this main function all the things are done to plot the components for the residual. Here, also the original generic_implicit sweeper
+    is applied in the way to the problem so that quadrature is not applied to the algebraic parts. This can be don as long as the
+    ``solve_system`` does the correct things.
+    """
+
+    problems = [LinearTestDAEMinionConstrained, LinearTestDAEMinionEmbedded, LinearTestDAEMinionConstrained]
+    sweepers = [genericImplicitConstrained, genericImplicitEmbedded, genericImplicitOriginal]
+
+    hook_class = [LogResidualComponentsPostIter]
+
+    M = 5
+    QI = 'LU'  # try also 'IE' to see how the residual component in algebraic equation behaves!
+    restol = -1
+    maxiter = 40
+
+    t0 = 0.0
+    dtValues = [0.5, 0.2, 0.1, 0.05, 0.02, 0.01, 0.005, 0.002, 0.001]
+
+    color = ['firebrick', 'dodgerblue', 'forestgreen', 'black']
+
+    for i, dt in enumerate(dtValues):
+        fig, ax = plt.subplots(1, 2, figsize=(17.0, 9.5))
+        fig2, ax2 = plt.subplots(1, 1, figsize=(9.5, 9.5))
+
+        for ind, (problem, sweeper) in enumerate(zip(problems, sweepers)):
+            ax_wrapper = ax[ind] if ind < 2 else ax2
+
+            Tend = t0 + dt
+            stats = run(dt, restol, maxiter, M, QI, problem, sweeper, t0, Tend, hook_class)
+
+            residual_components_iter = [get_sorted(stats, iter=k, type='residual_comp_post_iter', sortby='time') for k in range(1, maxiter + 1)]
+            residual_components_iter = flatten_nested_list(residual_components_iter)
+
+            if sweeper.__name__ == 'genericImplicitEmbedded':
+                linestyle = 'solid'
+                title = r"Residual components of $\mathtt{SDC-E}$"
+            elif sweeper.__name__ == 'genericImplicitConstrained':
+                linestyle = 'dashed'
+                title = r"Residual components of $\mathtt{SDC-C}$"
+            else:
+                linestyle = 'dashed'
+                title = "Residual components of original SDC-ODE sweeper"
+
+            solid_capstyle = 'round' if linestyle == 'solid' else None
+            dash_capstyle = 'round' if linestyle == 'dashed' else None
+
+            ax_wrapper.set_title(title)
+            for diff_ind in range(len(residual_components_iter[0].diff)):
+                ax_wrapper.semilogy(
+                    np.arange(1, len(residual_components_iter) + 1),
+                    [abs(comp[0][diff_ind]) for comp in residual_components_iter],
+                    color=color[diff_ind],
+                    linewidth=4.0,
+                    linestyle=linestyle,
+                    solid_capstyle=solid_capstyle,
+                    dash_capstyle=dash_capstyle,
+                    label=rf"$u_{diff_ind + 1}$",
+                )
+
+            ax_wrapper.semilogy(
+                np.arange(1, len(residual_components_iter) + 1),
+                [abs(comp[1][0]) for comp in residual_components_iter],
+                color=color[-1],
+                linewidth=4.0,
+                linestyle=linestyle,
+                marker='o',
+                markersize=10.0,
+                solid_capstyle=solid_capstyle,
+                dash_capstyle=dash_capstyle,
+                label=r"$u_4$",
+            )
+
+            ax_wrapper.tick_params(axis='both', which='major', labelsize=14)
+            ax_wrapper.set_xlabel(r'Iteration $k$', fontsize=20)
+            ax_wrapper.set_xlim(0, maxiter + 1)
+            ax_wrapper.set_yscale('symlog', linthresh=1e-17)
+            ax_wrapper.set_ylim(-1e-17, 1e1)
+            ax_wrapper.minorticks_off()
+
+        ax[0].set_ylabel(r"$||r_{u_{1, 2, 3, 4}}^k||_\infty$", fontsize=20)
+        ax[0].legend(frameon=False, fontsize=12, loc='upper right', ncols=2)
+
+        ax2.set_ylabel(r"$||r_{u_{1, 2, 3, 4}}^k||_\infty$", fontsize=20)
+        ax2.legend(frameon=False, fontsize=12, loc='upper right', ncols=2)
+
+        fig.savefig(f"data/{i}_plotResidualComponentsEmbedding_dt={dt}.png", dpi=300, bbox_inches='tight')
+        plt.close(fig)
+
+        fig2.savefig(f"data/{i}_plotResidualComponentsOriginal_dt={dt}.png", dpi=300, bbox_inches='tight')
+        plt.close(fig2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The $\varepsilon$-embedding can be used to derive reasonable schemes for (semi-explicit) DAEs that are close to stiff ODEs. When we consider a scalar problem of the form $$y'=f(y, z),$$ $$\varepsilon z' = g(y,z),$$ for $0 < \varepsilon \ll 1$, then setting $\varepsilon=0$ results in the semi-explicit DAE $$y'=f(y, z),$$ $$0 = g(y,z).$$ Thus, when SDC is applied to the ODE we get the scheme $$\mathbf{y}^{k+1} = \mathbf{y}_0 + \Delta t (\mathbf{Q}-\mathbf{Q}_d) f(\mathbf{y}^k,\mathbf{z}^k) + \Delta t \mathbf{Q}_d f(\mathbf{y}^{k+1},\mathbf{z}^{k+1}),$$ $$\varepsilon\mathbf{z}^{k+1} = \varepsilon\mathbf{z}_0 + \Delta t (\mathbf{Q}-\mathbf{Q}_d) g(\mathbf{y}^k,\mathbf{z}^k) + \Delta t \mathbf{Q}_d g(\mathbf{y}^{k+1},\mathbf{z}^{k+1}).$$ Again, setting $\varepsilon=0$ results in a first possible SDC scheme to solve the DAE: $$\mathbf{y}^{k+1} = \mathbf{y}_0 + \Delta t (\mathbf{Q}-\mathbf{Q}_d) f(\mathbf{y}^k,\mathbf{z}^k) + \Delta t \mathbf{Q}_d f(\mathbf{y}^{k+1},\mathbf{z}^{k+1}),$$ $$0 = \Delta t (\mathbf{Q}-\mathbf{Q}_d) g(\mathbf{y}^k,\mathbf{z}^k) + \Delta t \mathbf{Q}_d g(\mathbf{y}^{k+1},\mathbf{z}^{k+1}).$$ which is called $\mathtt{SDC-E}$ or ``genericImplicitEmbedded``. [[E. Hairer, G. Wanner, eq. (1.12) on p. 375]](https://link.springer.com/book/10.1007/978-3-642-05221-7) suggested treating the algebraic constraints _directly_. Thus, another reasonable SDC scheme is $$\mathbf{y}^{k+1} = \mathbf{y}_0 + \Delta t (\mathbf{Q}-\mathbf{Q}_d) f(\mathbf{y}^k,\mathbf{z}^k) + \Delta t \mathbf{Q}_d f(\mathbf{y}^{k+1},\mathbf{z}^{k+1}),$$ $$0 = g(\mathbf{y}^{k+1},\mathbf{z}^{k+1}),$$ called $\mathtt{SDC-C}$ or ``genericImplicitConstrained``. Here, no quadrature is applied to the algebraic parts.

This PR contains these both sweepers to solve semi-explicit DAEs. In the playground the residual components are plotted for both sweepers for a new implemented problem ``LinearTestDAEMinion`` which is a stiff linear one. Moreover, the original SDC-ODE sweeper ``generic_implicit`` sweeper can also be applied to the DAE problem (where we ignore the unnecessary computations). This can be done as long as the ``solve_system`` in the problem class does the correct things. Then, when you run the script ``residual_components.py`` it generates plots for different time step sizes $\Delta t$ where the residual components on last collocation node $\tau_M$ are plotted along iterations. I recommend playing around here to see how it does behave. And then in the plots corresponding to ``generic_implicit``'s solves you see that the residual in the algebraic component is always large. And the reason here for that is that in [compute_residual](https://github.com/Parallel-in-Time/pySDC/blob/master/pySDC/core/sweeper.py#L171) the residual is not computed correctly. To check this consider the ``compute_residual`` methods of the two new sweepers in this PR. 

However, words above are not set in stone. This is only my assumption, since @brownbaerchen already mentioned issues in convergence when using the residual and you also mentioned that @Ouardghi has issues with the residual. This playground is thus for ..playing around (Who would have thought it?) and see how the residual behaves in the different treatments. Moreover, it could serve as basis for discussion when we three will meet for that.

Since this is only a playground there are no tests here, but I'll submit them later for sure. I already tried to make everything clean. I know it is not perfect (as usual) but when transferring the sweepers + problems to the ``projects`` folder we can discuss how to make it cleaner. For playing around this should be enough I hope.

Oh, I forgot to mention that I added ``genericImplicitOriginal`` which is in principle ``generic_implicit`` only overload the ``compute_residual`` method and having an attribute ``residual_components`` which is used for logging and plotting in the playground. I didn't want to clutter up ``generic_implicit``..