### PR TITLE
Fix inverted all_to_done guard and drop a redundant end-point computation

### DIFF
--- a/pySDC/core/controller.py
+++ b/pySDC/core/controller.py
@@ -454,7 +454,7 @@ class ParaDiagController(Controller):
                 f'Warning: Your sweeper class {description["sweeper_class"]} is not derived from {QDiagonalization}. You probably want to use another sweeper class.'
             )
 
-        if controller_params.get('all_to_done', False):
+        if not controller_params.get('all_to_done', True):
             raise NotImplementedError('ParaDiag only implemented with option `all_to_done=True`')
         if 'alpha' not in controller_params.keys():
             from pySDC.core.errors import ParameterError

--- a/pySDC/implementations/controller_classes/controller_MPI.py
+++ b/pySDC/implementations/controller_classes/controller_MPI.py
@@ -249,6 +249,10 @@ class controller_MPI(Controller):
             blocking: flag to indicate that we need blocking communication
             level: the level number
             add_to_stats: a flag to end recording data in the hooks (defaults to False)
+
+        Note:
+            Computing the end point is this function's job, not the caller's. Callers must not do it
+            themselves.
         """
         for hook in self.hooks:
             hook.pre_comm(step=self.S, level_number=level)
@@ -758,9 +762,8 @@ class controller_MPI(Controller):
         self.S.levels[-1].sweep.compute_residual(stage='IT_COARSE')
         for hook in self.hooks:
             hook.post_sweep(step=self.S, level_number=len(self.S.levels) - 1)
-        self.S.levels[-1].sweep.compute_end_point()
 
-        # send to next step
+        # send to next step (`send_full` computes the end point itself)
         self.send_full(comm=comm, blocking=True, level=len(self.S.levels) - 1, add_to_stats=True)
         if self.S.status.force_done:
             return None


### PR DESCRIPTION
Two small, independent controller fixes found while auditing the ParaDiag/MPI paths.

## 1. The `all_to_done` guard was inverted

`ParaDiagController.__init__`:

```python
if controller_params.get('all_to_done', False):
    raise NotImplementedError('ParaDiag only implemented with option `all_to_done=True`')
...
controller_params['all_to_done'] = True     # forced two lines later anyway
```

The second argument to `.get()` is the **default used when the key is absent**, not a value being compared against — so the condition reduces to "is `all_to_done` truthy". Measured against the real controller:

| you pass | before | after |
|---|---|---|
| `all_to_done=True` | **`NotImplementedError`** | accepted |
| `all_to_done=False` | accepted, then silently overridden to `True` | **`NotImplementedError`** |
| omitted | accepted | accepted |

So the one input that failed was the correct one, and the error message named the very value being rejected. The guard now rejects `False`, as its message says.

## 2. A redundant end-point computation in `it_coarse`

`controller_MPI.it_coarse` called `sweep.compute_end_point()` immediately before `send_full`, which computes the end point itself. Nothing modifies `u` in between, so it was the same value computed twice — a wasted field-sized linear combination over the collocation nodes on every coarse sweep, on every step. Cheap per call, but it is per coarse sweep on 3D fields.

Removed, and the rule written into `send_full`'s docstring so it does not creep back:

> Computing the end point is this function's job, not the caller's. Callers must not do it themselves.

Checked the one thing that could have made this observable: **no hook overrides `pre_comm`** (only the base no-op exists), so nothing reads `uend` between the caller's call and `send_full`'s own.

## Verification

`uend` SHA-256 under MPI, unchanged from before the removal in all four cases — including the two that actually exercise `it_coarse`:

| case | `uend` SHA-256 |
|---|---|
| PFASST (2 lvl, 4 proc) | `bc1548f75354022f` |
| MLSDC (2 lvl, 1 proc) | `47ac08a6ffa86d29` |
| MSSDC-Jacobi (1 lvl, 4 proc) | `50f07b627bcbab7e` |
| MSSDC-Gauss-Seidel (1 lvl, 4 proc) | `9c472f3153daeae8` |

975 base tests pass; 96 ParaDiag tests (controller, sweepers, tutorial step 9) pass; 32 MPI-marked convergence-controller and hook tests pass. `ruff` clean.

The one MPI error, `test_hooks/test_log_to_file.py::test_loggingMPI`, is a pre-existing setup failure — confirmed to fail identically on stock `master` with this change stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)