### PR TITLE
Small fixes

### DIFF
--- a/pySDC/implementations/controller_classes/controller_nonMPI.py
+++ b/pySDC/implementations/controller_classes/controller_nonMPI.py
@@ -39,7 +39,7 @@ class controller_nonMPI(Controller):
             for _ in range(num_procs - 1):
                 self.MS.append(dill.copy(self.MS[0]))
         # if this fails (e.g. due to un-picklable data in the steps), initialize separately
-        except (dill.PicklingError, TypeError) as error:
+        except (dill.PicklingError, TypeError, ValueError) as error:
             self.logger.warning(f'Need to initialize steps separately due to pickling error: {error}')
             for _ in range(num_procs - 1):
                 self.MS.append(stepclass.Step(description))

--- a/pySDC/implementations/problem_classes/AllenCahn_2D_FFT.py
+++ b/pySDC/implementations/problem_classes/AllenCahn_2D_FFT.py
@@ -26,7 +26,7 @@ class allencahn2d_imex(Problem):
 
     or uniform distributed random numbers in :math:`[-1, 1]` for :math:`i, j=0,..,N-1`, where :math:`N` is the number of
     spatial grid points. For time-stepping, the problem is treated *semi-implicitly*, i.e., the diffusion part is solved by
-    Fast-Fourier Tranform (FFT) and the nonlinear term is treated explicitly.
+    Fast-Fourier Transform (FFT) and the nonlinear term is treated explicitly.
 
     An exact solution is not known, but instead the numerical solution can be compared via a generated reference solution computed
     by a ``SciPy`` routine.
@@ -120,11 +120,10 @@ class allencahn2d_imex(Problem):
         """
 
         f = self.dtype_f(self.init)
-        v = u.flatten()
         tmp = self.lap * np.fft.rfft2(u)
         f.impl[:] = np.fft.irfft2(tmp)
         if self.eps > 0:
-            f.expl[:] = (1.0 / self.eps**2 * v * (1.0 - v**self.nu)).reshape(self.nvars)
+            f.expl[:] = 1.0 / self.eps**2 * u * (1.0 - u**self.nu)
         return f
 
     def solve_system(self, rhs, factor, u0, t):
@@ -200,7 +199,7 @@ class allencahn2d_imex(Problem):
 
 class allencahn2d_imex_stab(allencahn2d_imex):
     r"""
-    This implements the two-dimensional Allen-Cahn equation with periodic boundary conditions :math:`u \in [-1, 1]^2`
+    This implements the two-dimensional Allen-Cahn equation with periodic boundary conditions :math:`u \in [-0.5, 0.5]^2`
     with stabilized splitting
 
     .. math::
@@ -219,7 +218,7 @@ class allencahn2d_imex_stab(allencahn2d_imex):
 
     or uniform distributed random numbers in :math:`[-1, 1]` for :math:`i, j=0,..,N-1`, where :math:`N` is the number of
     spatial grid points. For time-stepping, the problem is treated *semi-implicitly*, i.e., the diffusion part is solved with
-    Fast-Fourier Tranform (FFT) and the nonlinear term is treated explicitly.
+    Fast-Fourier Transform (FFT) and the nonlinear term is treated explicitly.
 
     An exact solution is not known, but instead the numerical solution can be compared via a generated reference solution computed
     by a ``SciPy`` routine.
@@ -276,11 +275,10 @@ class allencahn2d_imex_stab(allencahn2d_imex):
         """
 
         f = self.dtype_f(self.init)
-        v = u.flatten()
         tmp = self.lap * np.fft.rfft2(u)
         f.impl[:] = np.fft.irfft2(tmp)
         if self.eps > 0:
-            f.expl[:] = (1.0 / self.eps**2 * v * (1.0 - v**self.nu) + 2.0 / self.eps**2 * v).reshape(self.nvars)
+            f.expl[:] = 1.0 / self.eps**2 * u * (1.0 - u**self.nu) + 2.0 / self.eps**2 * u
         return f
 
     def solve_system(self, rhs, factor, u0, t):

--- a/pySDC/implementations/problem_classes/AllenCahn_MPIFFT.py
+++ b/pySDC/implementations/problem_classes/AllenCahn_MPIFFT.py
@@ -20,7 +20,7 @@ class allencahn_imex(IMEX_Laplacian_MPIFFT):
         u({\bf x}, 0) = \tanh\left(\frac{r - \sqrt{(x_i-0.5)^2 + (y_j-0.5)^2}}{\sqrt{2}\varepsilon}\right),
 
     for :math:`i, j=0,..,N-1`, where :math:`N` is the number of spatial grid points. For time-stepping, the problem is treated
-    *semi-implicitly*, i.e., the linear part is solved with Fast-Fourier Tranform (FFT) and the nonlinear part in the right-hand
+    *semi-implicitly*, i.e., the linear part is solved with Fast-Fourier Transform (FFT) and the nonlinear part in the right-hand
     side will be treated explicitly using ``mpi4py-fft`` [1]_ to solve them.
 
     Parameters
@@ -183,7 +183,7 @@ class allencahn_imex_timeforcing(allencahn_imex):
         u({\bf x}, 0) = \tanh\left(\frac{r - \sqrt{(x_i-0.5)^2 + (y_j-0.5)^2}}{\sqrt{2}\varepsilon}\right),
 
     for :math:`i, j=0,..,N-1`, where :math:`N` is the number of spatial grid points. For time-stepping, the problem is treated
-    *semi-implicitly*, i.e., the linear part is solved with Fast-Fourier Tranform (FFT) and the nonlinear part in the right-hand
+    *semi-implicitly*, i.e., the linear part is solved with Fast-Fourier Transform (FFT) and the nonlinear part in the right-hand
     side will be treated explicitly using ``mpi4py-fft`` [1]_ to solve them.
     """
 
@@ -230,7 +230,7 @@ class allencahn_imex_timeforcing(allencahn_imex):
             if self.comm is not None:
                 Ht_global = self.comm.allreduce(sendobj=Ht_local, op=MPI.SUM)
             else:
-                Ht_global = Rt_local
+                Ht_global = Ht_local
 
             # add/substract time-dependent driving force
             if Ht_global != 0.0:
@@ -258,7 +258,7 @@ class allencahn_imex_timeforcing(allencahn_imex):
             if self.comm is not None:
                 Ht_global = self.comm.allreduce(sendobj=Ht_local, op=MPI.SUM)
             else:
-                Ht_global = Rt_local
+                Ht_global = Ht_local
 
             # add/substract time-dependent driving force
             if Ht_global != 0.0:


### PR DESCRIPTION
I fixed a few typos in Allen-Cahn problems. In the MPI version with forcing, some typos were bugs. Since the bugs only effect runs with a single processor, I don't think it matters too much. All other typos were in comments. Also, in the non-MPI version I removed some unnecessary copying and reshaping.

Also, there is a new version of mpi4py. If you now try to pickle a communicator, it will raise a `ValueError` for whatever reason. So we need to add this in the non-MPI controller step instantiation. This update must have been extremely recently because the actions this morning passed, but [this one](https://github.com/brownbaerchen/pySDC/actions/runs/10140130314/job/28034717724) in the meantime failed, in case you don't believe me ;).