### PR TITLE
Dispatch on which steps a controller owns, not on its class name

### DIFF
--- a/pySDC/core/controller.py
+++ b/pySDC/core/controller.py
@@ -277,6 +277,20 @@ class Controller(object):
         """
         return self.__hooks
 
+    @property
+    def steps(self) -> List[Any]:
+        """
+        Getter for the steps this controller owns.
+
+        Controllers that hold the whole block expose them as `MS`; MPI controllers hold a single step
+        as `S`. Dispatch on which of those exists rather than on the class name, so that subclasses
+        keep working.
+
+        Returns:
+            list: the steps owned by this controller
+        """
+        return self.MS if hasattr(self, 'MS') else [self.S]
+
     def setup_convergence_controllers(self, description: Dict[str, Any]) -> None:
         '''
         Setup variables needed for convergence controllers, notably a list containing all of them and a list containing

--- a/pySDC/core/convergence_controller.py
+++ b/pySDC/core/convergence_controller.py
@@ -453,10 +453,7 @@ class ConvergenceController(object):
         return data
 
     def add_status_variable_to_step(self, key, value=None):
-        if type(self.controller).__name__ == 'controller_MPI':
-            steps = [self.controller.S]
-        else:
-            steps = self.controller.MS
+        steps = self.controller.steps
 
         steps[0].status.add_attr(key)
 
@@ -464,19 +461,13 @@ class ConvergenceController(object):
             self.set_step_status_variable(key, value)
 
     def set_step_status_variable(self, key, value):
-        if type(self.controller).__name__ == 'controller_MPI':
-            steps = [self.controller.S]
-        else:
-            steps = self.controller.MS
+        steps = self.controller.steps
 
         for S in steps:
             S.status.__dict__[key] = value
 
     def add_status_variable_to_level(self, key, value=None):
-        if type(self.controller).__name__ == 'controller_MPI':
-            steps = [self.controller.S]
-        else:
-            steps = self.controller.MS
+        steps = self.controller.steps
 
         steps[0].levels[0].status.add_attr(key)
 
@@ -484,10 +475,7 @@ class ConvergenceController(object):
             self.set_level_status_variable(key, value)
 
     def set_level_status_variable(self, key, value):
-        if type(self.controller).__name__ == 'controller_MPI':
-            steps = [self.controller.S]
-        else:
-            steps = self.controller.MS
+        steps = self.controller.steps
 
         for S in steps:
             for L in S.levels:


### PR DESCRIPTION
ConvergenceController resolved the controller's steps with

    if type(self.controller).__name__ == 'controller_MPI':
        steps = [self.controller.S]
    else:
        steps = self.controller.MS

at four sites. Any SUBCLASS of controller_MPI has a different __name__, so it fell into the else branch and died with AttributeError on the missing MS.

That is why nothing subclasses controller_MPI. The one variant in the tree, projects/Performance/controller_MPI_scorep.py, is a whole copy declared as `class controller_MPI(Controller)` -- it only works because the name matches. The dispatch quietly rewarded copying over extending.

Replaced with a `steps` property on Controller that dispatches on which attribute the controller actually has. Behaviour is unchanged for every existing controller, including the scorep copy, and subclassing now works.

Verified by rebuilding controller_MPI from extracted coupling primitives in a subclass: it fails on master, and on this branch it runs and reproduces stock PFASST bit-for-bit (uend sha256 bc1548f75354022f).