### PR TITLE
Fixed job name in Trigger coverage bot action

### DIFF
--- a/.github/workflows/trigger_coverage_bot.yml
+++ b/.github/workflows/trigger_coverage_bot.yml
@@ -9,7 +9,7 @@ on:
   
 jobs:
 
-  Upload to Codecov:
+  Upload_to_Codecov:
     runs-on: ubuntu-latest
 
     if: ${{ github.repository_owner == 'Parallel-in-Time' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.pull_requests != '' }}
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Conda environment with Micromamba
+      - name: Install virtual environment with Micromamba
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: "etc/environment-postprocess.yml"


### PR DESCRIPTION
Seems spaces are not allowed in job names, see [here](https://github.com/Parallel-in-Time/pySDC/actions/runs/15894913965).