### PR TITLE
Fix for missing numpy data types on some platforms

### DIFF
--- a/pySDC/helpers/fieldsIO.py
+++ b/pySDC/helpers/fieldsIO.py
@@ -49,6 +49,7 @@ wether code is run in parallel or not.
 import os
 import numpy as np
 from typing import Type, TypeVar
+import logging
 
 T = TypeVar("T")
 
@@ -78,8 +79,6 @@ try:
         }
     )
 except AttributeError:
-    import logging
-
     logging.getLogger('FieldsIO').debug('Warning: Quadruple precision not available on this machine')
 try:
     DTYPES.update(
@@ -89,8 +88,6 @@ try:
         }
     )
 except AttributeError:
-    import logging
-
     logging.getLogger('FieldsIO').debug('Warning: Single precision not available on this machine')
 
 DTYPES_AVAIL = {val: key for key, val in DTYPES.items()}

--- a/pySDC/helpers/fieldsIO.py
+++ b/pySDC/helpers/fieldsIO.py
@@ -69,11 +69,30 @@ except ImportError:
 DTYPES = {
     0: np.float64,  # double precision
     1: np.complex128,
-    2: np.longdouble,  # quadruple precision
-    3: np.clongdouble,
-    4: np.float32,  # single precision
-    5: np.complex64,
 }
+try:
+    DTYPES.update(
+        {
+            2: np.float128,  # quadruple precision
+            3: np.complex256,
+        }
+    )
+except AttributeError:
+    import logging
+
+    logging.getLogger('FieldsIO').debug('Warning: Quadruple precision not available on this machine')
+try:
+    DTYPES.update(
+        {
+            4: np.float32,  # single precision
+            5: np.complex64,
+        }
+    )
+except AttributeError:
+    import logging
+
+    logging.getLogger('FieldsIO').debug('Warning: Single precision not available on this machine')
+
 DTYPES_AVAIL = {val: key for key, val in DTYPES.items()}
 
 # Header dtype
@@ -100,7 +119,7 @@ class FieldsIO:
         fileName : str
             File.
         """
-        assert dtype in DTYPES_AVAIL, f"{dtype=} not available"
+        assert dtype in DTYPES_AVAIL, f"{dtype=} not available. Supported on this machine: {list(DTYPES_AVAIL.keys())}"
         self.dtype = dtype
         self.fileName = fileName
         self.initialized = False

--- a/pySDC/helpers/fieldsIO.py
+++ b/pySDC/helpers/fieldsIO.py
@@ -69,8 +69,8 @@ except ImportError:
 DTYPES = {
     0: np.float64,  # double precision
     1: np.complex128,
-    2: np.float128,  # quadruple precision
-    3: np.complex256,
+    2: np.longdouble,  # quadruple precision
+    3: np.clongdouble,
     4: np.float32,  # single precision
     5: np.complex64,
 }


### PR DESCRIPTION
I had some trouble with round-off errors today and noticed that my numpy doesn't actually have quadruple precision. So `np.float128` will raise an error on my machine. `np.longdouble`, on the other hand, is just regular double on my machine. This is extremely weird behaviour that I neither like nor understand. I switched out the quadruple precision things for the word version so I can run the IO stuff with double precision at least.
Notice that the [numpy documentation](https://numpy.org/doc/2.1/reference/arrays.scalars.html#numpy.longdouble) says that `np.longdouble` is an alias for `np.float128` on Linux x86_64 machines. So this fix applies to Mac and Windows users.