### PR TITLE
Let plain SDC do multiple sweeps again

### DIFF
--- a/pySDC/implementations/controller_classes/controller_MPI.py
+++ b/pySDC/implementations/controller_classes/controller_MPI.py
@@ -62,8 +62,10 @@ class controller_MPI(Controller):
 
         # `it_coarse` sweeps the coarsest level exactly once. Single-level Gauss-like MSSDC routes
         # through it too. Check here rather than asserting mid-sweep: by then every rank has posted
-        # receives, so a failure hangs the job instead of raising.
-        if self.S.levels[-1].params.nsweeps > 1 and (num_levels > 1 or not self.params.mssdc_jac):
+        # receives, so a failure hangs the job instead of raising. `mssdc_jac` only decides the
+        # routing when there is more than one step: a single step is plain SDC and always goes
+        # through `it_fine`, which honours nsweeps.
+        if self.S.levels[-1].params.nsweeps > 1 and (num_levels > 1 or (num_procs > 1 and not self.params.mssdc_jac)):
             raise ControllerError('this controller cannot do multiple sweeps on coarsest level')
 
         self.check_variable_coefficients(num_procs)

--- a/pySDC/implementations/controller_classes/controller_nonMPI.py
+++ b/pySDC/implementations/controller_classes/controller_nonMPI.py
@@ -72,7 +72,9 @@ class controller_nonMPI(Controller):
 
         # `it_coarse` sweeps the coarsest level exactly once. Single-level Gauss-like MSSDC routes
         # through it too, so reject multiple sweeps there as well instead of silently ignoring them.
-        if self.nsweeps[-1] > 1 and (self.nlevels > 1 or not self.params.mssdc_jac):
+        # `mssdc_jac` only decides the routing when there is more than one step: a single step is
+        # plain SDC and always goes through `it_fine`, which honours nsweeps.
+        if self.nsweeps[-1] > 1 and (self.nlevels > 1 or (num_procs > 1 and not self.params.mssdc_jac)):
             raise ControllerError('this controller cannot do multiple sweeps on coarsest level')
 
         self.check_variable_coefficients(num_procs)

--- a/pySDC/tests/test_controllers/test_coarse_nsweeps_guard.py
+++ b/pySDC/tests/test_controllers/test_coarse_nsweeps_guard.py
@@ -1,0 +1,68 @@
+import pytest
+
+
+def get_description(nsweeps, nlevels):
+    from pySDC.implementations.problem_classes.TestEquation_0D import testequation0d
+    from pySDC.implementations.sweeper_classes.generic_implicit import generic_implicit
+    from pySDC.implementations.transfer_classes.TransferMesh import mesh_to_mesh
+
+    return {
+        'problem_class': testequation0d,
+        'problem_params': {'lambdas': [[-1.0e-1 - 1j], [-1.0]][:nlevels], 'u0': 1.0},
+        'sweeper_class': generic_implicit,
+        'sweeper_params': {'num_nodes': [3, 2][:nlevels], 'quad_type': 'RADAU-RIGHT', 'QI': 'IE'},
+        'level_params': {'restol': 1e-10, 'dt': 0.1, 'nsweeps': nsweeps},
+        'step_params': {'maxiter': 20},
+        'space_transfer_class': mesh_to_mesh,
+    }
+
+
+@pytest.mark.base
+@pytest.mark.parametrize('num_procs', [1, 2])
+@pytest.mark.parametrize('nlevels', [1, 2])
+@pytest.mark.parametrize('mssdc_jac', [True, False])
+@pytest.mark.parametrize('nsweeps', [1, 2])
+def test_coarse_nsweeps_guard(num_procs, nlevels, mssdc_jac, nsweeps):
+    """
+    `it_coarse` sweeps the coarsest level exactly once, so nsweeps > 1 there must be rejected. That
+    is every multi-level run, plus Gauss-like MSSDC, which is single-level but only exists for more
+    than one step. Plain SDC (a single step) always routes through `it_fine` regardless of
+    `mssdc_jac` and must keep working -- see https://github.com/Parallel-in-Time/pySDC/pull/668.
+    """
+    from pySDC.core.errors import ControllerError
+    from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
+
+    reaches_it_coarse = nlevels > 1 or (num_procs > 1 and not mssdc_jac)
+    controller_params = {'logger_level': 40, 'mssdc_jac': mssdc_jac}
+
+    if nsweeps > 1 and reaches_it_coarse:
+        with pytest.raises(ControllerError, match='multiple sweeps on coarsest level'):
+            controller_nonMPI(num_procs, controller_params, get_description(nsweeps, nlevels))
+        return
+
+    controller = controller_nonMPI(num_procs, controller_params, get_description(nsweeps, nlevels))
+    P = controller.MS[0].levels[0].prob
+    Tend = num_procs * controller.MS[0].levels[0].params.dt
+    uend, _ = controller.run(u0=P.u_exact(0.0), t0=0.0, Tend=Tend)
+    assert abs(uend - P.u_exact(Tend)) < 1e-8, 'run with an allowed nsweeps did not converge'
+
+
+@pytest.mark.mpi4py
+@pytest.mark.parametrize('nsweeps', [1, 2])
+def test_coarse_nsweeps_guard_MPI(nsweeps):
+    """Same for the MPI controller, on the single-step path that the guard used to reject."""
+    from mpi4py import MPI
+    from pySDC.implementations.controller_classes.controller_MPI import controller_MPI
+
+    controller = controller_MPI(
+        {'logger_level': 40, 'mssdc_jac': False}, get_description(nsweeps, 1), comm=MPI.COMM_SELF
+    )
+    P = controller.S.levels[0].prob
+    Tend = controller.S.levels[0].params.dt
+    uend, _ = controller.run(u0=P.u_exact(0.0), t0=0.0, Tend=Tend)
+    assert abs(uend - P.u_exact(Tend)) < 1e-8, 'run with an allowed nsweeps did not converge'
+
+
+if __name__ == '__main__':
+    test_coarse_nsweeps_guard(1, 1, False, 2)
+    test_coarse_nsweeps_guard_MPI(2)


