### PR TITLE
Fixes for running spectral discretizations on GPU

### DIFF
--- a/pySDC/helpers/spectral_helper.py
+++ b/pySDC/helpers/spectral_helper.py
@@ -235,12 +235,13 @@ class SpectralHelper1D:
         import cupy as cp
         import cupyx.scipy.sparse as sparse_lib
         import cupyx.scipy.sparse.linalg as linalg
+        import cupyx.scipy.fft as fft_lib
         from pySDC.implementations.datatype_classes.cupy_mesh import cupy_mesh
 
         cls.xp = cp
         cls.sparse_lib = sparse_lib
         cls.linalg = linalg
-        cls.fft_lib = vkFFT
+        cls.fft_lib = fft_lib
 
     @classmethod
     def setup_CPU(cls, useFFTW=False):

--- a/pySDC/implementations/problem_classes/generic_spectral.py
+++ b/pySDC/implementations/problem_classes/generic_spectral.py
@@ -429,6 +429,9 @@ class GenericSpectralLinear(Problem):
         self.setUpFieldsIO()
 
         coords = [me.get_1dgrid() for me in self.spectral.axes]
+        if self.spectral.useGPU:
+            coords = [me.get() for me in coords]
+
         assert np.allclose([len(me) for me in coords], self.spectral.global_shape[1:])
 
         fOut = Rectilinear(np.float64, fileName=fileName)
@@ -438,9 +441,14 @@ class GenericSpectralLinear(Problem):
 
     def processSolutionForOutput(self, u):
         if self.spectral_space:
-            return np.array(self.itransform(u).real)
+            u = self.itransform(u).real
         else:
-            return np.array(u.real)
+            u = u.real
+
+        if self.spectral.useGPU:
+            u = u.get()
+
+        return np.array(u)
 
 
 def compute_residual_DAE(self, stage=''):

--- a/pySDC/implementations/problem_classes/generic_spectral.py
+++ b/pySDC/implementations/problem_classes/generic_spectral.py
@@ -448,7 +448,7 @@ class GenericSpectralLinear(Problem):
         if self.spectral.useGPU:
             u = u.get()
 
-        return np.array(u)
+        return u.view(np.ndarray)
 
 
 def compute_residual_DAE(self, stage=''):

--- a/pySDC/projects/RayleighBenard/RBC3D_configs.py
+++ b/pySDC/projects/RayleighBenard/RBC3D_configs.py
@@ -110,6 +110,9 @@ class RayleighBenard3DRegular(Config):
             t0, solution = outfile.readField(restart_idx)
             solution = solution[: P.spectral.ncomponents, ...]
 
+            if P.useGPU:
+                solution = P.xp.array(solution)
+
             u0 = P.u_init
 
             if P.spectral_space:
@@ -235,6 +238,7 @@ class RBC3Dverification(RayleighBenard3DRegular):
         ic_config = self.ic_config['config'](
             args={**self.args, 'res': self.ic_config['res'], 'dt': self.ic_config['dt']}
         )
+        ic_config.base_path = self.base_path
         desc = ic_config.get_description(res=self.ic_config['res'], dt=self.ic_config['dt'])
         ic_nx = desc['problem_params']['nx']
         ic_ny = desc['problem_params']['ny']


### PR DESCRIPTION
Some issues came up when writing data to disk on GPUs. Previously, I had only run benchmarks without any writing of data. This PR addresses these issues.
Also, the vkfft backend is not working anymore for some reason. I simply reverted to cuFFT for the time being.