### PR TITLE
Updated spectral helper to new scipy version

### DIFF
--- a/pySDC/helpers/spectral_helper.py
+++ b/pySDC/helpers/spectral_helper.py
@@ -292,7 +292,7 @@ class ChebychevHelper(SpectralHelper1D):
 
         def get_forward_conv(name):
             if name == 'T2U':
-                mat = (sp.eye(N) - sp.diags(xp.ones(N - 2), offsets=+2)) / 2.0
+                mat = (sp.eye(N) - sp.diags(xp.ones(N - 2), offsets=+2)).tocsc() / 2.0
                 mat[:, 0] *= 2
             elif name == 'D2T':
                 mat = sp.eye(N) - sp.diags(xp.ones(N - 2), offsets=+2)


### PR DESCRIPTION
There was a version change in scipy which broke some tests. This PR fixes the tests in the base and mpi4py environments. 
However, there is still one test failing in the `parallelSDC_reloaded` project. Do you have a minute to fix that one, @tlunet? If you could make it faster while you are at it, that would also be great.. ;)