### PR TITLE
Refactor of RK implementation

### DIFF
--- a/pySDC/implementations/convergence_controller_classes/estimate_embedded_error.py
+++ b/pySDC/implementations/convergence_controller_classes/estimate_embedded_error.py
@@ -93,10 +93,13 @@ class EstimateEmbeddedError(ConvergenceController):
             dtype_u: The embedded error estimate
         """
         if self.params.sweeper_type == "RK":
-            # lower order solution is stored in the second to last entry of L.u
-            return abs(L.u[-2] - L.u[-1])
+            if L.f[1] is None:
+                return -1
+            else:
+                L.sweep.compute_end_point()
+                return abs(L.uend - L.sweep.u_secondary)
         elif self.params.sweeper_type == "SDC":
-            # order rises by one between sweeps, making this so ridiculously easy
+            # order rises by one between sweeps
             return abs(L.uold[-1] - L.u[-1])
         elif self.params.sweeper_type == 'MPI':
             comm = L.sweep.comm

--- a/pySDC/implementations/convergence_controller_classes/estimate_embedded_error.py
+++ b/pySDC/implementations/convergence_controller_classes/estimate_embedded_error.py
@@ -93,11 +93,8 @@ class EstimateEmbeddedError(ConvergenceController):
             dtype_u: The embedded error estimate
         """
         if self.params.sweeper_type == "RK":
-            if L.f[1] is None:
-                return -1
-            else:
-                L.sweep.compute_end_point()
-                return abs(L.uend - L.sweep.u_secondary)
+            L.sweep.compute_end_point()
+            return abs(L.uend - L.sweep.u_secondary)
         elif self.params.sweeper_type == "SDC":
             # order rises by one between sweeps
             return abs(L.uold[-1] - L.u[-1])

--- a/pySDC/implementations/sweeper_classes/Runge_Kutta.py
+++ b/pySDC/implementations/sweeper_classes/Runge_Kutta.py
@@ -267,26 +267,28 @@ class RungeKutta(Sweeper):
         """
         In this Runge-Kutta implementation, the solution to the step is always stored in the last node
         """
-        if self.level.f[1] is None:
-            self.level.uend = self.level.u[0]
+        lvl = self.level
+
+        if lvl.f[1] is None:
+            lvl.uend = lvl.prob.dtype_u(lvl.u[0])
             if type(self.coll) == ButcherTableauEmbedded:
-                self.u_secondary = self.level.u[0].copy()
+                self.u_secondary = lvl.prob.dtype_u(lvl.u[0])
         elif self.coll.globally_stiffly_accurate:
-            self.level.uend = self.level.u[-1]
+            lvl.uend = lvl.prob.dtype_u(lvl.u[-1])
             if type(self.coll) == ButcherTableauEmbedded:
-                self.u_secondary = self.level.u[0].copy()
-                for w2, k in zip(self.coll.weights[1], self.level.f[1:]):
-                    self.u_secondary += self.level.dt * w2 * k
+                self.u_secondary = lvl.prob.dtype_u(lvl.u[0])
+                for w2, k in zip(self.coll.weights[1], lvl.f[1:]):
+                    self.u_secondary += lvl.dt * w2 * k
         else:
-            self.level.uend = self.level.u[0].copy()
+            lvl.uend = lvl.prob.dtype_u(lvl.u[0])
             if type(self.coll) == ButcherTableau:
-                for w, k in zip(self.coll.weights, self.level.f[1:]):
-                    self.level.uend += self.level.dt * w * k
+                for w, k in zip(self.coll.weights, lvl.f[1:]):
+                    lvl.uend += lvl.dt * w * k
             elif type(self.coll) == ButcherTableauEmbedded:
-                self.u_secondary = self.level.u[0].copy()
-                for w1, w2, k in zip(self.coll.weights[0], self.coll.weights[1], self.level.f[1:]):
-                    self.level.uend += self.level.dt * w1 * k
-                    self.u_secondary += self.level.dt * w2 * k
+                self.u_secondary = lvl.prob.dtype_u(lvl.u[0])
+                for w1, w2, k in zip(self.coll.weights[0], self.coll.weights[1], lvl.f[1:]):
+                    lvl.uend += lvl.dt * w1 * k
+                    self.u_secondary += lvl.dt * w2 * k
 
     @property
     def level(self):
@@ -444,32 +446,34 @@ class RungeKuttaIMEX(RungeKutta):
         """
         In this Runge-Kutta implementation, the solution to the step is always stored in the last node
         """
-        if self.level.f[1] is None:
-            self.level.uend = self.level.u[0]
+        lvl = self.level
+
+        if lvl.f[1] is None:
+            lvl.uend = lvl.prob.dtype_u(lvl.u[0])
             if type(self.coll) == ButcherTableauEmbedded:
