### PR TITLE
Vectorized setup of left preconditioner in spectral discretizations

### DIFF
--- a/pySDC/implementations/problem_classes/generic_spectral.py
+++ b/pySDC/implementations/problem_classes/generic_spectral.py
@@ -232,16 +232,12 @@ class GenericSpectralLinear(Problem):
             self.logger.debug(f'Setting up left preconditioner with {N} local degrees of freedom')
 
             # reverse Kronecker product
-            if self.spectral.useGPU:
-                import scipy.sparse as sp
-            else:
-                sp = self.spectral.sparse_lib
+            nc = self.ncomponents
 
-            R = sp.lil_matrix((self.ncomponents * N,) * 2, dtype=int)
+            rows = self.xp.arange(N * nc)
+            cols = (rows % nc) * N + rows // nc
 
-            for j in range(self.ncomponents):
-                for i in range(N):
-                    R[i * self.ncomponents + j, j * N + i] = 1
+            R = self.spectral.sparse_lib.csr_matrix((self.xp.ones(N * nc), (rows, cols)), shape=(N * nc, N * nc))
 
             self.Pl = self.spectral.sparse_lib.csc_matrix(R, dtype=complex)
 

--- a/pySDC/implementations/problem_classes/generic_spectral.py
+++ b/pySDC/implementations/problem_classes/generic_spectral.py
@@ -237,9 +237,9 @@ class GenericSpectralLinear(Problem):
             rows = self.xp.arange(N * nc)
             cols = (rows % nc) * N + rows // nc
 
-            R = self.spectral.sparse_lib.csr_matrix((self.xp.ones(N * nc), (rows, cols)), shape=(N * nc, N * nc))
-
-            self.Pl = self.spectral.sparse_lib.csc_matrix(R, dtype=complex)
+            self.Pl = self.spectral.sparse_lib.csc_matrix(
+                (self.xp.ones(N * nc, dtype=complex), (rows, cols)), shape=(N * nc, N * nc)
+            )
 
             self.logger.debug('Finished setup of left preconditioner')
         else:

--- a/pySDC/projects/RayleighBenard/RBC3D_configs.py
+++ b/pySDC/projects/RayleighBenard/RBC3D_configs.py
@@ -240,7 +240,15 @@ class RBC3Dverification(RayleighBenard3DRegular):
         ic_ny = desc['problem_params']['ny']
         ic_nz = desc['problem_params']['nz']
 
-        _P = type(P)(nx=ic_nx, ny=ic_ny, nz=ic_nz, comm=P.comm, useGPU=P.useGPU)
+        _P = type(P)(
+            nx=ic_nx,
+            ny=ic_ny,
+            nz=ic_nz,
+            comm=P.comm,
+            useGPU=P.useGPU,
+            Dirichlet_recombination=False,
+            left_preconditioner=False,
+        )
         _P.setUpFieldsIO()
         filename = ic_config.get_file_name()
         ic_file = FieldsIO.fromFile(filename)


### PR DESCRIPTION
The non-vectorized setup took quite long for lagre problems. This vectorized implementation, thanks to the AI, is much faster.

Also, when instantiating an auxiliary problem to interpolate initial conditions in the RBC project we can actually skip the preconditioner setup entirely. That is the change in the `RBC3D_configs.py` file.