### PR TITLE
Fixed prepare-commit-msg for ruff git hook

### DIFF
--- a/docs/contrib/02_continuous_integration.md
+++ b/docs/contrib/02_continuous_integration.md
@@ -72,7 +72,7 @@ export files=$(git diff --staged --name-only HEAD | grep .py | sed -e "s,^,$(git
 if [[ $files != "" ]]
 then
         export ruff_output=$(ruff check --quiet $files)
-        if [[ "$ruff_output" != 0 ]]
+        if [[ "$ruff_output" != "" ]]
         then
                 git interpret-trailers --in-place --trailer "$(echo "$ruff_output" | sed -e 's/^/#/')" "$COMMIT_MSG_FILE"
                 git interpret-trailers --in-place --trailer "#!!!!!!!!!! WARNING: RUFF FAILED !!!!!!!!!!" "$COMMIT_MSG_FILE"


### PR DESCRIPTION
When flakeheaven doesn't find anything, it returns `0`. When ruff doesn't find anything it returns empty. The current git hook would therefore always print that ruff has failed in the commit message. This is just a fix so that the commit message is unaltered if there are no issues with the linter.