### PR TITLE
Tiny cleanup

### DIFF
--- a/pySDC/implementations/sweeper_classes/generic_implicit_MPI.py
+++ b/pySDC/implementations/sweeper_classes/generic_implicit_MPI.py
@@ -247,7 +247,6 @@ class generic_implicit_MPI(SweeperMPI, generic_implicit):
 
         L = self.level
         P = L.prob
-        L.uend = P.dtype_u(P.init, val=0.0)
 
         # check if Mth node is equal to right point and do_coll_update is false, perform a simple copy
         if self.coll.right_is_node and not self.params.do_coll_update:

--- a/pySDC/implementations/sweeper_classes/imex_1st_order_MPI.py
+++ b/pySDC/implementations/sweeper_classes/imex_1st_order_MPI.py
@@ -92,7 +92,6 @@ class imex_1st_order_MPI(SweeperMPI, imex_1st_order):
 
         L = self.level
         P = L.prob
-        L.uend = P.dtype_u(P.init, val=0.0)
 
         # check if Mth node is equal to right point and do_coll_update is false, perform a simple copy
         if self.coll.right_is_node and not self.params.do_coll_update:


### PR DESCRIPTION
I was surprised by how much more memory diagonal SDC needs compared to space-only parallelism. Unfortunately, I didn't find an easy solution. Instead, I just removed one unnecessary memory allocation.

In diagonal SDC, the solution and right hand side evaluation is stored at only one collocation node. But also the solution and RHS at the initial conditions is stored and every task stores the solution to the step.
Compared to space-only parallelism at the same number of overall tasks, all solution size objects are larger by the number of tasks in time.
If one uses four tasks in time / four colocation nodes, the solution and RHS evals in diagonal SDC take up $\frac{2\times 4}{5}=1.6$ times the memory compared to space-only parallelism each. And $u_\mathrm{end}$ is four times as large.
The solution size objects therefore require about six times as much memory in diagonal SDC when running in parallel on the same number of tasks compared to space-only parallel. This factor of roughly 6 is also what I measured in actual runs. 