### PR TITLE
Allow other name for FLEX preconditioner

### DIFF
--- a/pySDC/core/sweeper.py
+++ b/pySDC/core/sweeper.py
@@ -270,5 +270,5 @@ class Sweeper(object):
         k : int
             Index of the sweep (0 for initial sweep, 1 for the first one, ...).
         """
-        if self.params.QI == 'MIN-SR-FLEX':
+        if self.params.QI.lower() in ['min-sr-flex', 'min_sr_flex']:
             self.QI = self.get_Qdelta_implicit(qd_type="MIN-SR-FLEX", k=k)


### PR DESCRIPTION
Thibaut and I noticed earlier that in `qmat` you can use underscores or dashes in the names of preconditioners, but in `pySDC` only dashes lead to update of the preconditioner coefficients between iterations. Can lead to some difficult to find bugs because there is no indication that something has gone wrong.

This is a simple fix so that `MIN-SR-FLEX` and `MIN_SR_FLEX` now both work the same. 