### PR TITLE
Coverage-reports from Gitlab are now found and combined

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -35,6 +35,7 @@ jobs:
 
   user_cpu_tests_linux:
     runs-on: ubuntu-latest
+    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -76,6 +77,7 @@ jobs:
 
   project_cpu_tests_linux:
     runs-on: ubuntu-latest
+    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -132,6 +134,7 @@ jobs:
 
   user_libpressio_tests:
     runs-on: ubuntu-latest
+    if: false
     container:
       image: brownbaerchen/libpressio:amd64_2
       volumes:

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -35,7 +35,6 @@ jobs:
 
   user_cpu_tests_linux:
     runs-on: ubuntu-latest
-    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -77,7 +76,6 @@ jobs:
 
   project_cpu_tests_linux:
     runs-on: ubuntu-latest
-    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -134,7 +132,6 @@ jobs:
 
   user_libpressio_tests:
     runs-on: ubuntu-latest
-    if: false
     container:
       image: brownbaerchen/libpressio:amd64_2
       volumes:

--- a/.github/workflows/gitlab_ci.yml
+++ b/.github/workflows/gitlab_ci.yml
@@ -122,6 +122,7 @@ jobs:
           cd artifacts
           unzip -f '*.zip' -d .
           ls -lah
+          find -type d .. test_JUWELS
           rm *.zip
           ls -lah
           cd ..

--- a/.github/workflows/gitlab_ci.yml
+++ b/.github/workflows/gitlab_ci.yml
@@ -122,10 +122,10 @@ jobs:
           cd artifacts
           unzip -f '*.zip' -d .
           ls -lah
-          find -type d .. test_JUWELS
           rm *.zip
-          ls -lah
           cd ..
+          ls -lah
+          find . -type d "test_JUWELS"
 
   get_artifacts_from_other_workflow:
     runs-on: ubuntu-latest

--- a/.github/workflows/gitlab_ci.yml
+++ b/.github/workflows/gitlab_ci.yml
@@ -120,12 +120,11 @@ jobs:
           pwd
           ls -lah
           cd artifacts
-          unzip -f '*.zip' -d .
+          find . -type f -name "*.zip" -exec {} unzip ;
           ls -lah
           rm *.zip
           cd ..
           ls -lah
-          find . -type d -name "test_JUWELS"
 
   get_artifacts_from_other_workflow:
     runs-on: ubuntu-latest

--- a/.github/workflows/gitlab_ci.yml
+++ b/.github/workflows/gitlab_ci.yml
@@ -115,6 +115,14 @@ jobs:
           GITLAB_PROJECT_ID: "6029"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MIRROR_BRANCH: ${{ env.MIRROR_BRANCH }}
+      - name: Unzip downloaded artifacts
+        run: |
+          ls -lah
+          cd ./artifacts
+          unzip -f '*.zip'
+          rm '*.zip'
+          ls -lah
+          cd ..
 
   get_artifacts_from_other_workflow:
     runs-on: ubuntu-latest

--- a/.github/workflows/gitlab_ci.yml
+++ b/.github/workflows/gitlab_ci.yml
@@ -120,7 +120,7 @@ jobs:
           pwd
           ls -lah
           cd artifacts
-          find . -type f -name "*.zip" -exec {} unzip ;
+          find . -name "*.zip" -type f -exec unzip -o {} ;
           ls -lah
           rm *.zip
           cd ..

--- a/.github/workflows/gitlab_ci.yml
+++ b/.github/workflows/gitlab_ci.yml
@@ -125,7 +125,7 @@ jobs:
           rm *.zip
           cd ..
           ls -lah
-          find . -type d "test_JUWELS"
+          find . -type d -name "test_JUWELS"
 
   get_artifacts_from_other_workflow:
     runs-on: ubuntu-latest

--- a/.github/workflows/gitlab_ci.yml
+++ b/.github/workflows/gitlab_ci.yml
@@ -117,11 +117,13 @@ jobs:
           MIRROR_BRANCH: ${{ env.MIRROR_BRANCH }}
       - name: Unzip downloaded artifacts
         run: |
+          pwd
           ls -lah
           cd ./artifacts
-          unzip -f '*.zip'
+          unzip -f '*.zip' .
           ls -lah
           rm *.zip
+          ls -lah
           cd ..
 
   get_artifacts_from_other_workflow:

--- a/.github/workflows/gitlab_ci.yml
+++ b/.github/workflows/gitlab_ci.yml
@@ -120,8 +120,8 @@ jobs:
           ls -lah
           cd ./artifacts
           unzip -f '*.zip'
-          rm '*.zip'
           ls -lah
+          rm *.zip
           cd ..
 
   get_artifacts_from_other_workflow:

--- a/.github/workflows/gitlab_ci.yml
+++ b/.github/workflows/gitlab_ci.yml
@@ -104,7 +104,7 @@ jobs:
           git config user.email "unused@example.com"
           git config user.name "Sync bot"
           echo "Merge the two parts of the Merge-Request to test the resulting version"
-          git merge "${{ github.event.pul­­l_request.head.sha }}"
+          git merge "${{ github.event.pull_request.head.sha }}"
       - name: Mirror and wait for Gitlab-CI
         uses: jakob-fritz/github2lab_action@v0.8
         env:

--- a/.github/workflows/gitlab_ci.yml
+++ b/.github/workflows/gitlab_ci.yml
@@ -125,6 +125,12 @@ jobs:
           rm *.zip
           cd ..
           ls -lah
+      - name: Uploading artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Gitlab-Action_artifacts
+          path: |
+            ./artifacts/*
 
   get_artifacts_from_other_workflow:
     runs-on: ubuntu-latest

--- a/.github/workflows/gitlab_ci.yml
+++ b/.github/workflows/gitlab_ci.yml
@@ -120,7 +120,7 @@ jobs:
           pwd
           ls -lah
           cd artifacts
-          find . -name "*.zip" -type f -exec unzip -o {} ;
+          find . -name "*.zip" -type f -exec unzip -o {} \;
           ls -lah
           rm *.zip
           cd ..

--- a/.github/workflows/gitlab_ci.yml
+++ b/.github/workflows/gitlab_ci.yml
@@ -104,7 +104,7 @@ jobs:
           git config user.email "unused@example.com"
           git config user.name "Sync bot"
           echo "Merge the two parts of the Merge-Request to test the resulting version"
-          git merge "${{ github.event.pull_request.head.sha }}"
+          git merge "${{ github.event.pul­­l_request.head.sha }}"
       - name: Mirror and wait for Gitlab-CI
         uses: jakob-fritz/github2lab_action@v0.8
         env:
@@ -119,8 +119,8 @@ jobs:
         run: |
           pwd
           ls -lah
-          cd ./artifacts
-          unzip -f '*.zip' .
+          cd artifacts
+          unzip -f '*.zip' -d .
           ls -lah
           rm *.zip
           ls -lah


### PR DESCRIPTION
The coverage-reports from the Jobs in Gitlab-CI are now also transferred correctly and combined with the other reports.