### PR TITLE
Added workflow for triggering the Codecov bot in PRs

### DIFF
--- a/.github/workflows/trigger_coverage_bot.yml
+++ b/.github/workflows/trigger_coverage_bot.yml
@@ -1,0 +1,48 @@
+---
+
+name: Trigger coverage bot
+
+on:
+  workflow_run:
+    workflows: ["CI pipeline for pySDC"]
+    types: ["completed"]
+  
+jobs:
+
+  Upload to Codecov:
+    runs-on: ubuntu-latest
+
+    if: ${{ github.repository_owner == 'Parallel-in-Time' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.pull_requests != '' }}
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Conda environment with Micromamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: "etc/environment-postprocess.yml"
+
+      - name: Downloading artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: .
+          merge-multiple: true
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.ACTION_READ_TOKEN }}
+
+      - name: Prepare artifacts
+        run: |
+          python -m coverage combine coverage_*.dat
+          python -m coverage xml
+          python -m coverage html
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV }}
+


### PR DESCRIPTION
I do miss the Codecov bot posting about coverage in our PRs. I want to bring it back, but I don't know a lot about it, so maybe this will not actually do the trick.. I cannot test it before since this workflow will only be triggered once it is in the master branch.

What I added here is a separate workflow that runs when the GitHub CI is done and during PRs. All it does in that case is upload the coverage report to Codecov, which I assume will then trigger the bot.

Problem: Coverage will almost certainly be lower than in the master branch because the GPU tests are not included in this report. This should not lead to fluctuations in the coverage report, though, because the report is generated for a non-master branch and therefore does not show up in the tracking.

I suggest we bring back the bot first and when we managed to do that, we configure it to not fail when coverage has decreased. It will still show which parts of the PR are tested and which aren't, which is very useful information.