### PR TITLE
Firedrake ensemble fix

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -205,7 +205,7 @@ jobs:
           firedrake-clean
           cd ./pySDC
           coverage run -m pytest --continue-on-collection-errors -v --durations=0 /repositories/pySDC/pySDC/tests -m firedrake
-        timeout-minutes: 120
+        timeout-minutes: 45
       - name: Make coverage report
         run: |
           . /home/firedrake/firedrake/bin/activate

--- a/pySDC/helpers/firedrake_ensemble_communicator.py
+++ b/pySDC/helpers/firedrake_ensemble_communicator.py
@@ -67,6 +67,9 @@ class FiredrakeEnsembleCommunicator:
             return self.ensemble.ensemble_comm.Isend(buf=buf, dest=dest, tag=tag)
         return self.ensemble.isend(buf, dest, tag=tag)[0]
 
+    def Free(self):
+        del self
+
 
 def get_ensemble(comm, space_size):
     return fd.Ensemble(comm, space_size)

--- a/pySDC/tests/test_helpers/test_gusto_coupling.py
+++ b/pySDC/tests/test_helpers/test_gusto_coupling.py
@@ -658,7 +658,7 @@ def test_pySDC_integrator_MSSDC(n_steps, useMPIController, setup, submit=True, n
     if useMPIController:
         from pySDC.helpers.firedrake_ensemble_communicator import FiredrakeEnsembleCommunicator
 
-        controller_communicator = FiredrakeEnsembleCommunicator(COMM_WORLD, COMM_WORLD.size//n_steps)
+        controller_communicator = FiredrakeEnsembleCommunicator(COMM_WORLD, COMM_WORLD.size // n_steps)
         assert controller_communicator.size == n_steps
         MSSDC_args = {'useMPIController': True, 'controller_communicator': controller_communicator}
         dirname = f'./tmp_{controller_communicator.rank}'

--- a/pySDC/tests/test_helpers/test_gusto_coupling.py
+++ b/pySDC/tests/test_helpers/test_gusto_coupling.py
@@ -26,7 +26,10 @@ def tracer_setup(tmpdir='./tmp', degree=1, small_dt=False, comm=None):
         COMM_WORLD,
     )
     from gusto import OutputParameters, Domain, IO
+    from gusto.core.logging import logger, INFO
     from collections import namedtuple
+
+    logger.setLevel(INFO)
 
     opts = ('domain', 'tmax', 'io', 'f_init', 'f_end', 'degree', 'uexpr', 'umax', 'radius', 'tol')
     TracerSetup = namedtuple('TracerSetup', opts)
@@ -785,5 +788,5 @@ if __name__ == '__main__':
         # test_generic_gusto_problem(setup)
         # test_pySDC_integrator_RK(False, RK4, setup)
         # test_pySDC_integrator(False, False, setup)
-        test_pySDC_integrator_with_adaptivity(1e-3, setup)
-        # test_pySDC_integrator_MSSDC(2, False, setup)
+        # test_pySDC_integrator_with_adaptivity(1e-3, setup)
+        test_pySDC_integrator_MSSDC(4, True, setup)

--- a/pySDC/tests/test_helpers/test_gusto_coupling.py
+++ b/pySDC/tests/test_helpers/test_gusto_coupling.py
@@ -623,15 +623,17 @@ def test_pySDC_integrator_with_adaptivity(dt_initial, setup):
 @pytest.mark.firedrake
 @pytest.mark.parametrize('n_steps', [1, 2, 4])
 @pytest.mark.parametrize('useMPIController', [True, False])
-def test_pySDC_integrator_MSSDC(n_steps, useMPIController, setup, submit=True):
+def test_pySDC_integrator_MSSDC(n_steps, useMPIController, setup, submit=True, n_tasks=4):
     if submit and useMPIController:
         import os
         import subprocess
 
+        assert n_steps <= n_tasks
+
         my_env = os.environ.copy()
         my_env['COVERAGE_PROCESS_START'] = 'pyproject.toml'
         cwd = '.'
-        cmd = f'mpiexec -np {n_steps} python {__file__} --test=MSSDC'.split()
+        cmd = f'mpiexec -np {n_tasks} python {__file__} --test=MSSDC --n_steps={n_steps}'.split()
 
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=my_env, cwd=cwd)
         p.wait()
@@ -656,7 +658,7 @@ def test_pySDC_integrator_MSSDC(n_steps, useMPIController, setup, submit=True):
     if useMPIController:
         from pySDC.helpers.firedrake_ensemble_communicator import FiredrakeEnsembleCommunicator
 
-        controller_communicator = FiredrakeEnsembleCommunicator(COMM_WORLD, 1)
+        controller_communicator = FiredrakeEnsembleCommunicator(COMM_WORLD, COMM_WORLD.size//n_steps)
         assert controller_communicator.size == n_steps
         MSSDC_args = {'useMPIController': True, 'controller_communicator': controller_communicator}
         dirname = f'./tmp_{controller_communicator.rank}'
@@ -780,10 +782,16 @@ if __name__ == '__main__':
         type=str,
         default=None,
     )
+    parser.add_argument(
+        '--n_steps',
+        help="number of steps",
+        type=int,
+        default=None,
+    )
     args = parser.parse_args()
 
     if args.test == 'MSSDC':
-        test_pySDC_integrator_MSSDC(n_steps=MPI.COMM_WORLD.size, useMPIController=True, setup=setup, submit=False)
+        test_pySDC_integrator_MSSDC(n_steps=args.n_steps, useMPIController=True, setup=setup, submit=False)
     else:
         # test_generic_gusto_problem(setup)
         # test_pySDC_integrator_RK(False, RK4, setup)

--- a/pySDC/tutorial/step_7/F_pySDC_with_Gusto.py
+++ b/pySDC/tutorial/step_7/F_pySDC_with_Gusto.py
@@ -29,6 +29,9 @@ from pySDC.helpers.pySDC_as_gusto_time_discretization import pySDC_integrator
 from pySDC.helpers.firedrake_ensemble_communicator import FiredrakeEnsembleCommunicator
 from gusto import SDC, BackwardEuler
 from gusto.core.labels import implicit, time_derivative
+from gusto.core.logging import logger, INFO
+
+logger.setLevel(INFO)
 
 
 from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter


### PR DESCRIPTION
After [some changes to Gusto](https://github.com/firedrakeproject/gusto/commit/81dedbde34e5e599239a329d50178e5b5e6a0ebb), some [strange deadlocks have started to appear in the pySDC tests](https://github.com/Parallel-in-Time/pySDC/actions/runs/13234132362/job/37084519438).

In the Gusto changes, a debug output showing the max/min values of some fields was added, which I presume requires communication across space. Removing this debug information is sufficient to get these tests to pass again.

In order to make sure the space-parallelism is set up correctly, I changed the MPI tests to always use four tasks and distribute them to do space-only, time-only, or space-time parallelism. All of these tests pass without the debug output.

This is definitely some fishy business. Do you know if the debug output works in Gusto without pySDC, @jshipton @tommbendall? If I add `return None` after [this line](https://github.com/firedrakeproject/gusto/blob/3737472c3c36cbf65b71f591dc812614016c5ac7/gusto/timestepping/timestepper.py#L170), the pySDC tests pass with debug level output in Gusto, so I am pretty confident it is related to the remainder of this function.

Btw, I had some issues in freeing communicators at the end of the script on my laptop, so I added the `Free` function to the Firedrake ensemble communicator wrapper. This should not make a large difference in practice.