### PR TITLE
Fix failing libpressio tests

### DIFF
--- a/pySDC/projects/compression/Docker/install_pySDC.sh
+++ b/pySDC/projects/compression/Docker/install_pySDC.sh
@@ -9,6 +9,9 @@ source /opt/spack/share/spack/setup-env.sh
 # load libpressio in spack to make sure we are using the correct Python
 spack load libpressio
 
+which mpicc
+mpicc --version
+
 # install local version of pySDC and other dependencies
 python -m pip install --upgrade pip
 cd /pySDC
@@ -16,6 +19,8 @@ pip install -e .
 python -m pip install pytest
 python -m pip install coverage
 python -m pip install mpi4py
+
+python -c "import mpi4py; print(mpi4py)"
 
 # go back to original working directory
 cd $current_dir

--- a/pySDC/projects/compression/Docker/install_pySDC.sh
+++ b/pySDC/projects/compression/Docker/install_pySDC.sh
@@ -18,10 +18,9 @@ cd /pySDC
 pip install -e .
 python -m pip install pytest
 python -m pip install coverage
-python -m pip install mpi4py
+python -m pip install --no-binary :all: mpi4py
 
 python -c "from mpi4py import MPI"
-mpirun -np 2 python -c "from mpi4py import MPI"
 
 # go back to original working directory
 cd $current_dir

--- a/pySDC/projects/compression/Docker/install_pySDC.sh
+++ b/pySDC/projects/compression/Docker/install_pySDC.sh
@@ -15,7 +15,7 @@ cd /pySDC
 pip install -e .
 python -m pip install pytest
 python -m pip install coverage
-python -m pip install mpi4py<4.1.0
+python -m pip install "mpi4py<4.1.0"
 
 # go back to original working directory
 cd $current_dir

--- a/pySDC/projects/compression/Docker/install_pySDC.sh
+++ b/pySDC/projects/compression/Docker/install_pySDC.sh
@@ -20,7 +20,8 @@ python -m pip install pytest
 python -m pip install coverage
 python -m pip install mpi4py
 
-python -c "import mpi4py; print(mpi4py)"
+python -c "from mpi4py import MPI"
+mpirun -np 2 python -c "from mpi4py import MPI"
 
 # go back to original working directory
 cd $current_dir

--- a/pySDC/projects/compression/Docker/install_pySDC.sh
+++ b/pySDC/projects/compression/Docker/install_pySDC.sh
@@ -9,18 +9,13 @@ source /opt/spack/share/spack/setup-env.sh
 # load libpressio in spack to make sure we are using the correct Python
 spack load libpressio
 
-which mpicc
-mpicc --version
-
 # install local version of pySDC and other dependencies
 python -m pip install --upgrade pip
 cd /pySDC
 pip install -e .
 python -m pip install pytest
 python -m pip install coverage
-python -m pip install --no-binary :all: mpi4py
-
-python -c "from mpi4py import MPI"
+python -m pip install mpi4py<4.1.0
 
 # go back to original working directory
 cd $current_dir


### PR DESCRIPTION
The installation of mpi4py was broken with the [release of version 4.1.0](https://github.com/mpi4py/mpi4py/releases/tag/4.1.0). They added some pip wheel stuff, which seems incompatible with the docker image.
Note that the latest version of mpi4py does work in the container if installed without pulling the wheels, i.e. with `python -m pip install --no-binary :all: mpi4py`, but then the installation takes a bit longer which is why we decided to restrict the version instead.