### PR TITLE
Fix for missing libcudart

### DIFF
--- a/pySDC/projects/AllenCahn_Bayreuth/environment.yml
+++ b/pySDC/projects/AllenCahn_Bayreuth/environment.yml
@@ -4,6 +4,7 @@ name: pySDC
 channels:
   - conda-forge
 dependencies:
+  - mpich
   - mpi4py>=3.0.0
   - mpi4py-fft>=2.0.2
   - matplotlib>=3.0

--- a/pySDC/projects/SDC_showdown/environment.yml
+++ b/pySDC/projects/SDC_showdown/environment.yml
@@ -4,6 +4,7 @@ name: pySDC
 channels:
   - conda-forge
 dependencies:
+  - mpich
   - petsc4py
   - matplotlib>=3.0
   - dill>=0.2.6


### PR DESCRIPTION
For some reason, there was an import error about a missing libcudart when importing mpi4py in two environments. I added `mpich` as a dependency there, which resolves the issue.