### PR TITLE
More genericity for QDelta coefficients

### DIFF
--- a/pySDC/core/level.py
+++ b/pySDC/core/level.py
@@ -1,3 +1,6 @@
+from pySDC.core.sweeper import Sweeper
+from pySDC.core.problem import Problem
+
 from pySDC.helpers.pysdc_helper import FrozenClass
 
 
@@ -72,8 +75,8 @@ class Level(FrozenClass):
         self.status = _Status()
 
         # instantiate sweeper, problem and hooks
-        self.__sweep = sweeper_class(sweeper_params, self)
-        self.__prob = problem_class(**problem_params)
+        self.__sweep: Sweeper = sweeper_class(sweeper_params, self)
+        self.__prob: Problem = problem_class(**problem_params)
 
         # set name
         self.level_index = level_index
@@ -119,7 +122,7 @@ class Level(FrozenClass):
         self.tau = [None] * self.sweep.coll.num_nodes
 
     @property
-    def sweep(self):
+    def sweep(self) -> Sweeper:
         """
         Getter for the sweeper
 
@@ -129,7 +132,7 @@ class Level(FrozenClass):
         return self.__sweep
 
     @property
-    def prob(self):
+    def prob(self) -> Problem:
         """
         Getter for the problem
 

--- a/pySDC/core/step.py
+++ b/pySDC/core/step.py
@@ -1,6 +1,6 @@
 import logging
 
-from pySDC.core import level as levclass
+from pySDC.core.level import Level
 from pySDC.core.base_transfer import BaseTransfer
 from pySDC.core.errors import ParameterError
 from pySDC.helpers.pysdc_helper import FrozenClass
@@ -73,7 +73,7 @@ class Step(FrozenClass):
         # empty attributes
         self.__transfer_dict = {}
         self.base_transfer = None
-        self.levels = []
+        self.levels: list[Level] = []
         self.__prev = None
         self.__next = None
 
@@ -149,7 +149,7 @@ class Step(FrozenClass):
 
         # generate levels, register and connect if needed
         for l in range(len(descr_list)):
