### PR TITLE
Added caching decorator

### DIFF
--- a/pySDC/helpers/spectral_helper.py
+++ b/pySDC/helpers/spectral_helper.py
@@ -8,6 +8,8 @@ from functools import wraps
 def cache(func):
     """
     Decorator for caching return values of functions.
+    This is very similar to `functools.cache`, but without the memory leaks (see
+    https://docs.astral.sh/ruff/rules/cached-instance-method/).
 
     Example:
 

--- a/pySDC/tests/test_helpers/test_spectral_helper.py
+++ b/pySDC/tests/test_helpers/test_spectral_helper.py
@@ -551,6 +551,30 @@ def test_dealias_MPI(num_procs, axis, bx, bz, nx=32, nz=64, **kwargs):
     run_MPI_test(num_procs=num_procs, axis=axis, nx=nx, nz=nz, bx=bx, bz=bz, test='dealias')
 
 
+@pytest.mark.base
+def test_cache_decorator():
+    from pySDC.helpers.spectral_helper import cache
+    import numpy as np
+
+    class Dummy:
+        num_calls = 0
+
+        @cache
+        def increment(self, x):
+            self.num_calls += 1
+            return x + 1
+
+    dummy = Dummy()
+    values = [0, 1, 1, 0, 3, 1, 2]
+    unique_vals = np.unique(values)
+
+    for x in values:
+        assert dummy.increment(x) == x + 1
+
+    assert dummy.num_calls < len(values)
+    assert dummy.num_calls == len(unique_vals)
+
+
 if __name__ == '__main__':
     str_to_bool = lambda me: False if me == 'False' else True
     str_to_tuple = lambda arg: tuple(int(me) for me in arg.split(','))


### PR DESCRIPTION
This is one feature that I added during the large refactor and one that can be merged independently. It is not particularly useful as used in this PR, but is used extensively in the refactored version.

The caching decorator returns a cached result if the function arguments match a previous call and can be used like this:
```
num_calls = 0

@cache
def increment(x):
    num_calls += 1
    return x + 1

increment(0)  # returns 1, num_calls = 1
increment(1)  # returns 2, num_calls = 2
increment(0)  # returns 1, num_calls = 2
```