### PR DESCRIPTION
## The regression

The coarse-nsweeps guard added in #668 reads

```python
if nsweeps[-1] > 1 and (nlevels > 1 or not mssdc_jac):
```

and so rejects any single-level run with `mssdc_jac=False` and `nsweeps > 1`. That is plain SDC, which never goes near `it_coarse`. It has been failing the `RayleighBenard` CI job on master since #668 merged (run 33978749570 onwards); every failure in that job's log is this error or a rank cascade of it.

## Why the condition was wrong

`mssdc_jac` only picks the route when there is more than one *step*. With a single step both controllers go to `IT_FINE` regardless of it, and `it_fine` honours `nsweeps`:

- `controller_nonMPI.py:536` — `if len(local_MS_running) == 1 or self.params.mssdc_jac: -> IT_FINE`
- `controller_MPI.py:651` — `if num_procs == 1 or self.params.mssdc_jac: -> IT_FINE`

`mssdc_jac = False` is set unconditionally by about forty configs (Resilience, GPU, PinTSimE, compression, the tutorials) precisely because it is a no-op there, so the guard fired on configurations that had always worked. The RBC3D configs are exactly that shape: single level, `controller_nonMPI(1, ...)`, `nsweeps` 2–4.

`check_variable_coefficients` from #669, two lines below the guard, already gates on `len(S.levels) == 1 and num_procs == 1`. This guard just missed the `num_procs` term.

## The fix

Both controllers now add it:

```python
if nsweeps[-1] > 1 and (nlevels > 1 or (num_procs > 1 and not mssdc_jac)):
```

Serial MSSDC (`num_procs > 1`, `mssdc_jac=False`) and every multi-level case still raise from `__init__` before any communication — the point of #668 is intact.

## Other callers

Checked, both unaffected. `controller_ParaDiag_nonMPI` descends from `ParaDiagController`, a sibling of these two, so it never sees the guard. `projects/Performance/controller_MPI_scorep.py:546` is a standalone copy still carrying the pre-#668 mid-sweep assert; it was untouched by #668 and is untouched here.

Repo-wide, the only `nsweeps > 1` configurations are RBC3D (single-level, fixed by this) and `AsympConv/PFASST_conv_tests.py` (`[nsweeps, 1]` — coarsest is 1, always fine).

## Test

#668 shipped without a test. Added `pySDC/tests/test_controllers/test_coarse_nsweeps_guard.py`, pinning the truth table across levels, steps and `mssdc_jac` for both controllers. It fails on the two regressed cells without this change.

## Verification

| | before | after |
|---|---|---|
| `RayleighBenard/tests/` | 6 failed, 5 passed | **16 passed** |
| `test_parallel_sweeper`, mpirun 2 and 3 ranks × nsweeps 1–3 | raised | **all pass** |
| `Resilience/tests/` | — | **98 passed** |
| `pySDC/tests -m "base or mpi4py"` | 195F/133E, 3486P | **195F/133E, 3504P** |

No regressions in the core suite: the 195 failures and 133 errors are pre-existing local environment gaps (no `pytest-isolate-mpi`, missing optional deps), identical before and after; the +18 passes are the new file. The truth-table matrix agrees bit-for-bit between the two controllers, and the newly-allowed cases match `mssdc_jac=True` exactly.

## Not in scope

The exit-143 SIGTERM failures in the same CI runs are unrelated infrastructure flakiness (conda-forge MPICH on certain Azure regions). Notably the `Resilience` job failure in run 34016219862 is that, not this bug — its log ends at `Process completed with exit code 143` with no test failures at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)