### PR TITLE
Add Python 3.13 to core test pipeline

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           environment-file: ${{ env.YML }}
           create-args: >-
-              python=3.12
+              python=3.13
       - name: Code reformatting with black
         run: |
           black pySDC  --check --diff --color
@@ -70,7 +70,7 @@ jobs:
           mv .coverage coverage_${{ matrix.env }}.dat
       - name: Uploading artifacts
         uses: actions/upload-artifact@v4
-        if: matrix.python == '3.12'
+        if: matrix.python == '3.13'
         with:
           name: test-artifacts-cpu-${{ matrix.env }}
           path: |

--- a/pySDC/projects/Resilience/environment.yml
+++ b/pySDC/projects/Resilience/environment.yml
@@ -4,7 +4,6 @@ name: pySDC
 channels:
   - conda-forge
 dependencies:
-  - python=3.13
   - mpi4py>=3.0.0
   - mpi4py-fft>=2.0.2
   - mpich


### PR DESCRIPTION
According to the [status of Python versions](https://devguide.python.org/versions/), Python 3.13 is supported at least to some extend. When I last installed a fresh pySDC environment without explicitly specifying a Python version, I even ended up with 3.13. Therefore, I suggest we better test it to accommodate future users.
However, the pipeline is already too large as is, with some project tests taking a very long time. Therefore, I did not add 3.13 to those tests. In fact, I would be open to stop doing the project tests with all supported Python versions. IMHO, it would suffice to use the latest version (only 3.13 in this case) or to allow projects to specify a supported Python version. 