### PR TITLE
Reject multiple coarse sweeps before communicating, not mid-sweep

### DIFF
--- a/pySDC/implementations/controller_classes/controller_MPI.py
+++ b/pySDC/implementations/controller_classes/controller_MPI.py
@@ -60,6 +60,12 @@ class controller_MPI(Controller):
                 if not L.sweep.coll.right_is_node or L.sweep.params.do_coll_update:
                     raise ControllerError("For PFASST to work, we assume uend^k = u_M^k")
 
+        # `it_coarse` sweeps the coarsest level exactly once. Single-level Gauss-like MSSDC routes
+        # through it too. Check here rather than asserting mid-sweep: by then every rank has posted
+        # receives, so a failure hangs the job instead of raising.
+        if self.S.levels[-1].params.nsweeps > 1 and (num_levels > 1 or not self.params.mssdc_jac):
+            raise ControllerError('this controller cannot do multiple sweeps on coarsest level')
+
         if num_levels == 1 and self.params.predict_type is not None:
             self.logger.warning(
                 'you have specified a predictor type but only a single level.. predictor will be ignored'
@@ -746,10 +752,6 @@ class controller_MPI(Controller):
         # do the sweep
         for hook in self.hooks:
             hook.pre_sweep(step=self.S, level_number=len(self.S.levels) - 1)
-        assert self.S.levels[-1].params.nsweeps == 1, (
-            'ERROR: this controller can only work with one sweep on the coarse level, got %s'
-            % self.S.levels[-1].params.nsweeps
-        )
         self.S.levels[-1].sweep.update_nodes()
         self.S.levels[-1].sweep.compute_residual(stage='IT_COARSE')
         for hook in self.hooks:

--- a/pySDC/implementations/controller_classes/controller_nonMPI.py
+++ b/pySDC/implementations/controller_classes/controller_nonMPI.py
@@ -70,7 +70,9 @@ class controller_nonMPI(Controller):
             if all(S.levels[nl].params.nsweeps == self.MS[0].levels[nl].params.nsweeps for S in self.MS):
                 self.nsweeps.append(self.MS[0].levels[nl].params.nsweeps)
 
-        if self.nlevels > 1 and self.nsweeps[-1] > 1:
+        # `it_coarse` sweeps the coarsest level exactly once. Single-level Gauss-like MSSDC routes
+        # through it too, so reject multiple sweeps there as well instead of silently ignoring them.
+        if self.nsweeps[-1] > 1 and (self.nlevels > 1 or not self.params.mssdc_jac):
             raise ControllerError('this controller cannot do multiple sweeps on coarsest level')
 
         if self.nlevels == 1 and self.params.predict_type is not None:


### PR DESCRIPTION
## The bug

Single-level Gauss-like MSSDC (`mssdc_jac=False`) routes through `it_coarse`, which sweeps the coarsest level exactly once. The two controllers handled `nsweeps > 1` there differently, and both were wrong:

- **`controller_nonMPI`** gated its `__init__` check on `nlevels > 1`, so a single level silently ignored the extra sweeps and returned an answer.
- **`controller_MPI`** asserted inside `it_coarse`, *after* `recv_full`. By then every rank has posted receives, so the assertion **hung the job** instead of raising it.

Reproduced repeatedly: with `nsweeps=2, mssdc_jac=False` on 4 ranks, `controller_nonMPI` completes while `controller_MPI` has to be killed. On an HPC allocation a hang is considerably worse than an error.

## The fix

Both controllers now raise the same `ControllerError` from `__init__`, before any communication, and the runtime assert in `it_coarse` is gone.

```python
if nsweeps[-1] > 1 and (nlevels > 1 or not mssdc_jac):
    raise ControllerError('this controller cannot do multiple sweeps on coarsest level')
```

The condition is deliberately **not** an unconditional ban on `nsweeps > 1` at a single level: Jacobi-like MSSDC (the default) routes through `it_fine`, which honours `nsweeps`, and that case keeps working.

## Verification

| case | before | after |
|---|---|---|
| `nsweeps=2, jac=False` | nonMPI completes silently / **MPI hangs** | both raise identically, immediately |
| `nsweeps=2, jac=True` | `1791b9c4fa185d91` | `1791b9c4fa185d91` — unchanged, both agree |
| `nsweeps=1, jac=False` | `c3af9cb11d2330f9` | `c3af9cb11d2330f9` — unchanged, both agree |

Hashes are SHA-256 of `uend`; both valid-config values are byte-identical to their pre-fix values, so nothing legitimate moved.

Base suite 189 passed, `ruff` clean. The full `mpi4py` suite was not run locally (it exceeds a sane local time budget); the MPI-marked tests that construct `controller_MPI` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)