### PR TITLE
Perform at least one SDC iteration

### DIFF
--- a/pySDC/implementations/convergence_controller_classes/check_convergence.py
+++ b/pySDC/implementations/convergence_controller_classes/check_convergence.py
@@ -73,7 +73,7 @@ class CheckConvergence(ConvergenceController):
 
         # get residual and check against prescribed tolerance (plus check number of iterations)
         iter_converged = S.status.iter >= S.params.maxiter
-        res_converged = L.status.residual <= L.params.restol
+        res_converged = L.status.residual <= L.params.restol and (S.status.iter > 0 or L.status.sweep > 0)
         e_tol_converged = (
             L.status.increment < L.params.e_tol if (L.params.get('e_tol') and L.status.get('increment')) else False
         )

--- a/pySDC/implementations/convergence_controller_classes/check_convergence.py
+++ b/pySDC/implementations/convergence_controller_classes/check_convergence.py
@@ -73,9 +73,7 @@ class CheckConvergence(ConvergenceController):
 
         # get residual and check against prescribed tolerance (plus check number of iterations)
         iter_converged = S.status.iter >= S.params.maxiter
-        res_converged = L.status.residual <= L.params.restol and (
-            (S.status.iter > 0 or L.status.sweep > 0) or L.sweep.params.initial_guess not in ['spread', 'copy', 'zero']
-        )
+        res_converged = L.status.residual <= L.params.restol and (S.status.iter > 0 or L.status.sweep > 0)
         e_tol_converged = (
             L.status.increment < L.params.e_tol if (L.params.get('e_tol') and L.status.get('increment')) else False
         )

--- a/pySDC/implementations/convergence_controller_classes/check_convergence.py
+++ b/pySDC/implementations/convergence_controller_classes/check_convergence.py
@@ -73,7 +73,9 @@ class CheckConvergence(ConvergenceController):
 
         # get residual and check against prescribed tolerance (plus check number of iterations)
         iter_converged = S.status.iter >= S.params.maxiter
-        res_converged = L.status.residual <= L.params.restol and (S.status.iter > 0 or L.status.sweep > 0)
+        res_converged = L.status.residual <= L.params.restol and (
+            (S.status.iter > 0 or L.status.sweep > 0) or L.sweep.params.initial_guess not in ['spread', 'copy', 'zero']
+        )
         e_tol_converged = (
             L.status.increment < L.params.e_tol if (L.params.get('e_tol') and L.status.get('increment')) else False
         )


### PR DESCRIPTION
Abdel and I were running into issues from time to time when the SDC residual of the prediction was low enough proclaim convergence. In this case, the code just does not do anything anymore but counting up the time and returning this solution.
I would consider this a bug.
The fix here is a bit weird because in single level SDC the sweep and iterations variables are interchangeable. Do you see any problem with doing it like this @pancetta?