### PR TITLE
Restrict k-dependent QDelta coefficients to SDC

### DIFF
--- a/pySDC/core/controller.py
+++ b/pySDC/core/controller.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Type, Union
 import numpy as np
 
 from pySDC.core.base_transfer import BaseTransfer
+from pySDC.core.errors import ControllerError
 from pySDC.helpers.pysdc_helper import FrozenClass
 from pySDC.core.check_convergence import CheckConvergence
 from pySDC.core.default_hook import DefaultHooks
@@ -290,6 +291,42 @@ class Controller(object):
             list: the steps owned by this controller
         """
         return self.MS if hasattr(self, 'MS') else [self.S]
+
+    def check_variable_coefficients(self, num_procs: int) -> None:
+        """
+        Reject k-dependent QDelta coefficients outside plain SDC.
+
+        MIN-SR-FLEX and the Jumper variants vary QDelta with the sweep index, and the nilpotency
+        argument behind them is derived for SDC, where that index *is* the SDC iteration count.
+        Anything needing more iterations (PFASST) or fewer (MLSDC) breaks that identity and would
+        need its own analysis first.
+
+        They are also only refreshed by `Sweeper.updateVariableCoeffs`, which runs on the finest
+        level of the Jacobi sweep alone, so on a coarse level or on the Gauss-Seidel path they
+        silently degrade to a fixed preconditioner. Failing loudly beats either of those.
+
+        Note this gates parallelism across *steps* and the number of *levels*. Parallelism across
+        collocation nodes (`generic_implicit_MPI` and friends) is still SDC and stays allowed.
+
+        Args:
+            num_procs (int): number of parallel time steps
+
+        Raises:
+            ControllerError: if a k-dependent QDelta is combined with multiple levels or steps
+        """
+        S = self.steps[0]
+        if len(S.levels) == 1 and num_procs == 1:
+            return
+
+        for level in S.levels:
+            for name in ['genQI', 'genQE']:
+                generator = getattr(level.sweep, name, None)
+                if generator is not None and generator.isKDependent():
+                    raise ControllerError(
+                        f'{type(generator).__name__} varies QDelta with the sweep index and is only '
+                        f'verified for SDC, but you have {len(S.levels)} level(s) and {num_procs} '
+                        f'step(s). Use a preconditioner with fixed coefficients, e.g. MIN-SR-S or LU.'
+                    )
 
     def setup_convergence_controllers(self, description: Dict[str, Any]) -> None:
         '''

--- a/pySDC/implementations/controller_classes/controller_MPI.py
+++ b/pySDC/implementations/controller_classes/controller_MPI.py
@@ -66,6 +66,8 @@ class controller_MPI(Controller):
         if self.S.levels[-1].params.nsweeps > 1 and (num_levels > 1 or not self.params.mssdc_jac):
             raise ControllerError('this controller cannot do multiple sweeps on coarsest level')
 
+        self.check_variable_coefficients(num_procs)
+
         if num_levels == 1 and self.params.predict_type is not None:
             self.logger.warning(
                 'you have specified a predictor type but only a single level.. predictor will be ignored'

--- a/pySDC/implementations/controller_classes/controller_nonMPI.py
+++ b/pySDC/implementations/controller_classes/controller_nonMPI.py
@@ -75,6 +75,8 @@ class controller_nonMPI(Controller):
         if self.nsweeps[-1] > 1 and (self.nlevels > 1 or not self.params.mssdc_jac):
             raise ControllerError('this controller cannot do multiple sweeps on coarsest level')
 
+        self.check_variable_coefficients(num_procs)
+
         if self.nlevels == 1 and self.params.predict_type is not None:
             self.logger.warning(
                 'you have specified a predictor type but only a single level.. predictor will be ignored'


### PR DESCRIPTION
## Why

`MIN-SR-FLEX` and the two Jumper variants vary QDelta with the sweep index. The nilpotency argument behind them is derived for **SDC**, where that index *is* the SDC iteration count. Anything needing more iterations (PFASST) or fewer (MLSDC) breaks that identity and would need its own analysis first.

There is also a second, more concrete problem. Those coefficients are only ever refreshed by `Sweeper.updateVariableCoeffs`, which is called from `it_fine` alone — one call site per controller, both on level 0:

- `controller_nonMPI.py`, in `it_fine`
- `controller_MPI.py`, in `it_fine`

So on a coarse level, or on the Gauss-Seidel path that single-level `mssdc_jac=False` takes, the coefficients **silently never update** and the "variable" preconditioner quietly degrades to a fixed one. Users asking for `MIN-SR-FLEX` with MLSDC or PFASST today get neither an error nor the preconditioner they requested.

Failing loudly beats running something unverified, and beats running something silently different from what was asked.

## What changed

`Controller.check_variable_coefficients` raises `ControllerError` unless there is exactly one level and one step. Both controllers call it from `__init__`, alongside the existing single-level checks.

**Parallelism across collocation nodes is unaffected.** `generic_implicit_MPI` and friends are still SDC, and stay allowed — this gates *steps* and *levels*, not MPI.

## Verification

| QI | levels | steps | result |
|---|---|---|---|
| `MIN-SR-FLEX` | 1 | 1 | accept — the verified case |
| `MIN-SR-FLEX` | 2 | 1 | reject (MLSDC) |
| `MIN-SR-FLEX` | 1 | 4 | reject (MSSDC) |
| `MIN-SR-FLEX` | 2 | 4 | reject (PFASST) |
| `FLEX-JUMPER` | 1 / 2 | 1 / 4 | accept / reject |
| `JUMPER` | 2 | 4 | reject |
| `LU`, `MIN-SR-S`, `IE` | 2 | 4 | accept — fixed coefficients, untouched |

`parallelSDC_reloaded` is the main user of `MIN-SR-FLEX` and is unaffected: it runs `controller_nonMPI(num_procs=1)` on a single level throughout, including `fig06_allenCahnMPI`, which parallelises over nodes via `generic_implicit_MPI`. 22 of its tests pass; the 3 failures (`nilpotency`, `fig05`, `fig06`) are `numpy has no attribute 'float128'` on Apple Silicon and were confirmed to fail identically on stock `master` with this change stashed.

975 tests pass across core, controllers, convergence controllers, hooks, tutorials and sweepers. `ruff` clean.

## For the reviewer

- This is deliberately a **hard error, not a warning**. The combinations it rejects do not currently do what the user asked, so silently continuing is the worse option. If you would rather warn and proceed for a release cycle, that is a one-line change.
- Ungating later is possible but the cost is theory, not code: it needs a definition of what `k` means per setting, per-level index state, and separate nilpotency analyses for MSSDC, MLSDC and PFASST. A cheap way to find out whether any of that is worth doing is to combine `parallelSDC_reloaded/nilpotency.py` with `matrixPFASST`'s composite iteration matrix and simply measure whether the product over M sweeps is nilpotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)