-            L = levclass.Level(
+            L = Level(
                 problem_class=descr_list[l]['problem_class'],
                 problem_params=descr_list[l]['problem_params'],
                 sweeper_class=descr_list[l]['sweeper_class'],

--- a/pySDC/core/sweeper.py
+++ b/pySDC/core/sweeper.py
@@ -1,11 +1,17 @@
 import logging
 import numpy as np
-from qmat import QDELTA_GENERATORS
+from qmat.qdelta import QDeltaGenerator, QDELTA_GENERATORS
 
 from pySDC.core.errors import ParameterError
 from pySDC.core.level import Level
 from pySDC.core.collocation import CollBase
 from pySDC.helpers.pysdc_helper import FrozenClass
+
+
+# Organize QDeltaGenerator class in dict[type(QDeltaGenerator),set(str)] to retrieve aliases
+QDELTA_GENERATORS_ALIASES = {v: [] for v in set(QDELTA_GENERATORS.values())}
+for k, v in QDELTA_GENERATORS.items():
+    QDELTA_GENERATORS_ALIASES[v].add(k)
 
 
 # short helper class to add params as attributes
@@ -83,26 +89,13 @@ class Sweeper(object):
         self.__level = level
         self.parallelizable = False
 
-    def getGenerator(self, qd_type):
-        coll = self.coll
-
-        generator = QDELTA_GENERATORS[qd_type](
-            # for algebraic types (LU, ...)
-            Q=coll.generator.Q,
-            # for MIN in tables, MIN-SR-S ...
-            nNodes=coll.num_nodes,
-            nodeType=coll.node_type,
-            quadType=coll.quad_type,
-            # for time-stepping types, MIN-SR-NS
-            nodes=coll.nodes,
-            tLeft=coll.tleft,
-        )
-
-        return generator
+    def buildGenerator(self, qdType: str) -> QDeltaGenerator:
+        return QDELTA_GENERATORS[qdType](qGen=self.coll.generator, tLeft=self.coll.tleft)
 
     def get_Qdelta_implicit(self, qd_type, k=None):
         QDmat = np.zeros_like(self.coll.Qmat)
-        self.genQI = self.getGenerator(qd_type)
+        if not hasattr(self, "genQI") or qd_type not in QDELTA_GENERATORS_ALIASES[type(self.genQI)]:
+            self.genQI: QDeltaGenerator = self.buildGenerator(qd_type)
         QDmat[1:, 1:] = self.genQI.genCoeffs(k=k)
 
         err_msg = 'Lower triangular matrix expected!'
@@ -114,7 +107,8 @@ class Sweeper(object):
     def get_Qdelta_explicit(self, qd_type, k=None):
         coll = self.coll
         QDmat = np.zeros(coll.Qmat.shape, dtype=float)
-        self.genQE = self.getGenerator(qd_type)
+        if not hasattr(self, "genQE") or qd_type not in QDELTA_GENERATORS_ALIASES[type(self.genQE)]:
+            self.genQE: QDeltaGenerator = self.buildGenerator(qd_type)
         QDmat[1:, 1:], QDmat[1:, 0] = self.genQE.genCoeffs(k=k, dTau=True)
 
         err_msg = 'Strictly lower triangular matrix expected!'
@@ -267,5 +261,9 @@ class Sweeper(object):
         k : int
             Index of the sweep (0 for initial sweep, 1 for the first one, ...).
         """
-        if self.genQI._K_DEPENDENT:
-            self.QI = self.get_Qdelta_implicit(qd_type=self.genQI.__class__.__name__, k=k)
+        if self.genQI.isKDependent():
+            qdType = type(self.genQI).__name__
+            self.QI = self.get_Qdelta_implicit(qdType, k=k)
+        if self.genQE.isKDependent():
+            qdType = type(self.genQE).__name__
+            self.QE = self.get_Qdelta_explicit(qdType, k=k)

--- a/pySDC/core/sweeper.py
+++ b/pySDC/core/sweeper.py
@@ -8,7 +8,7 @@ from pySDC.helpers.pysdc_helper import FrozenClass
 
 
 # Organize QDeltaGenerator class in dict[type(QDeltaGenerator),set(str)] to retrieve aliases
-QDELTA_GENERATORS_ALIASES = {v: [] for v in set(QDELTA_GENERATORS.values())}
+QDELTA_GENERATORS_ALIASES = {v: set() for v in set(QDELTA_GENERATORS.values())}
 for k, v in QDELTA_GENERATORS.items():
     QDELTA_GENERATORS_ALIASES[v].add(k)
 
@@ -262,9 +262,9 @@ class Sweeper(object):
         k : int
             Index of the sweep (0 for initial sweep, 1 for the first one, ...).
         """
-        if self.genQI.isKDependent():
+        if hasattr(self, "genQI") and self.genQI.isKDependent():
             qdType = type(self.genQI).__name__
             self.QI = self.get_Qdelta_implicit(qdType, k=k)
-        if self.genQE.isKDependent():
+        if hasattr(self, "genQE") and self.genQE.isKDependent():
             qdType = type(self.genQE).__name__
             self.QE = self.get_Qdelta_explicit(qdType, k=k)

--- a/pySDC/core/sweeper.py
+++ b/pySDC/core/sweeper.py
@@ -3,7 +3,6 @@ import numpy as np
 from qmat.qdelta import QDeltaGenerator, QDELTA_GENERATORS
 
 from pySDC.core.errors import ParameterError
-from pySDC.core.level import Level
 from pySDC.core.collocation import CollBase
 from pySDC.helpers.pysdc_helper import FrozenClass
 
@@ -245,6 +244,8 @@ class Sweeper(object):
         Args:
             L (pySDC.Level.level): current level
         """
+        from pySDC.core.level import Level
+
         assert isinstance(L, Level)
         self.__level = L
 

--- a/pySDC/core/sweeper.py
+++ b/pySDC/core/sweeper.py
@@ -87,6 +87,9 @@ class Sweeper(object):
 
         self.__level = level
         self.parallelizable = False
+        for name in ["genQI", "genQE"]:
+            if hasattr(self, name):
+                delattr(self, name)
 
     def buildGenerator(self, qdType: str) -> QDeltaGenerator:
         return QDELTA_GENERATORS[qdType](qGen=self.coll.generator, tLeft=self.coll.tleft)

--- a/pySDC/implementations/controller_classes/controller_MPI.py
+++ b/pySDC/implementations/controller_classes/controller_MPI.py
@@ -28,7 +28,7 @@ class controller_MPI(Controller):
         super().__init__(controller_params, description, useMPI=True)
 
         # create single step per processor
-        self.S = Step(description)
+        self.S: Step = Step(description)
 
         # pass communicator for future use
         self.comm = comm
@@ -688,8 +688,11 @@ class controller_MPI(Controller):
 
             for hook in self.hooks:
                 hook.pre_sweep(step=self.S, level_number=0)
+
+            self.S.levels[0].sweep.updateVariableCoeffs(k + 1)  # update QDelta coefficients if variable preconditioner
             self.S.levels[0].sweep.update_nodes()
             self.S.levels[0].sweep.compute_residual(stage='IT_FINE')
+
             for hook in self.hooks:
                 hook.post_sweep(step=self.S, level_number=0)
 
@@ -718,6 +721,7 @@ class controller_MPI(Controller):
 
                 for hook in self.hooks:
                     hook.pre_sweep(step=self.S, level_number=l)
+
                 self.S.levels[l].sweep.update_nodes()
                 self.S.levels[l].sweep.compute_residual(stage='IT_DOWN')
                 for hook in self.hooks:

--- a/pySDC/implementations/convergence_controller_classes/adaptive_collocation.py
+++ b/pySDC/implementations/convergence_controller_classes/adaptive_collocation.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from qmat.lagrange import LagrangeApproximation
 from pySDC.core.convergence_controller import ConvergenceController, Status
-from pySDC.core.collocation import CollBase
 
 
 class AdaptiveCollocation(ConvergenceController):

--- a/pySDC/implementations/sweeper_classes/generic_implicit.py
+++ b/pySDC/implementations/sweeper_classes/generic_implicit.py
@@ -65,9 +65,6 @@ class generic_implicit(Sweeper):
         # get number of collocation nodes for easier access
         M = self.coll.num_nodes
 
-        # update the MIN-SR-FLEX preconditioner
-        self.updateVariableCoeffs(L.status.sweep)
-
         # gather all terms which are known already (e.g. from the previous iteration)
         # this corresponds to u0 + QF(u^k) - QdF(u^k) + tau
 

--- a/pySDC/implementations/sweeper_classes/generic_implicit_MPI.py
+++ b/pySDC/implementations/sweeper_classes/generic_implicit_MPI.py
@@ -209,9 +209,6 @@ class generic_implicit_MPI(SweeperMPI, generic_implicit):
         # only if the level has been touched before
         assert L.status.unlocked
 
-        # update the MIN-SR-FLEX preconditioner
-        self.updateVariableCoeffs(L.status.sweep)
-
         # gather all terms which are known already (e.g. from the previous iteration)
         # this corresponds to u0 + QF(u^k) - QdF(u^k) + tau
 

--- a/pySDC/implementations/sweeper_classes/imex_1st_order.py
+++ b/pySDC/implementations/sweeper_classes/imex_1st_order.py
@@ -72,9 +72,6 @@ class imex_1st_order(Sweeper):
         # get number of collocation nodes for easier access
         M = self.coll.num_nodes
 
-        # update the MIN-SR-FLEX preconditioner
-        self.updateVariableCoeffs(L.status.sweep)
-
         # gather all terms which are known already (e.g. from the previous iteration)
         # this corresponds to u0 + QF(u^k) - QIFI(u^k) - QEFE(u^k) + tau
 

--- a/pySDC/implementations/sweeper_classes/imex_1st_order_MPI.py
+++ b/pySDC/implementations/sweeper_classes/imex_1st_order_MPI.py
@@ -55,9 +55,6 @@ class imex_1st_order_MPI(SweeperMPI, imex_1st_order):
         # gather all terms which are known already (e.g. from the previous iteration)
         # this corresponds to u0 + QF(u^k) - QdF(u^k) + tau
 
-        # update the MIN-SR-FLEX preconditioner
-        self.updateVariableCoeffs(L.status.sweep)
-
         # get QF(u^k)
         rhs = self.integrate()
 

--- a/pySDC/tests/test_sweepers/test_preconditioners.py
+++ b/pySDC/tests/test_sweepers/test_preconditioners.py
@@ -112,7 +112,7 @@ def test_FLEX_preconditioner_in_sweepers(imex, num_nodes, MPI=False):
 
     for k in range(1, level_params['nsweeps'] + 1):
         lvl.status.sweep = k
-        sweep.update_nodes()
+        sweep.updateVariableCoeffs(k)
         assert np.allclose(
             sweep.QI, sweep.get_Qdelta_implicit(sweeper_params['QI'], k)
         ), f'Got incorrect FLEX preconditioner in sweep {k}'
@@ -216,4 +216,4 @@ if __name__ == '__main__':
     test_LU('LEGENDRE', 'RADAU-RIGHT', 4)
     test_LU('EQUID', 'LOBATTO', 5)
 
-    test_FLEX_preconditioner_in_sweepers(True)
+    test_FLEX_preconditioner_in_sweepers(True, 4)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     'sympy>=1.0',
     'numba>=0.35',
     'dill>=0.2.6',
-    'qmat>=0.1.8',
+    'qmat>=0.1.19',
     ]
 
 [project.urls]


### PR DESCRIPTION
This PR makes use of the new update in `qmat`, that allows to generate any QDelta coefficients using always the same `qGen` argument, without any required code modification for new QDelta types. 

It also re-activates the caching of the `genQE` and `genQI` attributes, which do not need to be re-built again when variable coefficients are updated between sweeps : it uses the internal cache of `qmat` that can store different QDelta matrices if they are different. Furthermore, it allows variable coefficients for explicit sweeps.

Finally, coefficient update are now done in the controller classes, more precisely in the `it_fine` method, rather than in the `update_node` of the sweeper class. It means that there is no need to modify the `update_node` of each sweeper implementation to allow the use of FLEX preconditionners (for instance). In case some implementation are still calling the `updateVariableCoeffs` method, it simply becomes a no-op.

In addition, a few cleaning / refactoring / type hints that appears to be necessary during the changes mentionned above.

