### PR TITLE
Sweepers require level during instantiation

### DIFF
--- a/pySDC/core/level.py
+++ b/pySDC/core/level.py
@@ -67,13 +67,13 @@ class Level(FrozenClass):
             level_index (int): custom name for this level
         """
 
-        # instantiate sweeper, problem and hooks
-        self.__sweep = sweeper_class(sweeper_params, self)
-        self.__prob = problem_class(**problem_params)
-
         # set level parameters and status
         self.params = _Pars(level_params)
         self.status = _Status()
+
+        # instantiate sweeper, problem and hooks
+        self.__sweep = sweeper_class(sweeper_params, self)
+        self.__prob = problem_class(**problem_params)
 
         # set name
         self.level_index = level_index

--- a/pySDC/core/level.py
+++ b/pySDC/core/level.py
@@ -68,7 +68,7 @@ class Level(FrozenClass):
         """
 
         # instantiate sweeper, problem and hooks
-        self.__sweep = sweeper_class(sweeper_params)
+        self.__sweep = sweeper_class(sweeper_params, self)
         self.__prob = problem_class(**problem_params)
 
         # set level parameters and status
@@ -86,9 +86,6 @@ class Level(FrozenClass):
         self.fold = [None] * (self.sweep.coll.num_nodes + 1)
 
         self.tau = [None] * self.sweep.coll.num_nodes
-
-        # pass this level to the sweeper for easy access
-        self.sweep.level = self
 
         self.__tag = None
 

--- a/pySDC/core/sweeper.py
+++ b/pySDC/core/sweeper.py
@@ -44,16 +44,15 @@ class Sweeper(object):
         coll (pySDC.Collocation.CollBase): collocation object
     """
 
-    def __init__(self, params):
+    def __init__(self, params, level):
         """
         Initialization routine for the base sweeper
 
         Args:
             params (dict): parameter object
-
+            level (pySDC.Level.level): the level that uses this sweeper
         """
 
-        # set up logger
         self.logger = logging.getLogger('sweeper')
 
         essential_keys = ['num_nodes']
@@ -81,9 +80,7 @@ class Sweeper(object):
             )
             self.params.do_coll_update = True
 
-        # This will be set as soon as the sweeper is instantiated at the level
-        self.__level = None
-
+        self.__level = level
         self.parallelizable = False
 
     def setupGenerator(self, qd_type):

--- a/pySDC/helpers/setup_helper.py
+++ b/pySDC/helpers/setup_helper.py
@@ -24,7 +24,9 @@ def generate_description(problem_class, **kwargs):
 
     problem_keys = problem_class.__init__.__code__.co_varnames
     level_keys = level_params({}).__dict__.keys()
-    sweeper_keys = description['sweeper_class']({'num_nodes': 1, 'quad_type': 'RADAU-RIGHT'}).params.__dict__.keys()
+    sweeper_keys = description['sweeper_class'](
+        {'num_nodes': 1, 'quad_type': 'RADAU-RIGHT'}, None
+    ).params.__dict__.keys()
     step_keys = step_params({}).__dict__.keys()
 
     # TODO: add convergence controllers

--- a/pySDC/implementations/convergence_controller_classes/adaptive_collocation.py
+++ b/pySDC/implementations/convergence_controller_classes/adaptive_collocation.py
@@ -142,8 +142,7 @@ class AdaptiveCollocation(ConvergenceController):
             nodes_old = L.sweep.coll.nodes.copy()
 
             # change sweeper
-            L.sweep.__init__(update_params_sweeper)
-            L.sweep.level = L
+            L.sweep.__init__(update_params_sweeper, L)
 
             # reset level to tell it the new structure of the solution
             L.params.__dict__.update(new_params_level)

--- a/pySDC/implementations/sweeper_classes/Multistep.py
+++ b/pySDC/implementations/sweeper_classes/Multistep.py
@@ -1,4 +1,5 @@
 from pySDC.core.sweeper import Sweeper, _Pars
+from pySDC.core.level import Level
 
 
 class Cache(object):
@@ -55,7 +56,7 @@ class MultiStep(Sweeper):
     alpha = None
     beta = None
 
-    def __init__(self, params):
+    def __init__(self, params, level):
         """
         Initialization routine for the base sweeper.
 
