### PR TITLE
Added `integrate` method to `RungeKuttaDAE`

### DIFF
--- a/pySDC/projects/DAE/tests/test_RungeKuttaDAE.py
+++ b/pySDC/projects/DAE/tests/test_RungeKuttaDAE.py
@@ -153,10 +153,10 @@ def testOrderAccuracySemiExplicitIndexOne(sweeper_name):
 
     assert np.isclose(
         orderDiff, expectedOrderDiff[sweeper_name], atol=1e0
-    ), f"Expected order {expectedOrderDiff[sweeper_name]} in differential variable, got {orderDiff}"
+    ), f"SE index-1 case: Expected order {expectedOrderDiff[sweeper_name]} in differential variable for {sweeper_name}, got {orderDiff}"
     assert np.isclose(
         orderAlg, expectedOrderAlg[sweeper_name], atol=1e0
-    ), f"Expected order {expectedOrderAlg[sweeper_name]} in algebraic variable, got {orderAlg}"
+    ), f"SE index-1 case:  Expected order {expectedOrderAlg[sweeper_name]} in algebraic variable for {sweeper_name}, got {orderAlg}"
 
 
 @pytest.mark.base
@@ -238,10 +238,10 @@ def testOrderAccuracySemiExplicitIndexTwo(sweeper_name):
 
     assert np.isclose(
         orderDiff, expectedOrderDiff[sweeper_name], atol=1e0
-    ), f"Expected order {expectedOrderDiff[sweeper_name]} in differential variable, got {orderDiff}"
+    ), f"SE index-2 case: Expected order {expectedOrderDiff[sweeper_name]} in differential variable for {sweeper_name}, got {orderDiff}"
     assert np.isclose(
         orderAlg, expectedOrderAlg[sweeper_name], atol=1e0
-    ), f"Expected order {expectedOrderAlg[sweeper_name]} in algebraic variable, got {orderAlg}"
+    ), f"SE index-2 case: Expected order {expectedOrderAlg[sweeper_name]} in algebraic variable for {sweeper_name}, got {orderAlg}"
 
 
 @pytest.mark.base
@@ -281,7 +281,7 @@ def testOrderAccuracyFullyImplicitIndexTwo(sweeper_name):
     level_params = description['level_params']
 
     t0, Tend = 0.0, 2.0
-    dt_list = np.logspace(-1.7, -1.0, num=7)
+    dt_list = dt_list = np.logspace(-2.5, -1.0, num=7)
 
     errors = np.zeros(len(dt_list))
     for i, dt in enumerate(dt_list):
@@ -302,4 +302,4 @@ def testOrderAccuracyFullyImplicitIndexTwo(sweeper_name):
 
     assert np.isclose(
         order, expectedOrder[sweeper_name], atol=1e0
-    ), f"Expected order {expectedOrder[sweeper_name]} in differential variable, got {order}"
+    ), f"FI index-2 case: Expected order {expectedOrder[sweeper_name]} in differential variable for {sweeper_name}, got {order}"


### PR DESCRIPTION
Since `SwitchEstimator` requires values at the intermediate stages when applying Runge-Kutta methods, these values will now be computed in `update_nodes`. This required adding the `integrate` method. Here, we cannot inherit from the parent since it uses the `get_full_f` method (splitting of the right-hand side `f` which is currently not possible).

When adding that I noticed that `EDIRK4DAE` achieved order $3$ for a fully-implicit index- $2$ problem instead of $2$ as already set in the current test. I was wondering since order reduction could be expected for higher-index problems. However, when you compute the theoretically derived order conditions for index- $2$ problems in [[E. Hairer, C. Lubich, M. Roche, p. 63]](https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://link.springer.com/book/10.1007/BFb0093947&ved=2ahUKEwi16r-NubyHAxXLR_EDHVYbBVMQFnoECBgQAQ&usg=AOvVaw3APQeH4x4n3u1nwATd3ZnN), then you get that the order conditions cannot be satisfied since the coefficient matrix in the Butcher tableau is singular. Thus, setting a wider range of time step sizes like `dt_list = np.logspace(-2.5, -1.0, num=7)` leads to a correct result again.