### PR TITLE
Bump GitHub Actions to Node 24-compatible major versions

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -30,9 +30,9 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v7
       - name: Install Conda environment with Micromamba
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v3
         with:
           environment-file: ${{ env.YML }}
           create-args: >-
@@ -57,9 +57,9 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install Conda environment with Micromamba
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v3
         with:
           environment-file: "etc/environment-${{ matrix.env }}.yml"
           create-args: >-
@@ -81,7 +81,7 @@ jobs:
           coverage combine
           mv .coverage coverage_${{ matrix.env }}.dat
       - name: Uploading artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: matrix.python == '3.13'
         with:
           name: test-artifacts-cpu-${{ matrix.env }}
@@ -118,9 +118,9 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install Conda environment with Micromamba
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v3
         with:
           environment-file: "pySDC/projects/${{ matrix.env }}/environment.yml"
       - name: Install additional packages as needed
@@ -137,7 +137,7 @@ jobs:
           coverage combine
           mv .coverage coverage_${{ matrix.env }}.dat
       - name: Uploading artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-artifacts-project-${{ matrix.env }}
           path: |
@@ -155,7 +155,7 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install pySDC and pytest
         run: |
           source /pySDC/pySDC/projects/compression/Docker/install_pySDC.sh
@@ -174,7 +174,7 @@ jobs:
           coverage combine
           mv .coverage coverage_libpressio.dat
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-artifacts-libpressio
           path: |
@@ -198,11 +198,11 @@ jobs:
         # (https://github.com/actions/runner/issues/863)
         run: echo "HOME=/home/firedrake" >> "$GITHUB_ENV"
       - name: Checkout pySDC
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with: 
           path: ./pySDC
       - name: Checkout gusto
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: firedrakeproject/gusto
           path: ./gusto_repo
@@ -239,7 +239,7 @@ jobs:
           coverage combine
           mv .coverage ../coverage_firedrake.dat
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-artifacts-firedrake
           path: |
@@ -253,9 +253,9 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install Conda environment with Micromamba
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v3
         with:
           environment-file: "pySDC/projects/Monodomain/etc/environment-monodomain.yml"
           create-args: >-
@@ -280,7 +280,7 @@ jobs:
           coverage combine
           mv .coverage coverage_monodomain.dat
       - name: Uploading artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-artifacts-monodomain
           path: |
@@ -299,13 +299,13 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install Conda environment with Micromamba
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v3
         with:
           environment-file: "etc/environment-postprocess.yml"
       - name: Download all coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: .
           pattern: test-artifacts-*

--- a/.github/workflows/postprocess.yml
+++ b/.github/workflows/postprocess.yml
@@ -18,13 +18,13 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Install Conda environment with Micromamba
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v3
         with:
           environment-file: "etc/environment-postprocess.yml"
       - name: Downloading artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: .
           merge-multiple: true
@@ -79,7 +79,7 @@ jobs:
           mkdir -p docs/build/html/coverage
           mv htmlcov/* docs/build/html/coverage/.
       - name: Store docs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docs
           path: docs/build/html


### PR DESCRIPTION
## Summary

Every CI run prints "Node.js 20 is deprecated" warnings for actions still declaring `runs.using: node20` in their `action.yml`, which GitHub now force-runs on Node 24 anyway. Same issue previously seen and fixed in the RSE_course_JuRSE project.

(Supersedes #660, which was accidentally built on the already-merged #659 branch and dragged its full commit history along even though the file diff was identical. This PR is the same change on a clean branch off current `master`.)

Verified each action's actual `runs.using` value at both the currently-pinned and candidate new major version before bumping, not just assumed from version numbers:

- `actions/checkout`: `v1` (lint job only — a legacy pre-Node "plugin" action, not itself the source of the node20 warning, but badly outdated) and `v4` (`node20`) → `v7` (`node24`)
- `actions/upload-artifact`: `v4` (`node20`) → `v7` (`node24`)
- `actions/download-artifact`: `v4` (`node20`) → `v8` (`node24`)
- `mamba-org/setup-micromamba`: `v1` (`node20`) → `v3` (`node24`) — confirmed the two inputs actually used here (`environment-file`, `create-args`) are unchanged in `v3`

Left alone (confirmed not implicated in the warning at all):
- `codecov/codecov-action@v5` — composite action, no Node runtime
- `py-cov-action/python-coverage-comment-action@v3` — Docker action, no Node runtime
- `JamesIves/github-pages-deploy-action@v4` — already `node24`

## Test plan

- [x] Already validated on #660: CI run showed 43/43 jobs passing, zero Node.js 20 deprecation warnings, no breakage from the version jumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)