-                self.u_secondary = self.level.u[0].copy()
+                self.u_secondary = lvl.prob.dtype_u(lvl.u[0])
         elif self.coll.globally_stiffly_accurate and self.coll_explicit.globally_stiffly_accurate:
-            self.level.uend = self.level.u[-1]
+            lvl.uend = lvl.u[-1]
             if type(self.coll) == ButcherTableauEmbedded:
-                self.u_secondary = self.level.u[0].copy()
-                for w2, w2E, k in zip(self.coll.weights[1], self.coll_explicit.weights[1], self.level.f[1:]):
-                    self.u_secondary += self.level.dt * (w2 * k.impl + w2E * k.expl)
+                self.u_secondary = lvl.prob.dtype_u(lvl.u[0])
+                for w2, w2E, k in zip(self.coll.weights[1], self.coll_explicit.weights[1], lvl.f[1:]):
+                    self.u_secondary += lvl.dt * (w2 * k.impl + w2E * k.expl)
         else:
-            self.level.uend = self.level.u[0].copy()
+            lvl.uend = lvl.prob.dtype_u(lvl.u[0])
             if type(self.coll) == ButcherTableau:
-                for w, wE, k in zip(self.coll.weights, self.coll_explicit.weights, self.level.f[1:]):
-                    self.level.uend += self.level.dt * (w * k.impl + wE * k.expl)
+                for w, wE, k in zip(self.coll.weights, self.coll_explicit.weights, lvl.f[1:]):
+                    lvl.uend += lvl.dt * (w * k.impl + wE * k.expl)
             elif type(self.coll) == ButcherTableauEmbedded:
-                self.u_secondary = self.level.u[0].copy()
+                self.u_secondary = lvl.u[0].copy()
                 for w1, w2, w1E, w2E, k in zip(
                     self.coll.weights[0],
                     self.coll.weights[1],
                     self.coll_explicit.weights[0],
                     self.coll_explicit.weights[1],
-                    self.level.f[1:],
+                    lvl.f[1:],
                 ):
-                    self.level.uend += self.level.dt * (w1 * k.impl + w1E * k.expl)
-                    self.u_secondary += self.level.dt * (w2 * k.impl + w2E * k.expl)
+                    lvl.uend += lvl.dt * (w1 * k.impl + w1E * k.expl)
+                    self.u_secondary += lvl.dt * (w2 * k.impl + w2E * k.expl)
 
 
 class ForwardEuler(RungeKutta):

--- a/pySDC/tests/test_sweepers/test_Runge_Kutta_sweeper.py
+++ b/pySDC/tests/test_sweepers/test_Runge_Kutta_sweeper.py
@@ -18,10 +18,15 @@ SWEEPER_NAMES = [
     'ARK548L2SAERK',
     'ARK548L2SAESDIRK2',
     'ARK548L2SAERK2',
+    'ARK324L2SAERK',
+    'ARK324L2SAESDIRK',
 ]
 IMEX_SWEEPERS = [
     'ARK54',
     'ARK548L2SA',
+    'IMEXEuler',
+    'ARK32',
+    'ARK2',
 ]
 
 
@@ -61,6 +66,7 @@ def single_run(sweeper_name, dt, lambdas, use_RK_sweeper=True, Tend=None, useGPU
     from pySDC.implementations.hooks.log_embedded_error_estimate import LogEmbeddedErrorEstimate
     from pySDC.implementations.convergence_controller_classes.estimate_embedded_error import EstimateEmbeddedError
     from pySDC.implementations.sweeper_classes.generic_implicit import generic_implicit
+    from pySDC.implementations.sweeper_classes.Runge_Kutta import ButcherTableauEmbedded
 
     level_params = {'dt': dt}
 
@@ -93,13 +99,19 @@ def single_run(sweeper_name, dt, lambdas, use_RK_sweeper=True, Tend=None, useGPU
         'problem_class': problem_class,
         'sweeper_params': sweeper_params,
         'problem_params': problem_params,
-        'convergence_controllers': {EstimateEmbeddedError: {}},
+        'convergence_controllers': {},
     }
 
     controller_params = {
         'logger_level': 40,
         'hook_class': [LogWork, LogGlobalErrorPostRun, LogSolution, LogEmbeddedErrorEstimate],
     }
+
+    if (
+        hasattr(description['sweeper_class'], 'ButcherTableauClass')
+        and description['sweeper_class'].ButcherTableauClass == ButcherTableauEmbedded
+    ):
+        description['convergence_controllers'][EstimateEmbeddedError] = {}
 
     controller = controller_nonMPI(num_procs=1, controller_params=controller_params, description=description)
 
@@ -108,6 +120,7 @@ def single_run(sweeper_name, dt, lambdas, use_RK_sweeper=True, Tend=None, useGPU
         sweeper = controller.MS[0].levels[0].sweep
         sweeper.QI = rk_sweeper.get_Q_matrix()
         sweeper.coll = rk_sweeper.get_Butcher_tableau()
+        type(sweeper).compute_end_point = rk_sweeper.compute_end_point
 
     prob = controller.MS[0].levels[0].prob
     ic = prob.u_exact(0)
@@ -149,6 +162,11 @@ def test_order(sweeper_name, useGPU=False):
         'ARK548L2SAESDIRK2': 6,
         'ARK54': 6,
         'ARK548L2SA': 6,
+        'IMEXEuler': 2,
+        'ARK2': 3,
+        'ARK32': 4,
+        'ARK324L2SAERK': 4,
+        'ARK324L2SAESDIRK': 4,
     }
 
     dt_max = {
@@ -160,6 +178,7 @@ def test_order(sweeper_name, useGPU=False):
         'ARK548L2SAERK2': 1e0,
         'ARK54': 5e-2,
         'ARK548L2SA': 5e-2,
+        'IMEXEuler': 1e-2,
     }
 
     lambdas = [[-1.0e-1 + 0j]]
@@ -233,6 +252,8 @@ def test_stability(sweeper_name, useGPU=False):
         'ARK548L2SAERK': False,
         'ARK548L2SAESDIRK2': True,
         'ARK548L2SAERK2': False,
+        'ARK324L2SAERK': False,
+        'ARK324L2SAESDIRK': True,
     }
 
     re = -np.logspace(-3, 2, 50)
