### PR TITLE
More efficient globally stiffly accurate DIRK

### DIFF
--- a/pySDC/projects/Resilience/strategies.py
+++ b/pySDC/projects/Resilience/strategies.py
@@ -1242,7 +1242,7 @@ class DIRKStrategy(AdaptivityStrategy):
         """
         if problem.__name__ == "run_Lorenz":
             if key == 'work_newton' and op == sum:
-                return 1820
+                return 1456
             elif key == 'e_global_post_run' and op == max:
                 return 0.00013730538358736055
 
@@ -1433,7 +1433,7 @@ class ESDIRKStrategy(AdaptivityStrategy):
         """
         if problem.__name__ == "run_Lorenz":
             if key == 'work_newton' and op == sum:
-                return 984
+                return 820
             elif key == 'e_global_post_run' and op == max:
                 return 3.148061889390874e-06
 

--- a/pySDC/tests/test_sweepers/test_Runge_Kutta_sweeper.py
+++ b/pySDC/tests/test_sweepers/test_Runge_Kutta_sweeper.py
@@ -357,5 +357,5 @@ def test_RK_sweepers_with_GPU(test_name, sweeper_name):
 
 if __name__ == '__main__':
     # test_rhs_evals('ARK54')
-    test_order('ARK548L2SAERK2')
+    test_order('CrankNicholson')
     # test_order('ARK54')


### PR DESCRIPTION
Globally stiffly accurate DIRK are characterised by the last row of the Butcher tableau containing the weights. This means the last stage is the solution to the step. With the new implementation, the extra step for the combination of the weights is removed. Further, stages are only solved with implicit Euler if needed. This can be considered a bugfix, since before the same solution was computed with more work.

The reason I implemented this is that globally stiffly accurate DIRK methods are easy to use for simple DAEs. For instance, with RBC, in place of an equation for the pressure, there is the divergence-free constraint. If we then do a "collocation update" or it's equivalent in the DIRK context, we don't compute the pressure correctly. This is not case if we just use the last stage as the solution.