### PR TITLE
Make plot helper compatible with Python 3.13

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -204,6 +204,7 @@ jobs:
           . venv-pySDC/bin/activate
           pip install -e /repositories/pySDC
           pip install qmat
+          pip install pytest-isolate-mpi
           # test installation
           python -c "import pySDC; print(f'pySDC module: {pySDC}')"
       - name: Install gusto

--- a/pySDC/helpers/plot_helper.py
+++ b/pySDC/helpers/plot_helper.py
@@ -1,6 +1,6 @@
 import matplotlib as mpl
 import matplotlib.pyplot as plt
-from distutils.spawn import find_executable
+import shutil
 
 default_mpl_params = mpl.rcParams.copy()
 
@@ -100,7 +100,7 @@ def setup_mpl(font_size=8, reset=False):
 
     mpl.rcParams.update(style_options)
 
-    if find_executable('latex'):
+    if shutil.which('latex'):
         latex_support = {
             "pgf.texsystem": "pdflatex",  # change this if using xetex or lautex
             "text.usetex": True,  # use LaTeX to write all text

--- a/pySDC/helpers/plot_helper.py
+++ b/pySDC/helpers/plot_helper.py
@@ -125,7 +125,7 @@ def newfig(textwidth, scale, ratio=0.6180339887):
 
 
 def savefig(filename, save_pdf=True, save_pgf=True, save_png=True):
-    if save_pgf and find_executable('latex'):
+    if save_pgf and shutil.which('latex'):
         plt.savefig('{}.pgf'.format(filename), bbox_inches='tight')
     if save_pdf:
         plt.savefig('{}.pdf'.format(filename), bbox_inches='tight')

--- a/pySDC/tests/test_benchmarks/test_collocation.py
+++ b/pySDC/tests/test_benchmarks/test_collocation.py
@@ -25,6 +25,7 @@ def test_benchmark_collocation(benchmark):
     benchmark(wrapper)
 
 
+@pytest.mark.base
 @pytest.mark.parametrize("node_type", node_types)
 @pytest.mark.parametrize("quad_type", quad_types)
 def test_canintegratepolynomials(node_type, quad_type):
@@ -61,6 +62,7 @@ def test_canintegratepolynomials(node_type, quad_type):
         )
 
 
+@pytest.mark.base
 @pytest.mark.parametrize("node_type", node_types)
 @pytest.mark.parametrize("quad_type", quad_types)
 def test_relateQandSmat(node_type, quad_type):
@@ -82,6 +84,7 @@ def test_relateQandSmat(node_type, quad_type):
             )
 
 
+@pytest.mark.base
 @pytest.mark.parametrize("node_type", node_types)
 @pytest.mark.parametrize("quad_type", quad_types)
 def test_partialquadraturewithQ(node_type, quad_type):
@@ -104,6 +107,7 @@ def test_partialquadraturewithQ(node_type, quad_type):
             )
 
 
+@pytest.mark.base
 @pytest.mark.parametrize("node_type", node_types)
 @pytest.mark.parametrize("quad_type", quad_types)
 def test_partialquadraturewithS(node_type, quad_type):


### PR DESCRIPTION
Python `distutils` has been [deprecated since version 3.10 and removed in version 3.12](https://docs.python.org/3/library/distutils.html). In 3.12 I could still use it but after switching to 3.13, the plot helper was broken for me. 
Apparently,`distutil` has been replaced by `shutil`. `shutil.which` returns what you get when you use `which` in the shell you run Python in, or `None` if there is no executable of the name you are looking for. Therefore, this should give the same functionality as `distutil.spawn.find_executable` as it is used in the plot helper.