### PR TITLE
Give each step its own collocation index in AdaptiveCollocation

### DIFF
--- a/pySDC/implementations/convergence_controller_classes/adaptive_collocation.py
+++ b/pySDC/implementations/convergence_controller_classes/adaptive_collocation.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from qmat.lagrange import LagrangeApproximation
-from pySDC.core.convergence_controller import ConvergenceController, Status
+from pySDC.core.convergence_controller import ConvergenceController
 
 
 class AdaptiveCollocation(ConvergenceController):
@@ -124,13 +124,11 @@ class AdaptiveCollocation(ConvergenceController):
         """
 
         # generate dictionaries with the new parameters
-        new_params_sweeper = {
-            key: self.params.get(key)[self.status.active_coll] for key in self.params.vary_keys_sweeper
-        }
+        new_params_sweeper = {key: self.params.get(key)[S.status.active_coll] for key in self.params.vary_keys_sweeper}
         sweeper_params = self.params.sweeper_params.copy()
         update_params_sweeper = {**sweeper_params, **new_params_sweeper}
 
-        new_params_level = {key: self.params.get(key)[self.status.active_coll] for key in self.params.vary_keys_level}
+        new_params_level = {key: self.params.get(key)[S.status.active_coll] for key in self.params.vary_keys_level}
 
         # update sweeper for all levels
         for L in S.levels:
@@ -166,7 +164,7 @@ class AdaptiveCollocation(ConvergenceController):
                     L.f[i] = L.prob.eval_f(L.u[i], L.time)
 
         # log the new parameters
-        self.log(f'Switching to collocation {self.status.active_coll + 1} of {self.params.num_colls}', S, level=20)
+        self.log(f'Switching to collocation {S.status.active_coll + 1} of {self.params.num_colls}', S, level=20)
         msg = 'New quadrature:'
         for key in list(sweeper_params.keys()) + list(new_params_level.keys()):
             if key in self.params.vary_keys_sweeper:
@@ -181,13 +179,17 @@ class AdaptiveCollocation(ConvergenceController):
         """
         Add an index for which collocation method to use.
 
+        This lives on the step rather than on this object: every step walks through the collocation
+        methods on its own, and there is one instance of this class per controller, which is a whole
+        block of steps when running with more than one process.
+
         Args:
             controller (pySDC.Controller.controller): The controller
 
         Returns:
             None
         """
-        self.status = Status(['active_coll'])
+        self.add_status_variable_to_step('active_coll', 0)
 
     def reset_status_variables(self, controller, **kwargs):
         """
@@ -199,7 +201,7 @@ class AdaptiveCollocation(ConvergenceController):
         Returns:
             None
         """
-        self.status.active_coll = 0
+        self.set_step_status_variable('active_coll', 0)
 
     def post_iteration_processing(self, controller, S, **kwargs):
         """
