### PR TITLE
Ignore parallel coverage shards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ pip-delete-this-directory.txt
 htmlcov/
 .tox/
 .coverage
+.coverage.*
 .cache
 nosetests.xml
 coverage.xml


### PR DESCRIPTION
16 test files set `COVERAGE_PROCESS_START` before shelling out to `mpirun`, and coverage writes one `.coverage.<host>.<pid>.<rand>` file per process. `.gitignore` covered `.coverage` but not those shards, so any local MPI test run leaves a dozen or more untracked files behind.

One line:

```
.coverage
+.coverage.*
.cache
```

Verified by creating a real shard filename and confirming `git status` no longer reports it.

This is not hypothetical — while preparing a separate fix in this series I ran the MPI tests and `git add -A` swept 139 of these shards (~15 MB of binaries) into a commit. Caught on review, but the trap is easy to fall into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)