### PR TITLE
Fix syncing ci

### DIFF
--- a/.github/workflows/gitlab_ci.yml
+++ b/.github/workflows/gitlab_ci.yml
@@ -106,7 +106,7 @@ jobs:
           echo "Merge the two parts of the Merge-Request to test the resulting version"
           git merge "${{ github.event.pull_request.head.sha }}"
       - name: Mirror and wait for Gitlab-CI
-        uses: jakob-fritz/github2lab_action@v0.7
+        uses: jakob-fritz/github2lab_action@v0.8
         env:
           MODE: 'all'  # Either 'mirror', 'get_status', 'get_artifact', or 'all'
           GITLAB_TOKEN: ${{ secrets.GITLAB_SECRET }}

--- a/.github/workflows/gitlab_ci.yml
+++ b/.github/workflows/gitlab_ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, labeled]
   schedule:
-    - cron: '1 5 * * 1'
+    - cron: '2 5 * * 1'
 
 jobs:
   check_permission:


### PR DESCRIPTION
Use a new version of Github2Lab-Action

This new version triggers a new Gitlab-Pipeline even if no new code is pushed. This makes it possible to rerun a Github-Action with rerunning Gitlab-CI. It also means that a scheduled pipeline now triggers a separate Gitlab-CI.

Furthermore start the Gitlab-Actions a minute apart to make sure the querying doesn't fail.