### PR TITLE
Handle SLURM issues

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,7 +77,7 @@ test_JUWELS:
       - sbatch.out
   before_script:
     - bash etc/check_node_avail.sh || PARTITION_AVAIL=$?
-    - if [ "$PARTITION_AVAIL" != 0 ] ; then exit $PARTITION_AVAIL ; fi
+    - if [ -n "$PARTITION_AVAIL" ] ; then exit $PARTITION_AVAIL ; fi
     - mkdir -p benchmarks
     - module --force purge
     - module load Stages/2024

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,15 +92,15 @@ test_JUWELS:
     - if [ -n "$PARTITION_AVAIL" ] ; then exit $PARTITION_AVAIL ; fi
     # - touch benchmarks/output.json
     - echo $SYSTEMNAME
-    - sbatch --wait etc/juwels_${SHELL_SCRIPT}.sh
-    - touch .coverage.empty
-    - python -m coverage combine
-    - mv .coverage coverage_${SHELL_SCRIPT}.dat
-  after_script:
-    - echo "Following Errors occured:"
-    - cat sbatch.err
-    - echo "Following was written to stdout:"
-    - cat sbatch.out
+  #   - sbatch --wait etc/juwels_${SHELL_SCRIPT}.sh
+  #   - touch .coverage.empty
+  #   - python -m coverage combine
+  #   - mv .coverage coverage_${SHELL_SCRIPT}.dat
+  # after_script:
+  #   - echo "Following Errors occured:"
+  #   - cat sbatch.err
+  #   - echo "Following was written to stdout:"
+  #   - cat sbatch.out
 
 
 benchmark:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,6 +63,9 @@ test_JUWELS:
     - juwels
     - login
     - shell
+  allow_failure:
+    exit_codes:
+      - 100 # When partition is down or nodes of paration are not available
   parallel:
     matrix:
       - SHELL_SCRIPT: ['benchmark', 'cupy']

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,18 +65,19 @@ test_JUWELS:
     - shell
   allow_failure:
     exit_codes:
-      - 100 # When partition is down or nodes of paration are not available
+      - 404
   parallel:
     matrix:
       - SHELL_SCRIPT: ['benchmark', 'cupy']
   artifacts:
-    when: always
+    # when: always
     paths:
       - coverage_*.dat
       - sbatch.err
       - sbatch.out
   before_script:
     - bash etc/check_node_avail.sh
+    - echo $?
     - mkdir -p benchmarks
     - module --force purge
     - module load Stages/2024

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,8 +76,6 @@ test_JUWELS:
       - sbatch.err
       - sbatch.out
   before_script:
-    - bash etc/check_node_avail.sh || PARTITION_AVAIL=$?
-    - if [ -n "$PARTITION_AVAIL" ] ; then exit $PARTITION_AVAIL ; fi
     - mkdir -p benchmarks
     - module --force purge
     - module load Stages/2024
@@ -90,6 +88,8 @@ test_JUWELS:
     - jutil env activate -p ${JUWELS_PROJECT}
     - source $SCRATCH/.venv/pySDC/bin/activate
   script:
+    - bash etc/check_node_avail.sh || PARTITION_AVAIL=$?
+    - if [ -n "$PARTITION_AVAIL" ] ; then exit $PARTITION_AVAIL ; fi
     # - touch benchmarks/output.json
     - echo $SYSTEMNAME
     - sbatch --wait etc/juwels_${SHELL_SCRIPT}.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,7 +70,7 @@ test_JUWELS:
     matrix:
       - SHELL_SCRIPT: ['benchmark', 'cupy']
   artifacts:
-    # when: always
+    when: always
     paths:
       - coverage_*.dat
       - sbatch.err
@@ -92,15 +92,14 @@ test_JUWELS:
     - if [ -n "$PARTITION_AVAIL" ] ; then exit $PARTITION_AVAIL ; fi
     # - touch benchmarks/output.json
     - echo $SYSTEMNAME
