### PR TITLE
Coverage-report now uses less restricted file-names

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -63,17 +63,16 @@ jobs:
           coverage run -m pytest --continue-on-collection-errors -v --durations=0 pySDC/tests -m ${{ matrix.env }}
       - name: Make coverage report
         run: |
-          mv data data_${{ matrix.python }}
           coverage combine
-          mv .coverage coverage_${{ matrix.env }}_${{ matrix.python }}.dat
+          mv .coverage coverage_${{ matrix.env }}.dat
       - name: Uploading artifacts
         uses: actions/upload-artifact@v4
         if: matrix.python == '3.10'
         with:
           name: test-artifacts-cpu-${{ matrix.env }}
           path: |
-            data_3.10
-            coverage_${{ matrix.env }}_3.10.dat
+            data
+            coverage_${{ matrix.env }}.dat
 
   project_cpu_tests_linux:
     runs-on: ubuntu-latest
@@ -120,17 +119,16 @@ jobs:
           coverage run -m pytest --continue-on-collection-errors -v --durations=0 pySDC/projects/${{ matrix.env }}/tests
       - name: Make coverage report
         run: |
-          mv data data_${{ matrix.python }}
           coverage combine
-          mv .coverage coverage_${{ matrix.env }}_${{ matrix.python }}.dat
+          mv .coverage coverage_${{ matrix.env }}.dat
       - name: Uploading artifacts
         uses: actions/upload-artifact@v4
         if: matrix.python == '3.10'
         with:
           name: test-artifacts-project-${{ matrix.env }}
           path: |
-            data_3.10
-            coverage_${{ matrix.env }}_3.10.dat
+            data
+            coverage_${{ matrix.env }}.dat
 
   user_libpressio_tests:
     runs-on: ubuntu-latest
@@ -160,14 +158,14 @@ jobs:
 
           mv data data_libpressio
           coverage combine
-          mv .coverage coverage_libpressio_3.10.dat
+          mv .coverage coverage_libpressio.dat
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: test-artifacts-libpressio
           path: |
             data_libpressio
-            coverage_libpressio_3.10.dat
+            coverage_libpressio.dat
          
   user_monodomain_tests_linux:
     runs-on: ubuntu-latest
@@ -201,11 +199,11 @@ jobs:
         run: |
           mv data data_monodomain
           coverage combine
-          mv .coverage coverage_monodomain_3.10.dat
+          mv .coverage coverage_monodomain.dat
       - name: Uploading artifacts
         uses: actions/upload-artifact@v4
         with:
           name: test-artifacts-monodomain
           path: |
             data_monodomain
-            coverage_monodomain_3.10.dat
+            coverage_monodomain.dat

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           environment-file: ${{ env.YML }}
           create-args: >-
-              python=3.12
+              python=3.10
       - name: Code reformatting with black
         run: |
           black pySDC  --check --diff --color

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           environment-file: ${{ env.YML }}
           create-args: >-
-              python=3.10
+              python=3.12
       - name: Code reformatting with black
         run: |
           black pySDC  --check --diff --color
@@ -67,7 +67,7 @@ jobs:
           mv .coverage coverage_${{ matrix.env }}.dat
       - name: Uploading artifacts
         uses: actions/upload-artifact@v4
-        if: matrix.python == '3.10'
+        if: matrix.python == '3.12'
         with:
           name: test-artifacts-cpu-${{ matrix.env }}
           path: |
@@ -123,7 +123,7 @@ jobs:
           mv .coverage coverage_${{ matrix.env }}.dat
       - name: Uploading artifacts
         uses: actions/upload-artifact@v4
-        if: matrix.python == '3.10'
+        if: matrix.python == '3.12'
         with:
           name: test-artifacts-project-${{ matrix.env }}
           path: |
@@ -180,7 +180,7 @@ jobs:
         with:
           environment-file: "pySDC/projects/Monodomain/etc/environment-monodomain.yml"
           create-args: >-
-              python=3.10
+              python=3.12
       - name: Compile C++ ionic models
         env:
           IONIC_MODELS_PATH: "pySDC/projects/Monodomain/problem_classes/ionicmodels/cpp"

--- a/.github/workflows/postprocess.yml
+++ b/.github/workflows/postprocess.yml
@@ -32,8 +32,7 @@ jobs:
           github-token: ${{ secrets.ACTION_READ_TOKEN }}
       - name: Prepare artifacts
         run: |
-          cp data_3.10/* data/.
-          python -m coverage combine coverage_*_3.10.dat
+          python -m coverage combine coverage_*.dat
           python -m coverage xml
           python -m coverage html
       - name: Generate Coverage badge

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,7 +95,7 @@ test_JUWELS:
     - sbatch --wait etc/juwels_${SHELL_SCRIPT}.sh
     - touch .coverage.empty
     - python -m coverage combine
-    - mv .coverage coverage_${SHELL_SCRIPT}.dat
+    - mv .coverage coverage_${SHELL_SCRIPT}_3.10.dat
     - echo "Following Errors occured:"
     - cat sbatch.err
     - echo "Following was written to stdout:"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,7 +95,7 @@ test_JUWELS:
     - sbatch --wait etc/juwels_${SHELL_SCRIPT}.sh
     - touch .coverage.empty
     - python -m coverage combine
-    - mv .coverage coverage_${SHELL_SCRIPT}_3.10.dat
+    - mv .coverage coverage_${SHELL_SCRIPT}.dat
     - echo "Following Errors occured:"
     - cat sbatch.err
     - echo "Following was written to stdout:"
@@ -129,22 +129,3 @@ benchmark:
     - >-
       pytest --continue-on-collection-errors -v pySDC/tests -m "benchmark"
       --benchmark-json=benchmarks/output.json
-
-# bundle:
-#  image: mambaorg/micromamba
-#  stage: upload
-#  artifacts:
-#    paths:
-#      - data
-#      - coverage.xml
-#      - benchmarks
-#      - htmlcov
-#  before_script:
-#    - micromamba create --yes -f etc/environment-base.yml
-#    - eval "$(micromamba shell hook --shell=bash)"
-#    - micromamba activate pySDC
-#  script:
-#    - cp data_3.10/* data/.
-#    - python -m coverage combine coverage_*_3.10.dat
-#    - python -m coverage xml
-#    - python -m coverage html


### PR DESCRIPTION
The coverage-file created in Gitlab was named without the "3.10" suffix. This lead to the issue, that it was not taken into account, when creating the whole coverage report.

This issue now solves this, but changing the name of the created coverage-file. An alternativ would be to remove the need for the suffix "3.10" in another file (`.github/workflows/postprocess.yml` line 36).

Then, the coverage-report should include the coverage information from the cupy-tests.