@@ -71,6 +72,7 @@ class MultiStep(Sweeper):
 
         Args:
             params (dict): parameter object
+            level (pySDC.Level.level): the level that uses this sweeper
         """
         import logging
         from pySDC.core.collocation import CollBase
@@ -88,14 +90,35 @@ class MultiStep(Sweeper):
         # we need a dummy collocation object to instantiate the levels.
         self.coll = CollBase(num_nodes=1, quad_type='RADAU-RIGHT')
 
-        # This will be set as soon as the sweeper is instantiated at the level
-        self.__level = None
+        self.__level = level
 
         self.parallelizable = False
 
         # proprietary variables for the multistep methods
         self.steps = len(self.alpha)
         self.cache = Cache(self.steps)
+
+    @property
+    def level(self):
+        """
+        Returns the current level
+
+        Returns:
+            pySDC.Level.level: Current level
+        """
+        return self.__level
+
+    @level.setter
+    def level(self, lvl):
+        """
+        Sets a reference to the current level (done in the initialization of the level)
+
+        Args:
+            lvl (pySDC.Level.level): Current level
+        """
+        assert isinstance(lvl, Level), f"You tried to set the sweeper's level with an instance of {type(lvl)}!"
+
+        self.__level = lvl
 
     def predict(self):
         """

--- a/pySDC/implementations/sweeper_classes/Runge_Kutta.py
+++ b/pySDC/implementations/sweeper_classes/Runge_Kutta.py
@@ -125,12 +125,13 @@ class RungeKutta(Sweeper):
     The entries of the Butcher tableau are stored as class attributes.
     """
 
-    def __init__(self, params):
+    def __init__(self, params, level):
         """
         Initialization routine for the custom sweeper
 
         Args:
             params: parameters for the sweeper
+            level (pySDC.Level.level): the level that uses this sweeper
         """
         # set up logger
         self.logger = logging.getLogger('sweeper')
@@ -156,8 +157,7 @@ class RungeKutta(Sweeper):
 
         self.params = _Pars(params)
 
-        # This will be set as soon as the sweeper is instantiated at the level
-        self.__level = None
+        self.__level = level
 
         self.parallelizable = False
         self.QI = self.coll.Qmat
@@ -343,14 +343,15 @@ class RungeKuttaIMEX(RungeKutta):
     weights_explicit = None
     ButcherTableauClass_explicit = ButcherTableau
 
-    def __init__(self, params):
+    def __init__(self, params, level):
         """
         Initialization routine
 
         Args:
             params: parameters for the sweeper
+            level (pySDC.Level.level): the level that uses this sweeper
         """
-        super().__init__(params)
+        super().__init__(params, level)
         type(self).weights_explicit = self.weights if self.weights_explicit is None else self.weights_explicit
         self.coll_explicit = self.get_Butcher_tableau_explicit()
         self.QE = self.coll_explicit.Qmat

--- a/pySDC/implementations/sweeper_classes/Runge_Kutta.py
+++ b/pySDC/implementations/sweeper_classes/Runge_Kutta.py
@@ -157,7 +157,9 @@ class RungeKutta(Sweeper):
 
         self.params = _Pars(params)
 
-        self.__level = level
+        # set level using the setter in order to adapt residual tolerance if needed
+        self.__level = None
+        self.level = level
 
         self.parallelizable = False
         self.QI = self.coll.Qmat

--- a/pySDC/implementations/sweeper_classes/Runge_Kutta_Nystrom.py
+++ b/pySDC/implementations/sweeper_classes/Runge_Kutta_Nystrom.py
@@ -104,14 +104,15 @@ class RungeKuttaNystrom(RungeKutta):
     weights_bar = None
     matrix_bar = None
 
-    def __init__(self, params):
+    def __init__(self, params, level):
         """
         Initialization routine for the custom sweeper
 
         Args:
             params: parameters for the sweeper
+            level (pySDC.Level.level): the level that uses this sweeper
         """
-        super().__init__(params)
+        super().__init__(params, level)
         self.coll_bar = self.get_Butcher_tableau_bar()
         self.Qx = self.coll_bar.Qmat
 

--- a/pySDC/implementations/sweeper_classes/boris_2nd_order.py
+++ b/pySDC/implementations/sweeper_classes/boris_2nd_order.py
@@ -16,22 +16,21 @@ class boris_2nd_order(Sweeper):
         Sx: node-to-node Euler half-step for position update
     """
 
