### PR TITLE
Limited SciPy version in DAE project

### DIFF
--- a/pySDC/projects/DAE/environment.yml
+++ b/pySDC/projects/DAE/environment.yml
@@ -5,7 +5,7 @@ channels:
   - conda-forge
 dependencies:
   - numpy
-  - scipy>=0.17.1
+  - scipy>=0.17.1,<1.15
   - dill>=0.2.6
   - mpich
   - mpi4py>=3.0.0


### PR DESCRIPTION
For whatever reason, a recent scipy update has led to slightly larger errors and failing tests. Limiting the version to below 1.15 fixes this issue.