### PR TITLE
Immediately flush debug messages

### DIFF
--- a/pySDC/core/controller.py
+++ b/pySDC/core/controller.py
@@ -92,7 +92,25 @@ class Controller(object):
             file_handler = None
 
         std_formatter = logging.Formatter(fmt='%(name)s - %(levelname)s: %(message)s')
-        std_handler = logging.StreamHandler(sys.stdout)
+
+        if level <= logging.DEBUG:
+            import warnings
+
+            warnings.warn('Running with debug output will degrade performance as all output is immediately flushed.')
+
+            class StreamFlushingHandler(logging.StreamHandler):
+                """
+                This will immediately flush any messages to the output.
+                """
+
+                def emit(self, record):
+                    super().emit(record)
+                    self.flush()
+
+            std_handler = StreamFlushingHandler(sys.stdout)
+        else:
+            std_handler = logging.StreamHandler(sys.stdout)
+
         std_handler.setFormatter(std_formatter)
 
         # instantiate logger


### PR DESCRIPTION
When the code crashes, i.e. does not orderly finish, messages in the log that have not yet been flushed may not get flushed at all. Therefore, I was still using print statements a lot of the time which I removed when I was done.
The better approach is to flush all output immediately when running with debug output. Then, rather than adding temporary print statements during debugging, we can add meaningful messages and leave them in.

Now immediate flushing adds some overhead, I imagine, but presumably you don't care so much about performance when using debug output.

So this PR adds a handler for the loggers that immediately flushes if we use debug output, but it also gives a warning that this degrades performance.

Sadly, I don't know how to test this. If anyone has an idea, let me know!