-  #   - sbatch --wait etc/juwels_${SHELL_SCRIPT}.sh
-  #   - touch .coverage.empty
-  #   - python -m coverage combine
-  #   - mv .coverage coverage_${SHELL_SCRIPT}.dat
-  # after_script:
-  #   - echo "Following Errors occured:"
-  #   - cat sbatch.err
-  #   - echo "Following was written to stdout:"
-  #   - cat sbatch.out
+    - sbatch --wait etc/juwels_${SHELL_SCRIPT}.sh
+    - touch .coverage.empty
+    - python -m coverage combine
+    - mv .coverage coverage_${SHELL_SCRIPT}.dat
+    - echo "Following Errors occured:"
+    - cat sbatch.err
+    - echo "Following was written to stdout:"
+    - cat sbatch.out
 
 
 benchmark:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,6 +73,7 @@ test_JUWELS:
       - sbatch.err
       - sbatch.out
   before_script:
+    - bash etc/check_node_avail.sh
     - mkdir -p benchmarks
     - module --force purge
     - module load Stages/2024

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,7 +65,7 @@ test_JUWELS:
     - shell
   allow_failure:
     exit_codes:
-      - 404
+      - 100
   parallel:
     matrix:
       - SHELL_SCRIPT: ['benchmark', 'cupy']
@@ -76,8 +76,8 @@ test_JUWELS:
       - sbatch.err
       - sbatch.out
   before_script:
-    - bash etc/check_node_avail.sh
-    - echo $?
+    - bash etc/check_node_avail.sh || PARTITION_AVAIL=$?
+    - if [ "$PARTITION_AVAIL" != 0 ] ; then exit $PARTITION_AVAIL ; fi
     - mkdir -p benchmarks
     - module --force purge
     - module load Stages/2024

--- a/etc/check_node_avail.sh
+++ b/etc/check_node_avail.sh
@@ -18,6 +18,6 @@ if [ "$part_up" = "up" ] && [ "$nodes_avail" != "0/0" ] ; then {
     exit 0
 } else {
     echo "Partition down or no nodes available"
-    exit 100
+    exit 404
 }
 fi

--- a/etc/check_node_avail.sh
+++ b/etc/check_node_avail.sh
@@ -18,6 +18,6 @@ if [ "$part_up" = "up" ] && [ "$nodes_avail" != "0/0" ] ; then {
     exit 0
 } else {
     echo "Partition down or no nodes available"
-    exit 404
+    exit 100
 }
 fi

--- a/etc/check_node_avail.sh
+++ b/etc/check_node_avail.sh
@@ -18,6 +18,6 @@ if [ "$part_up" = "up" ] && [ "$nodes_avail" != "0/0" ] ; then {
     exit 0
 } else {
     echo "Partition down or no nodes available"
-    exit 1
+    exit 100
 }
 fi

--- a/etc/check_node_avail.sh
+++ b/etc/check_node_avail.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -x
+
+if [ "$SHELL_SCRIPT" = "cupy" ] ; then {
+    partition="develgpus"
+} else {
+    partition="devel"
+}
+fi
+
+# General info on partition:
+# sinfo -p $partition --noheader --format="%.15P %.5a %.10A"
+
+part_up=$(sinfo -p $partition --noheader --format="%a")
+nodes_avail=$(sinfo -p $partition --noheader --format="%A")
+
+if [ "$part_up" = "up" ] && [ "$nodes_avail" != "0/0" ] ; then {
+    echo "Partition up and nodes available"
+    exit 0
+} else {
+    echo "Partition down or no nodes available"
+    exit 1
+}
+fi


### PR DESCRIPTION
and exit before submitting a job to a partition where it cannot be picked up by any nodes.

The artifacts are still being tried to be collected (which fails because the files don't yet exist).

As the job fails if no node can run the SLURM-Job, the behaviour is similar to current behaviour, but with earlier failing of the CI-Job, as it does not need to time out.

Creating a warning instead of a failure is currently not possible due to an issue in the jacamar-runner (Issue is opened).