@@ -271,7 +292,7 @@ def test_rhs_evals(sweeper_name, useGPU=False):
     stats, _, controller = single_run(sweeper_name, 1.0, lambdas, Tend=10.0, useGPU=useGPU)
 
     sweep = controller.MS[0].levels[0].sweep
-    num_stages = sweep.coll.num_nodes - sweep.coll.num_solution_stages
+    num_stages = sweep.coll.num_nodes
 
     rhs_evaluations = [me[1] for me in get_sorted(stats, type='work_rhs')]
 
@@ -357,5 +378,7 @@ def test_RK_sweepers_with_GPU(test_name, sweeper_name):
 
 if __name__ == '__main__':
     # test_rhs_evals('ARK54')
-    test_order('CrankNicolson')
+    test_order('ARK2')
+    # test_order('ARK54')
+    # test_sweeper_equivalence('Cash_Karp')
     # test_order('ARK54')

--- a/pySDC/tests/test_sweepers/test_Runge_Kutta_sweeper.py
+++ b/pySDC/tests/test_sweepers/test_Runge_Kutta_sweeper.py
@@ -120,11 +120,15 @@ def single_run(sweeper_name, dt, lambdas, use_RK_sweeper=True, Tend=None, useGPU
         sweeper = controller.MS[0].levels[0].sweep
         sweeper.QI = rk_sweeper.get_Q_matrix()
         sweeper.coll = rk_sweeper.get_Butcher_tableau()
+        _compute_end_point = type(sweeper).compute_end_point
         type(sweeper).compute_end_point = rk_sweeper.compute_end_point
 
     prob = controller.MS[0].levels[0].prob
     ic = prob.u_exact(0)
     u_end, stats = controller.run(ic, 0.0, 5 * dt if Tend is None else Tend)
+
+    if not use_RK_sweeper:
+        type(sweeper).compute_end_point = _compute_end_point
 
     return stats, ic, controller
 


### PR DESCRIPTION
This PR includes a few things:
 - Collocation matrix now includes only the Runge-Kutta matrix and no longer the weights for computing the solution at the end point
 - `compute_end_point` now computes the solution at the end point. For stiffly accurate methods, the solution at the last node is copied
 - IMEX RKM can now have different weights for explicit and implicit methods. This is crucial for stiffly accurate IMEX methods, which can be applied to DAEs. If only the implicit part is stiffly accurate, a collocation update is still needed.
 - Added the second order stiffly accurate IMEX RK method (ARK2) that Dedalus use as well as IMEX Euler. The ARK2 method is the only one we have atm that works for DAEs like Rayleigh-Benard.
 - Refactor for Runge-Kutta Nyström: This is still using the old Butcher tableau implementation that does not need a collocation update because of the particle datatype and velocity verlet scheme. I removed a lot of code that can be inherited from the parent class. I removed the parameter `Velocity_verlet` because I didn't find where this was used. @ikrom96git, maybe you want to double check that this still works as you want.

I will search for higher order stiffly accurate IMEX RK methods to use with RBC in the mean time. But it is fair to say that IMEX SDC with no collocation update being stiffly accurate is quite an advantage. I do not think I will find high order embedded stiffly accurate IMEX RK methods.