### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         env: ['base', 'fenics', 'mpi4py', 'petsc', 'pytorch']
-        python: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python: ['3.10', '3.11', '3.12', '3.13']
     defaults:
       run:
         shell: bash -l {0}

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ implemented.
 -   Continuous integration via [GitHub
     Actions](https://github.com/Parallel-in-Time/pySDC/actions) and
     [Gitlab CI](https://gitlab.hzdr.de/r.speck/pysdc/-/pipelines) (through the [GitHub2Gitlab Action](https://github.com/jakob-fritz/github2lab_action))
--   Fully compatible with Python 3.10 - 3.14, runs at least on Ubuntu
+-   Fully compatible with Python 3.10 - 3.13, runs at least on Ubuntu
 
 ## Getting started
 


### PR DESCRIPTION
Python 3.9 is no longer officially supported as of this month, see [here](https://www.python.org/downloads/). I suggest we too drop the support / testing.
Note that `zip` does not support keyword argument `strict` in Python 3.9, yet ruff now makes us always use it these days, see #589.

I tried adding support for Python 3.14, which is now officially supported, but there are some conflicts with other dependencies of pySDC. So we have to wait until we support it.