### PR TITLE
Added path to download artifacts from Gitlab-CI to

### DIFF
--- a/.github/workflows/gitlab_ci.yml
+++ b/.github/workflows/gitlab_ci.yml
@@ -125,6 +125,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           merge-multiple: true
+          path: ./github_ci_artifacts
       - name: Set env-var
         id: get_id
         uses: actions/github-script@v7


### PR DESCRIPTION
Now the artifacts should be combined properly and provided together.

Previously only the artifacts from Github-Actions were uploaded and provided to e.g. coverage.io

Can (and should) be checked by looking at the named files that are uploaded. Those should include `coverage_cupy.dat` and `coverage_benchmkark.dat`. 