-    def __init__(self, params):
+    def __init__(self, params, level):
         """
         Initialization routine for the custom sweeper
 
         Args:
             params: parameters for the sweeper
+            level (pySDC.Level.level): the level that uses this sweeper
         """
-
-        # call parent's initialization routine
 
         if "QI" not in params:
             params["QI"] = "IE"
         if "QE" not in params:
             params["QE"] = "EE"
 
-        super(boris_2nd_order, self).__init__(params)
+        super(boris_2nd_order, self).__init__(params, level)
 
         # S- and SQ-matrices (derived from Q) and Sx- and ST-matrices for the integrator
         [

--- a/pySDC/implementations/sweeper_classes/explicit.py
+++ b/pySDC/implementations/sweeper_classes/explicit.py
@@ -9,19 +9,19 @@ class explicit(Sweeper):
         QE: explicit Euler integration matrix
     """
 
-    def __init__(self, params):
+    def __init__(self, params, level):
         """
         Initialization routine for the custom sweeper
 
         Args:
             params: parameters for the sweeper
+            level (pySDC.Level.level): the level that uses this sweeper
         """
 
         if 'QE' not in params:
             params['QE'] = 'EE'
 
-        # call parent's initialization routine
-        super(explicit, self).__init__(params)
+        super(explicit, self).__init__(params, level)
 
         # integration matrix
         self.QE = self.get_Qdelta_explicit(qd_type=self.params.QE)

--- a/pySDC/implementations/sweeper_classes/generic_implicit.py
+++ b/pySDC/implementations/sweeper_classes/generic_implicit.py
@@ -9,19 +9,19 @@ class generic_implicit(Sweeper):
         QI: lower triangular matrix
     """
 
-    def __init__(self, params):
+    def __init__(self, params, level):
         """
         Initialization routine for the custom sweeper
 
         Args:
             params: parameters for the sweeper
+            level (pySDC.Level.level): the level that uses this sweeper
         """
 
         if 'QI' not in params:
             params['QI'] = 'IE'
 
-        # call parent's initialization routine
-        super().__init__(params)
+        super().__init__(params, level)
 
         # get QI matrix
         self.QI = self.get_Qdelta_implicit(qd_type=self.params.QI)

--- a/pySDC/implementations/sweeper_classes/generic_implicit_MPI.py
+++ b/pySDC/implementations/sweeper_classes/generic_implicit_MPI.py
@@ -22,13 +22,20 @@ class SweeperMPI(Sweeper):
     `generic_implicit`.
     """
 
-    def __init__(self, params):
+    def __init__(self, params, level):
+        """
+        Initialization routine for the sweeper
+
+        Args:
+            params: parameters for the sweeper
+            level (pySDC.Level.level): the level that uses this sweeper
+        """
         self.logger = logging.getLogger('sweeper')
 
         if 'comm' not in params.keys():
             params['comm'] = MPI.COMM_WORLD
             self.logger.debug('Using MPI.COMM_WORLD for the communicator because none was supplied in the params.')
-        super().__init__(params)
+        super().__init__(params, level)
 
         if self.params.comm.size != self.coll.num_nodes:
             raise NotImplementedError(

--- a/pySDC/implementations/sweeper_classes/imex_1st_order.py
+++ b/pySDC/implementations/sweeper_classes/imex_1st_order.py
@@ -14,12 +14,13 @@ class imex_1st_order(Sweeper):
         QE: explicit Euler integration matrix
     """
 
-    def __init__(self, params):
+    def __init__(self, params, level):
         """
         Initialization routine for the custom sweeper
 
         Args:
             params: parameters for the sweeper
+            level (pySDC.Level.level): the level that uses this sweeper
         """
 
         if 'QI' not in params:
@@ -27,8 +28,7 @@ class imex_1st_order(Sweeper):
         if 'QE' not in params:
             params['QE'] = 'EE'
 
-        # call parent's initialization routine
-        super().__init__(params)
+        super().__init__(params, level)
 
         # IMEX integration matrices
         self.QI = self.get_Qdelta_implicit(qd_type=self.params.QI)

--- a/pySDC/implementations/sweeper_classes/imex_1st_order_MPI.py
+++ b/pySDC/implementations/sweeper_classes/imex_1st_order_MPI.py
@@ -4,11 +4,11 @@ from pySDC.implementations.sweeper_classes.imex_1st_order import imex_1st_order
 
 
 class imex_1st_order_MPI(SweeperMPI, imex_1st_order):
-    def __init__(self, params):
-        super().__init__(params)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         assert (
             self.params.QE == 'PIC'
-        ), f"Only Picard is implemented for explicit precondioner so far in {type(self).__name__}! You chose \"{self.params.QE}\""
+        ), f"Only Picard is implemented for explicit preconditioner so far in {type(self).__name__}! You chose \"{self.params.QE}\""
 
     def integrate(self, last_only=False):
         """

--- a/pySDC/implementations/sweeper_classes/multi_implicit.py
+++ b/pySDC/implementations/sweeper_classes/multi_implicit.py
@@ -12,12 +12,13 @@ class multi_implicit(Sweeper):
         Q2: implicit integration matrix for the second component
     """
 