@@ -212,8 +214,8 @@ class AdaptiveCollocation(ConvergenceController):
         Returns:
             None
         """
-        if (self.status.active_coll < self.params.num_colls - 1) and S.status.done:
-            self.status.active_coll += 1
+        if (S.status.active_coll < self.params.num_colls - 1) and S.status.done:
+            S.status.active_coll += 1
             S.status.done = False
             self.switch_sweeper(S)
 

--- a/pySDC/tests/test_convergence_controllers/test_adaptive_collocation.py
+++ b/pySDC/tests/test_convergence_controllers/test_adaptive_collocation.py
@@ -102,7 +102,7 @@ def single_test(**kwargs):
     nodes = np.append([0], level.sweep.coll.nodes)
 
     # initialize variables
-    cont.status.active_coll = 0
+    step.status.active_coll = 0
     step.status.slot = 0
     level.u[0] = prob.u_exact(t=0)
     level.status.time = 0.0
@@ -113,7 +113,7 @@ def single_test(**kwargs):
 
     # perform the interpolation
     cont.switch_sweeper(controller.MS[0])
-    cont.status.active_coll = 1
+    step.status.active_coll = 1
     cont.switch_sweeper(controller.MS[0])
     nodes = np.append([0], level.sweep.coll.nodes)
     error = max([abs(level.u[i] - prob.u_exact(nodes[i])) for i in range(len(level.u)) if level.u[i] is not None])
@@ -161,3 +161,57 @@ if __name__ == "__main__":
             'useMPI': True,
         }
     single_test(**kwargs)
+
+
+def run_block(num_procs, num_nodes=[2, 3]):
+    """
+    Run one block of `num_procs` steps and report the collocation method each step ended on.
+
+    Args:
+        num_procs (int): number of steps in the block
+        num_nodes (list): the collocation methods to walk through
+
+    Returns:
+        list: number of nodes each step finished with
+    """
+    from pySDC.implementations.problem_classes.polynomial_test_problem import polynomial_testequation
+    from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
+    from pySDC.implementations.convergence_controller_classes.adaptive_collocation import AdaptiveCollocation
+    from pySDC.implementations.sweeper_classes.generic_implicit import generic_implicit
+
+    description = {
+        'problem_class': polynomial_testequation,
+        'problem_params': {'degree': max(num_nodes)},
+        'sweeper_class': generic_implicit,
+        'sweeper_params': {'quad_type': 'RADAU-RIGHT', 'num_nodes': max(num_nodes), 'QI': 'LU'},
+        'level_params': {'dt': 1.0, 'restol': 1e-8},
+        'step_params': {'maxiter': 99},
+        'convergence_controllers': {
+            AdaptiveCollocation: {'num_nodes': num_nodes, 'quad_type': ['RADAU-RIGHT'] * len(num_nodes)}
+        },
+    }
+
+    controller = controller_nonMPI(num_procs=num_procs, controller_params={'logger_level': 30}, description=description)
+    P = controller.MS[0].levels[0].prob
+    controller.run(u0=P.u_exact(0), t0=0.0, Tend=num_procs * 1.0)
+
+    return [S.levels[0].sweep.coll.num_nodes for S in controller.MS]
+
+
+@pytest.mark.base
+@pytest.mark.parametrize('num_procs', [1, 2, 4])
+def test_all_steps_switch_collocation(num_procs):
+    """
+    Every step has to walk through all collocation methods, however many steps share a block.
+
+    The index of the active collocation method used to live on the convergence controller, of which
+    there is one per controller and therefore one per block. The first step to converge advanced it
+    and switched itself, after which the guard stopped every other step from ever switching, so with
+    `num_procs > 1` the collocation adaptivity was silently inert for all but one step.
+    """
+    num_nodes = [2, 3]
+    nodes = run_block(num_procs, num_nodes=num_nodes)
+
+    assert (
+        nodes == [num_nodes[-1]] * num_procs
+    ), f'Not all steps ended on the last collocation method: expected {[num_nodes[-1]] * num_procs}, got {nodes}'


### PR DESCRIPTION
Fixes a silent bug: with `num_procs > 1`, `AdaptiveCollocation` switched the collocation method for exactly one step per block and did nothing for the rest.

## The bug

`status.active_coll` lived on the convergence controller. There is one instance of that per controller, i.e. one per *block* of steps, but `post_iteration_processing` fires once per step:

```python
if (self.status.active_coll < self.params.num_colls - 1) and S.status.done:
    self.status.active_coll += 1
    S.status.done = False
    self.switch_sweeper(S)
```

The first step to converge increments the shared counter and switches itself. Every other step then meets `active_coll == num_colls - 1` and never switches at all — no error, no warning, and the run completes normally.

Measured with `num_nodes = [2, 3]` on the polynomial test problem, `restol = 1e-8`:

| `num_procs` | final `num_nodes` per step | |
|---|---|---|
| 1 | `[3]` | correct |
| 2 | `[3, 2]` | **wrong** |
| 4 | `[3, 2, 2, 2]` | **wrong** |

`check_parameters` does not restrict `num_procs`, so nothing warned about this.

## The fix

The collocation index is a property of a step, not of the block, so it moves onto the step status via the existing `add_status_variable_to_step` helper — the same mechanism `BasicRestarting` uses for `restart`. Each step then walks through the collocation methods independently, which is what `num_procs = 1` always did.

## Testing

`test_all_steps_switch_collocation` runs a block at `num_procs` 1, 2 and 4 and asserts every step ends on the last collocation method. Verified it **fails on the unfixed code** for `num_procs` 2 and 4 and passes for 1.

The existing interpolation test poked `cont.status.active_coll` directly and was updated to `step.status.active_coll`; it otherwise behaves the same.

Full run: 218 passed across `tests_core`, `test_controllers`, `test_convergence_controllers` and `test_hooks`; `ruff` clean. (`test_loggingMPI` errors locally because this env lacks the `pytest-mpi` plugin — pre-existing and unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)