### PR TITLE
Fix for non-contiguous arrays

### DIFF
--- a/pySDC/implementations/problem_classes/generic_spectral.py
+++ b/pySDC/implementations/problem_classes/generic_spectral.py
@@ -444,7 +444,7 @@ class GenericSpectralLinear(Problem):
         if self.spectral.useGPU:
             u = u.get()
 
-        return u.view(np.ndarray)
+        return np.ascontiguousarray(u.view(np.ndarray))
 
 
 def compute_residual_DAE(self, stage=''):


### PR DESCRIPTION
Turns out skipping the copy in #652 can lead to non-contiguous arrays that need to be cast to contiguous before writing. If the array is already contiguous, this is zero-copy.