-    def __init__(self, params):
+    def __init__(self, params, level):
         """
         Initialization routine for the custom sweeper
 
         Args:
             params: parameters for the sweeper
+            level (pySDC.Level.level): the level that uses this sweeper
         """
 
         # Default choice: implicit Euler
@@ -27,7 +28,7 @@ class multi_implicit(Sweeper):
             params['Q2'] = 'IE'
 
         # call parent's initialization routine
-        super(multi_implicit, self).__init__(params)
+        super(multi_implicit, self).__init__(params, level)
 
         # Integration matrices
         self.Q1 = self.get_Qdelta_implicit(qd_type=self.params.Q1)

--- a/pySDC/implementations/sweeper_classes/verlet.py
+++ b/pySDC/implementations/sweeper_classes/verlet.py
@@ -16,12 +16,13 @@ class verlet(Sweeper):
         qQ: update rule for final value (if needed)
     """
 
-    def __init__(self, params):
+    def __init__(self, params, level):
         """
         Initialization routine for the custom sweeper
 
         Args:
             params: parameters for the sweeper
+            level (pySDC.Level.level): the level that uses this sweeper
         """
 
         if 'QI' not in params:
@@ -29,8 +30,7 @@ class verlet(Sweeper):
         if 'QE' not in params:
             params['QE'] = 'EE'
 
-        # call parent's initialization routine
-        super(verlet, self).__init__(params)
+        super(verlet, self).__init__(params, level)
 
         # Trapezoidal rule, Qx and Double-Q as in the Boris-paper
         [self.QT, self.Qx, self.QQ] = self.__get_Qd()

--- a/pySDC/projects/DAE/sweepers/fullyImplicitDAE.py
+++ b/pySDC/projects/DAE/sweepers/fullyImplicitDAE.py
@@ -45,14 +45,13 @@ class FullyImplicitDAE(generic_implicit):
        J. Comput. Phys. Vol. 221 No. 2 (2007).
     """
 
-    def __init__(self, params):
+    def __init__(self, params, level):
         """Initialization routine"""
 
         if 'QI' not in params:
             params['QI'] = 'IE'
 
-        # call parent's initialization routine
-        super().__init__(params)
+        super().__init__(params, level)
 
         msg = f"Quadrature type {self.params.quad_type} is not implemented yet. Use 'RADAU-RIGHT' instead!"
         if self.coll.left_is_node:

--- a/pySDC/projects/DAE/sweepers/rungeKuttaDAE.py
+++ b/pySDC/projects/DAE/sweepers/rungeKuttaDAE.py
@@ -76,8 +76,8 @@ class RungeKuttaDAE(RungeKutta):
     More details can be found [here](https://github.com/Parallel-in-Time/pySDC/blob/master/pySDC/implementations/sweeper_classes/Runge_Kutta.py).
     """
 
-    def __init__(self, params):
-        super().__init__(params)
+    def __init__(self, params, level):
+        super().__init__(params, level)
         self.du_init = None
         self.fully_initialized = False
 

--- a/pySDC/projects/DAE/sweepers/semiImplicitDAE.py
+++ b/pySDC/projects/DAE/sweepers/semiImplicitDAE.py
@@ -83,14 +83,13 @@ class SemiImplicitDAE(FullyImplicitDAE):
     :math:`F_{new}(\vec{x}, \vec{x}')`.
     """
 
-    def __init__(self, params):
+    def __init__(self, params, level):
         """Initialization routine"""
 
         if 'QI' not in params:
             params['QI'] = 'IE'
 
-        # call parent's initialization routine
-        super().__init__(params)
+        super().__init__(params, level)
 
         msg = f"Quadrature type {self.params.quad_type} is not implemented yet. Use 'RADAU-RIGHT' instead!"
         if self.coll.left_is_node:

--- a/pySDC/projects/Monodomain/sweeper_classes/exponential_runge_kutta/imexexp_1st_order.py
+++ b/pySDC/projects/Monodomain/sweeper_classes/exponential_runge_kutta/imexexp_1st_order.py
@@ -17,19 +17,19 @@ class imexexp_1st_order(Sweeper):
     The underlying intergrator is exponential Runge-Kutta, leading to exponential SDC (ESDC).
     """
 
-    def __init__(self, params):
+    def __init__(self, params, level):
         """
         Initialization routine for the custom sweeper
 
         Args:
             params: parameters for the sweeper
+            level (pySDC.Level.level): the level that uses this sweeper
         """
 
         if "QI" not in params:
             params["QI"] = "IE"
 
-        # call parent's initialization routine
-        super(imexexp_1st_order, self).__init__(params)
+        super().__init__(params, level)
 
         # IMEX integration matrices
         self.QI = self.get_Qdelta_implicit(qd_type=self.params.QI)

--- a/pySDC/projects/Monodomain/sweeper_classes/runge_kutta/imexexp_1st_order.py
+++ b/pySDC/projects/Monodomain/sweeper_classes/runge_kutta/imexexp_1st_order.py
@@ -13,19 +13,19 @@ class imexexp_1st_order(Sweeper):
 
     """
 
-    def __init__(self, params):
+    def __init__(self, params, level):
         """
         Initialization routine for the custom sweeper
 
         Args:
             params: parameters for the sweeper
+            level (pySDC.Level.level): the level that uses this sweeper
         """
 
         if "QI" not in params:
             params["QI"] = "IE"
 
-        # call parent's initialization routine
-        super(imexexp_1st_order, self).__init__(params)
+        super().__init__(params, level)
 
         # IMEX integration matrices
         self.QI = self.get_Qdelta_implicit(qd_type=self.params.QI)

--- a/pySDC/projects/Second_orderSDC/tests/test_convergence.py
+++ b/pySDC/projects/Second_orderSDC/tests/test_convergence.py
@@ -182,5 +182,5 @@ def test_RKN_VV(sweeper_name, cwd=''):
 
 
 if __name__ == '__main__':
-    pass
+    test_RKN_VV('RKN')
     # BorisSDC_global_convergence()

--- a/pySDC/projects/Second_orderSDC/tests/test_convergence.py
+++ b/pySDC/projects/Second_orderSDC/tests/test_convergence.py
@@ -182,5 +182,5 @@ def test_RKN_VV(sweeper_name, cwd=''):
 
 
 if __name__ == '__main__':
-    test_RKN_VV('RKN')
+    pass
     # BorisSDC_global_convergence()

--- a/pySDC/projects/parallelSDC/linearized_implicit_fixed_parallel.py
+++ b/pySDC/projects/parallelSDC/linearized_implicit_fixed_parallel.py
@@ -13,19 +13,19 @@ class linearized_implicit_fixed_parallel(linearized_implicit_parallel):
         D: eigenvalues of the QI
     """
 
-    def __init__(self, params):
+    def __init__(self, params, level):
         """
         Initialization routine for the custom sweeper
 
         Args:
             params: parameters for the sweeper
+            level (pySDC.Level.level): the level that uses this sweeper
         """
 
         if 'fixed_time_in_jacobian' not in params:
             params['fixed_time_in_jacobian'] = 0
 
-        # call parent's initialization routine
-        super(linearized_implicit_fixed_parallel, self).__init__(params)
+        super().__init__(params, level)
 
         assert self.params.fixed_time_in_jacobian in range(self.coll.num_nodes + 1), (
             "ERROR: fixed_time_in_jacobian is too small or too large, got %s" % self.params.fixed_time_in_jacobian

--- a/pySDC/projects/parallelSDC/linearized_implicit_fixed_parallel_prec.py
+++ b/pySDC/projects/parallelSDC/linearized_implicit_fixed_parallel_prec.py
@@ -11,19 +11,19 @@ class linearized_implicit_fixed_parallel_prec(linearized_implicit_fixed_parallel
         D: eigenvalues of the QI
     """
 
-    def __init__(self, params):
+    def __init__(self, params, level):
         """
         Initialization routine for the custom sweeper
 
         Args:
             params: parameters for the sweeper
+            level (pySDC.Level.level): the level that uses this sweeper
         """
 
         if 'fixed_time_in_jacobian' not in params:
             params['fixed_time_in_jacobian'] = 0
 
-        # call parent's initialization routine
-        super(linearized_implicit_fixed_parallel, self).__init__(params)
+        super().__init__(params, level)
 
         assert self.params.fixed_time_in_jacobian in range(self.coll.num_nodes + 1), (
             "ERROR: fixed_time_in_jacobian is too small or too large, got %s" % self.params.fixed_time_in_jacobian

--- a/pySDC/projects/parallelSDC/linearized_implicit_parallel.py
+++ b/pySDC/projects/parallelSDC/linearized_implicit_parallel.py
@@ -8,19 +8,19 @@ class linearized_implicit_parallel(generic_implicit):
     Parallel sweeper using Newton for linearization
     """
 
-    def __init__(self, params):
+    def __init__(self, params, level):
         """
         Initialization routine for the custom sweeper
 
         Args:
             params: parameters for the sweeper
+            level (pySDC.Level.level): the level that uses this sweeper
         """
 
         if 'fixed_time_in_jacobian' not in params:
             params['fixed_time_in_jacobian'] = 0
 
-        # call parent's initialization routine
-        super(linearized_implicit_parallel, self).__init__(params)
+        super().__init__(params, level)
 
         self.D, self.V = np.linalg.eig(self.QI[1:, 1:])
         self.Vi = np.linalg.inv(self.V)

--- a/pySDC/projects/parallelSDC_reloaded/nilpotency.py
+++ b/pySDC/projects/parallelSDC_reloaded/nilpotency.py
@@ -3,7 +3,7 @@
 """
 Created on Fri Dec 22 17:17:14 2023
 
-Evaluate the nilpotency of diagonal preconditionners MIN-SR-S and MIN-SR-NS
+Evaluate the nilpotency of diagonal preconditioners MIN-SR-S and MIN-SR-NS
 with increasing number of nodes.
 """
 import numpy as np
@@ -36,7 +36,7 @@ nil_MIN_SR_S = []
 nil_MIN_SR_NS = []
 nNodes = range(2, 20)
 for m in nNodes:
-    s = Sweeper({"num_nodes": m, "quad_type": quadType, "node_type": nodeType})
+    s = Sweeper({"num_nodes": m, "quad_type": quadType, "node_type": nodeType}, None)
     Q = s.coll.Qmat[1:, 1:]
     nodes = s.coll.nodes
 

--- a/pySDC/projects/soft_failure/implicit_sweeper_faults.py
+++ b/pySDC/projects/soft_failure/implicit_sweeper_faults.py
@@ -28,12 +28,13 @@ class implicit_sweeper_faults(generic_implicit):
 
     """
 
-    def __init__(self, params):
+    def __init__(self, params, level):
         """
         Initialization routine for the custom sweeper
 
         Args:
             params: parameters for the sweeper
+            level (pySDC.Level.level): the level that uses this sweeper
         """
 
         if 'allow_fault_correction' not in params:
@@ -45,8 +46,7 @@ class implicit_sweeper_faults(generic_implicit):
         if 'dump_injections_filehandle' not in params:
             params['dump_injections_filehandle'] = None
 
-        # call parent's initialization routine
-        super(implicit_sweeper_faults, self).__init__(params)
+        super().__init__(params, level)
 
         self.fault_stats = _fault_stats()
 

--- a/pySDC/tests/test_sweepers/test_preconditioners.py
+++ b/pySDC/tests/test_sweepers/test_preconditioners.py
@@ -14,7 +14,7 @@ num_nodes = [2, 3, 4, 5]
 @pytest.mark.parametrize("M", num_nodes)
 def test_MIN_SR(node_type, quad_type, M):
     params = {'num_nodes': M, 'quad_type': quad_type, 'node_type': node_type}
-    sweeper = Sweeper(params)
+    sweeper = Sweeper(params, None)
     Q = sweeper.coll.Qmat[1:, 1:]
 
     # Check non-stiff limit
@@ -47,7 +47,7 @@ def test_MIN_SR(node_type, quad_type, M):
 @pytest.mark.parametrize("M", num_nodes)
 def test_MIN_SR_FLEX(node_type, quad_type, M):
     params = {'num_nodes': M, 'quad_type': quad_type, 'node_type': node_type}
-    sweeper = Sweeper(params)
+    sweeper = Sweeper(params, None)
 
     start_idx = 1
     for i in range(M):
@@ -138,7 +138,7 @@ def test_LU(node_type, quad_type, M):
         return
 
     params = {'num_nodes': M, 'quad_type': quad_type, 'node_type': node_type}
-    sweeper = Sweeper(params)
+    sweeper = Sweeper(params, None)
     Q = sweeper.coll.Qmat[1:, 1:]
 
     # Check nilpotency
@@ -160,7 +160,7 @@ def test_LU(node_type, quad_type, M):
 @pytest.mark.parametrize("M", num_nodes)
 def test_Qpar(node_type, quad_type, M):
     params = {'num_nodes': M, 'quad_type': quad_type, 'node_type': node_type}
-    sweeper = Sweeper(params)
+    sweeper = Sweeper(params, None)
     Q = sweeper.coll.Qmat[1:, 1:]
 
     QDelta = sweeper.get_Qdelta_implicit('Qpar')[1:, 1:]
@@ -174,7 +174,7 @@ def test_Qpar(node_type, quad_type, M):
 @pytest.mark.parametrize("M", num_nodes)
 def test_IE(node_type, quad_type, M):
     params = {'num_nodes': M, 'quad_type': quad_type, 'node_type': node_type}
-    sweeper = Sweeper(params)
+    sweeper = Sweeper(params, None)
 
     QDelta = sweeper.get_Qdelta_implicit('IE')[1:, 1:]
     for i in range(M):
@@ -188,7 +188,7 @@ def test_IE(node_type, quad_type, M):
 @pytest.mark.parametrize("M", num_nodes)
 def test_IEpar(node_type, quad_type, M):
     params = {'num_nodes': M, 'quad_type': quad_type, 'node_type': node_type}
-    sweeper = Sweeper(params)
+    sweeper = Sweeper(params, None)
 
     QDelta = sweeper.get_Qdelta_implicit('IEpar')[1:, 1:]
     assert np.all(np.diag(np.diag(QDelta)) == QDelta), "no diagonal QDelta"
@@ -201,7 +201,7 @@ def test_IEpar(node_type, quad_type, M):
 @pytest.mark.parametrize("M", num_nodes)
 def test_PIC(node_type, quad_type, M):
     params = {'num_nodes': M, 'quad_type': quad_type, 'node_type': node_type}
-    sweeper = Sweeper(params)
+    sweeper = Sweeper(params, None)
 
     QDelta = sweeper.get_Qdelta_implicit('PIC')[1:, 1:]
     assert np.all(QDelta == 0), "not a null matrix"


### PR DESCRIPTION
As @danielru has correctly noted 10 years ago in #46, the sweepers can be instantiated, but not used without a level.
Since I now have some capacity for tending the garden, I thought I'd change that. 
I also think it makes it easier get started with developing a new sweeper since its now more obvious that sweeper and level interact.

Note that it is possible to pass `None` as the level in the SDC sweepers. The sweepers have setters for the level that make sure you pass a proper level, but they are not used during instantiation. In some tests, sweepers are instantiated to check the attached collocation problem, so we should keep this.

Closes #46