### PR TITLE
Fix silently ignored average_jacobians parameter in step_9 tutorial

### DIFF
--- a/pySDC/tutorial/step_9/C_paradiag_in_pySDC.py
+++ b/pySDC/tutorial/step_9/C_paradiag_in_pySDC.py
@@ -91,9 +91,9 @@ def get_controller_params(problem='advection', mode='ParaDiag'):
         # For nonlinear problems, we need to communicate the average solution, which allows to compute the average
         # Jacobian locally. For linear problems, we do not want the extra communication.
         if problem == 'advection':
-            controller_params['average_jacobians'] = False
+            controller_params['average_jacobian'] = False
         elif problem == 'vdp':
-            controller_params['average_jacobians'] = True
+            controller_params['average_jacobian'] = True
     else:
         # We do Block-Jacobi multi-step SDC here. It's a bit silly but it's better for comparing "speedup"
         controller_params['mssdc_jac'] = True


### PR DESCRIPTION
## What

Renames `controller_params['average_jacobians']` → `controller_params['average_jacobian']` (singular) in `pySDC/tutorial/step_9/C_paradiag_in_pySDC.py`. Two lines.

## Why

The tutorial set the **plural** name, but the ParaDiag controller reads the **singular** one:

- `pySDC/core/controller.py:412` — `controller_params['average_jacobian'] = controller_params.get('average_jacobian', True)`
- `pySDC/implementations/controller_classes/controller_ParaDiag_nonMPI.py:170` — `if self.params.average_jacobian:`

`_Pars` is a `FrozenClass` that freezes *after* copying every incoming key, so the plural key was happily stored on the params object and then never read. `average_jacobian` silently fell back to its default of `True`.

The visible consequence: the advection case intends to **disable** Jacobian averaging — the comment says *"For linear problems, we do not want the extra communication"* — but averaging stayed on, so the tutorial did the extra communication it was explicitly trying to avoid. The vdp case wanted `True` and got `True` by accident, so it was unaffected.

## Why singular is the right direction

Grepped the whole repo (excluding `__pycache__`, including `projects/`, `playgrounds/` and `tests/`). The plural spelling occurs on exactly those two tutorial lines and nowhere else. The singular is what the controller defaults, what the controller reads, and what `pySDC/tests/test_controllers/test_controller_ParaDiag_nonMPI.py` sets. Nothing depends on the plural, so correcting the tutorial is the complete fix.

## Verification

- `get_controller_params` now yields `average_jacobian=False` for `'advection'` and `True` for `'vdp'` (before: effectively `True` for both).
- `pytest -q -m base pySDC/tests/test_tutorials` → **24 passed, 14 deselected**, including both `test_step_9_C` parametrizations, which assert that the ParaDiag, PFASST and serial solutions agree. So advection genuinely runs without Jacobian averaging now and still converges.
- `ruff check pySDC/` clean.

## Note for reviewers

This class of bug is possible because `_Pars` accepts arbitrary `controller_params` keys by design — that is how `alpha`, `average_jacobian` and the other controller-specific extras get through, so it is not an oversight. Making the controller *reject* unknown params would mean enumerating every valid key for all three controllers plus everything projects and playgrounds pass, and would break downstream users; `FrozenClass.add_attr` is the existing hook for registering them. Deliberately **not** done here — too large to bundle with a two-line tutorial fix. A cheaper warn-only variant (log unknown keys after the setattr loop, no behaviour change) would catch typos like this one and could be added incrementally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)