### PR TITLE
Update to latest version of github2lab_action

### DIFF
--- a/.github/workflows/gitlab_ci.yml
+++ b/.github/workflows/gitlab_ci.yml
@@ -106,7 +106,7 @@ jobs:
           echo "Merge the two parts of the Merge-Request to test the resulting version"
           git merge "${{ github.event.pull_request.head.sha }}"
       - name: Mirror and wait for Gitlab-CI
-        uses: jakob-fritz/github2lab_action@v0.8
+        uses: jakob-fritz/github2lab_action@v0.8.1
         env:
           MODE: 'all'  # Either 'mirror', 'get_status', 'get_artifact', or 'all'
           GITLAB_TOKEN: ${{ secrets.GITLAB_SECRET }}


### PR DESCRIPTION
That new version fails early if Gitlab-repo-url cannot be found. This often indicates an issue with tokens or variables.

This does not fix any issues, but helps finding the reason for failing CI-Workflows. This can make fixing faster and easier.