### PR TITLE
TL: mini fix for edge cases

### DIFF
--- a/pySDC/helpers/fieldsIO.py
+++ b/pySDC/helpers/fieldsIO.py
@@ -438,8 +438,6 @@ class Rectilinear(Scalar):
         gridSizes = np.fromfile(f, dtype=np.int32, count=dim)
         coords = [np.fromfile(f, dtype=np.float64, count=n) for n in gridSizes]
         self.setHeader(nVar, coords)
-        if self.MPI_ON:
-            self.MPI_SETUP_FILETYPE()
 
     def reshape(self, fields: np.ndarray):
         """Reshape the fields to a N-d array (inplace operation)"""

--- a/pySDC/helpers/fieldsIO.py
+++ b/pySDC/helpers/fieldsIO.py
@@ -417,8 +417,6 @@ class Rectilinear(Scalar):
         coords = self.setupCoords(*coords)
         self.header = {"nVar": int(nVar), "coords": coords}
         self.nItems = nVar * self.nDoF
-        if self.MPI_ON:
-            self.MPI_SETUP()
 
     @property
     def hInfos(self):
@@ -573,6 +571,8 @@ class Rectilinear(Scalar):
         data : np.ndarray
             Data to be written in the binary file.
         """
+        if self.mpiType is None:
+            self.MPI_SETUP()
         self.mpiFile.Set_view(disp=offset, etype=self.mpiType, filetype=self.mpiFileType)
         self.mpiFile.Write_all(data)
 
@@ -588,6 +588,8 @@ class Rectilinear(Scalar):
         data : np.ndarray
             Array on which to read the data from the binary file.
         """
+        if self.mpiType is None:
+            self.MPI_SETUP()
         self.mpiFile.Set_view(disp=offset, etype=self.mpiType, filetype=self.mpiFileType)
         self.mpiFile.Read_all(data)
 


### PR DESCRIPTION
There is a rare situation when the `MPI_SETUP` method (setup the subarray view for MPI_READ_ALL) is not called when using MPI : when the `Rectilinear` object is instantiated first, and the MPI communicator and local slices are given by `setupMPI` after. This requires to read the header again, or else it raises and error.

While this is not the recommended usage for `Rectilinear` (`setupMPI` should be called before instantiating any class), this modification allows it while not changing the overall behavior or performance of the class.