### PR TITLE
Add installation instructions using `pip install git+...`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ which can be found in the folder `etc/`. Use these as e.g.
 conda env create -f etc/environment-base.yml
 ```
 
-Alternatively, you can also use `pip` to install pySDC using the code from the GitHub repository:
+If you want to install the developer version using `pip` directly from the GitHub repository, use this:
 
 ```
 # optionally use venv

--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ which can be found in the folder `etc/`. Use these as e.g.
 conda env create -f etc/environment-base.yml
 ```
 
+Alternatively, you can also use `pip` to install pySDC using the code from the GitHub repository:
+
+```
+# optionally use venv
+python3 -m venv name_of_pySDC_env
+. ./name_of_pySDC_env/bin/activate
+# drop @5.5.0 if you want to install the develop version
+pip install git+https://github.com/Parallel-in-Time/pySDC@5.5.0
+```
+
 To check your installation, run
 
 ``` bash


### PR DESCRIPTION
These instructions are especially useful if working in a `venv`. We had to come up with this approach in https://github.com/precice/tutorials/pull/557 to get pySDC installed & running with a single call of a script.

Using `venv` is recommended by newer `pip` versions to not interfere with the system python packages. E.g. for the `pip` version coming with Ubuntu 24.04.

On Ubuntu 24.04 I get:
```
$ pip --version
pip 24.0 from /usr/lib/python3/dist-packages/pip (python 3.12)
$ pip install --user pySDC
× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
...