### PR TITLE
Say that the two transports of an algorithm are the same program, and make one asymmetry testable

### DIFF
--- a/pySDC/core/convergence_controller.py
+++ b/pySDC/core/convergence_controller.py
@@ -290,6 +290,35 @@ class ConvergenceController(object):
         """
         pass
 
+    def post_iteration_processing_block(self, controller: 'Controller', **kwargs: Any) -> None:
+        """
+        Do whatever you want to after each iteration, once for the whole block rather than once per step.
+
+        Use this instead of `post_iteration_processing` for state that belongs to the block rather than
+        to a step. A convergence controller is instantiated once per *controller*, so anything stored on
+        `self` spans a whole block in `controller_nonMPI` but a single rank under MPI, while the per-step
+        hooks fire once per step. A recursion driven from a per-step hook therefore advances a different
+        number of times depending only on how the run was decomposed. State that genuinely belongs to a
+        step should go on `S.status` via `add_status_variable_to_step` instead.
+
+        Note this fires once per iteration **per rank**, not once per block: under MPI every rank calls
+        it, so a quantity that has to agree across the block still needs a reduction in here. See
+        `AdaptiveAlpha` for how that looks.
+
+        Note also what that does *not* buy you. Under a pipelined method an early step converges and
+        drops out, so ranks take part in different numbers of iterations by design; a recursion driven
+        from here therefore still advances a different number of times on different ranks, and that is
+        the pipelining rather than a defect. Where every step iterates together -- ParaDiag, which
+        cannot converge one step at a time because the transform needs them all -- this is exact.
+
+        Args:
+            controller (pySDC.Controller): The controller
+
+        Returns:
+            None
+        """
+        pass
+
     def post_step_processing(self, controller: 'Controller', S: 'Step', **kwargs: Any) -> None:
         """
         Do whatever you want to after each step here.

--- a/pySDC/implementations/controller_classes/controller_MPI.py
+++ b/pySDC/implementations/controller_classes/controller_MPI.py
@@ -631,6 +631,9 @@ class controller_MPI(Controller):
             C.post_iteration_processing(self, self.S, comm=comm)
             C.convergence_control(self, self.S, comm=comm)
 
+        for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
+            C.post_iteration_processing_block(self, comm=comm)
+
         # if not ready, keep doing stuff
         if not self.S.status.done:
             # increment iteration count here (and only here)

--- a/pySDC/implementations/controller_classes/controller_ParaDiag_MPI.py
+++ b/pySDC/implementations/controller_classes/controller_ParaDiag_MPI.py
@@ -207,6 +207,9 @@ class controller_ParaDiag_MPI(ParaDiagController):
             C.post_iteration_processing(self, S, comm=comm)
             C.convergence_control(self, S, comm=comm)
 
+        for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
+            C.post_iteration_processing_block(self, comm=comm)
+
         for hook in self.hooks:
             hook.pre_comm(step=S, level_number=0)
         S.status.done = comm.allreduce(S.status.done, op=MPI.LAND)

--- a/pySDC/implementations/controller_classes/controller_ParaDiag_nonMPI.py
+++ b/pySDC/implementations/controller_classes/controller_ParaDiag_nonMPI.py
@@ -270,6 +270,9 @@ class controller_ParaDiag_nonMPI(ParaDiagController):
                 C.post_iteration_processing(self, S, MS=local_MS_running)
                 C.convergence_control(self, S, MS=local_MS_running)
 
+        for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
+            C.post_iteration_processing_block(self, MS=local_MS_running)
+
         for S in local_MS_running:
             if not S.status.first:
                 for hook in self.hooks:

--- a/pySDC/implementations/controller_classes/controller_nonMPI.py
+++ b/pySDC/implementations/controller_classes/controller_nonMPI.py
@@ -508,6 +508,9 @@ class controller_nonMPI(Controller):
                 C.post_iteration_processing(self, S, MS=local_MS_running)
                 C.convergence_control(self, S, MS=local_MS_running)
 
+        for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
+            C.post_iteration_processing_block(self, MS=local_MS_running)
+
         for S in local_MS_running:
             if not S.status.first:
                 for hook in self.hooks:

--- a/pySDC/implementations/convergence_controller_classes/adaptive_alpha.py
+++ b/pySDC/implementations/convergence_controller_classes/adaptive_alpha.py
@@ -78,7 +78,6 @@ class AdaptiveAlpha(ConvergenceController):
             None
         """
         self.e = self.params.e0
-        self.last_iter = None
         return None
 
     def get_gamma(self, controller):
@@ -94,23 +93,20 @@ class AdaptiveAlpha(ConvergenceController):
         eps = np.finfo(complex).eps
         return controller.n_steps * (3 * eps + self.params.inner_tol)
 
-    def post_iteration_processing(self, controller, S, **kwargs):
+    def post_iteration_processing_block(self, controller, **kwargs):
         r"""
         Compute the next :math:`\alpha` from the residual of the whole block.
 
+        This is a block hook rather than a per-step one because :math:`\alpha` belongs to the block:
+        it parametrises the transform across the steps, so it has to advance once per iteration no
+        matter how the block was decomposed.
+
         Args:
             controller (pySDC.Controller): The controller
-            S (pySDC.Step): The current step
 
         Returns:
             None
         """
-        # The virtually parallel controller calls this once per step, the MPI one once per rank. Either
-        # way alpha must advance once per iteration, or the recursion below runs L times too fast.
-        if self.last_iter == S.status.iter:
-            return None
-        self.last_iter = S.status.iter
-
         # the residual of the composite problem is the largest one across the block
         residual = max(step.levels[0].status.residual for step in controller.steps)
 
@@ -126,7 +122,7 @@ class AdaptiveAlpha(ConvergenceController):
         self.e = 2 * np.sqrt(gamma * self.e * residual)
 
         controller.params.alpha = min(max(alpha, self.params.alpha_min), self.params.alpha_max)
-        self.debug(f'Set alpha to {controller.params.alpha:.3e} from residual {residual:.3e}', S)
+        self.debug(f'Set alpha to {controller.params.alpha:.3e} from residual {residual:.3e}', controller.steps[0])
 
         # keep the history around; it is what you want to look at when tuning
         self.alphas.append(controller.params.alpha)

--- a/pySDC/tests/test_controllers/test_controller_conformance.py
+++ b/pySDC/tests/test_controllers/test_controller_conformance.py
@@ -1,0 +1,303 @@
+"""
+Conformance suite: the two transports of one algorithm have to be the same program.
+
+pySDC implements each time-parallel algorithm twice -- once with every step in one process
+(``controller_nonMPI``) and once with one step per rank (``controller_MPI``). Running virtually
+rather than in parallel is meant to be a *decomposition parameter*, not a different program, so a
+user who swaps the controller must get the same answer and the same features.
+
+Today they are not the same program, and nothing in the test suite says so. This file is where that
+gets asserted, one test per axis on which they can drift.
+
+What this file deliberately does NOT duplicate:
+
+- ParaDiag's cross-transport equivalence, which ``test_controller_ParaDiag_MPI.py`` already covers
+  in ParaDiag's own terms (``test_ParaDiag_MPI_matches_nonMPI`` and friends, at ``rtol=1e-14``).
+  The axes here are the ones that apply to *any* controller pair.
+- Algorithm correctness. Whether SDC converges, or ParaDiag has the right order, is tested
+  elsewhere; conformance only asks whether the two transports agree with *each other*.
+- ``test_controller_equivalence.py`` on the ``feat/timecomm-virtual`` branch, which was the Phase 0
+  characterisation test. ``test_pfasst_baseline`` here supersedes it -- delete that file when the
+  branch is rebased rather than keeping both.
+- ``AdaptiveAlpha``'s cross-transport agreement, pinned by ``test_adaptive_alpha.py`` and tutorial
+  step_9 E. The block-hook axis here checks the *contract*; those check one user of it.
+
+Axes marked ``xfail`` are known asymmetries with a documented cause. They are strict, so fixing one
+without removing its marker fails the suite: the marker is a to-do list, not a suppression.
+
+A note on the iteration estimator, since that asymmetry is not the obvious shape.
+``controller_MPI`` implements it inline, ``controller_nonMPI`` not at all, and the supported
+route is a third thing -- the ``CheckIterationEstimatorNonMPI`` convergence controller, which
+tutorial step_8 C exercises. Only that third one is tested: nothing in the repository ever sets
+``use_iteration_estimator`` to ``True``, and switching it on under MPI deadlocks. So this file
+covers the virtual half of that axis only and never launches the MPI implementation.
+"""
+
+import os
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+from pySDC.core.convergence_controller import ConvergenceController
+
+ATOL = 1e-14
+RTOL = 0.0
+DT = 0.1
+NUM_PROCS = 4
+
+
+class RecursionProbe(ConvergenceController):
+    """
+    A convergence controller that carries iteration-indexed state on ``self``, and records it.
+
+    This is the smallest thing that can detect the call-count contract: a convergence controller is
+    instantiated once per *controller*, so ``self`` spans a whole block virtually but a single rank
+    under MPI, while ``post_iteration_processing`` fires once per *step*. Anything recursive on
+    ``self`` therefore advances a different number of times in the two transports.
+
+    Deliberately not a real convergence controller -- it changes nothing about the run, so it can be
+    added to any configuration without perturbing the numbers the other axes compare.
+    """
+
+    def setup(self, controller, params, description, **kwargs):
+        return {'control_order': +500, **super().setup(controller, params, description, **kwargs)}
+
+    def setup_status_variables(self, controller, **kwargs):
+        self.calls = []
+        self.block_calls = 0
+        return None
+
+    def post_iteration_processing(self, controller, S, **kwargs):
+        self.calls.append((int(S.status.slot), int(S.status.iter)))
+        return None
+
+    def post_iteration_processing_block(self, controller, **kwargs):
+        self.block_calls += 1
+        return None
+
+
+def get_description(config, errtol=None):
+    """Single-level IMEX SDC, or the same problem as two-level MLSDC/PFASST."""
+    from pySDC.implementations.problem_classes.HeatEquation_ND_FD import heatNd_forced
+    from pySDC.implementations.sweeper_classes.imex_1st_order import imex_1st_order
+    from pySDC.implementations.transfer_classes.TransferMesh import mesh_to_mesh
+
+    description = {
+        'problem_class': heatNd_forced,
+        'problem_params': {'nu': 0.1, 'freq': (2,), 'nvars': (15,), 'bc': 'dirichlet-zero'},
+        'sweeper_class': imex_1st_order,
+        'sweeper_params': {'quad_type': 'RADAU-RIGHT', 'num_nodes': 3, 'QI': 'IE'},
+        'level_params': {'restol': 1e-09, 'dt': DT},
+        'step_params': {'maxiter': 10},
+    }
+    if config == 'multi_level':
+        description['problem_params']['nvars'] = [(31,), (15,)]
+        description['sweeper_params']['num_nodes'] = [3, 2]
+        description['space_transfer_class'] = mesh_to_mesh
+        description['space_transfer_params'] = {'rorder': 2, 'iorder': 6}
+    if errtol is not None:
+        description['step_params']['errtol'] = errtol
+    return description
+
+
+def run(useMPI, config='single_level', probe=False, errtol=None, num_procs=NUM_PROCS):
+    """
+    Run one configuration through one of the two transports and return everything the axes compare.
+
+    Returns:
+        dict: uend, the (time, niter) pairs, the sorted stats types, and the probe's final state
+    """
+    from pySDC.helpers.stats_helper import get_sorted
+
+    description = get_description(config, errtol=errtol)
+    controller_params = {'logger_level': 30}
+    if errtol is not None:
+        controller_params['use_iteration_estimator'] = True
+        controller_params['all_to_done'] = False
+    if probe:
+        description['convergence_controllers'] = {RecursionProbe: {}}
+
+    if useMPI:
+        from mpi4py import MPI
+        from pySDC.implementations.controller_classes.controller_MPI import controller_MPI
+
+        comm = MPI.COMM_WORLD
+        controller = controller_MPI(comm=comm, controller_params=controller_params, description=description)
+        P = controller.S.levels[0].prob
+    else:
+        from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
+
+        comm = None
+        controller = controller_nonMPI(
+            num_procs=num_procs, controller_params=controller_params, description=description
+        )
+        P = controller.MS[0].levels[0].prob
+
+    uend, stats = controller.run(u0=P.u_exact(0.0), t0=0.0, Tend=num_procs * DT)
+
+    probes = [me for me in controller.convergence_controllers if type(me) == RecursionProbe]
+    return {
+        'uend': np.asarray(uend),
+        'niter': np.array(get_sorted(stats, type='niter', sortby='time', comm=comm), dtype=float),
+        'stats_types': sorted({me.type for me in stats.keys()}),
+        'block_calls': probes[0].block_calls if probes else -1,
+        'iters_seen': len({it for _, it in probes[0].calls}) if probes else -1,
+    }
+
+
+CASES = {
+    'baseline_single': {'config': 'single_level'},
+    'baseline_multi': {'config': 'multi_level'},
+    'probe': {'config': 'single_level', 'probe': True},
+}
+
+
+@pytest.fixture(scope='module')
+def results(tmp_path_factory):
+    """
+    Run every case through both transports, launching ``mpirun`` exactly once.
+
+    Starting an MPI job costs about a minute here and dominates everything this file does -- the
+    solves themselves are milliseconds. One launch that covers every case therefore costs what a
+    single test used to, which is the difference between a suite worth having in CI and one that
+    gets deleted the next time somebody trims the pipeline (cf. #675).
+    """
+    root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+    out = str(tmp_path_factory.mktemp('conformance') / 'mpi_results.npz')
+
+    env = os.environ.copy()
+    env['PYTHONPATH'] = root
+    env['COVERAGE_PROCESS_START'] = 'pyproject.toml'
+
+    cmd = f'mpirun -np {NUM_PROCS} {sys.executable} {__file__} {out}'
+    p = subprocess.Popen(cmd.split(), env=env, cwd=root)
+    p.wait()
+    assert p.returncode == 0, f'ERROR: mpirun returned {p.returncode}'
+
+    loaded = np.load(out, allow_pickle=True)
+    out_dict = {}
+    for name, kwargs in CASES.items():
+        mpi = {k.split('/', 1)[1]: loaded[k] for k in loaded.files if k.startswith(f'{name}/')}
+        out_dict[name] = (run(useMPI=False, **kwargs), mpi)
+    return out_dict
+
+
+@pytest.mark.base
+def test_multilevel_visits_all_stages():
+    """
+    Without this, a green baseline could still be covering only 4 of the 7 stages.
+
+    ``it_check`` only sends a step to ``IT_DOWN`` when it has more than one level, so a single-level
+    run never visits ``IT_DOWN``, ``IT_COARSE`` or ``IT_UP``.
+    """
+    from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
+
+    visited = set()
+
+    class Recorder(controller_nonMPI):
+        def pfasst(self, local_MS_active):
+            visited.update(S.status.stage for S in local_MS_active)
+            return super().pfasst(local_MS_active)
+
+    description = get_description('multi_level')
+    controller = Recorder(num_procs=NUM_PROCS, controller_params={'logger_level': 30}, description=description)
+    P = controller.MS[0].levels[0].prob
+    controller.run(u0=P.u_exact(0.0), t0=0.0, Tend=NUM_PROCS * DT)
+
+    assert {'IT_DOWN', 'IT_COARSE', 'IT_UP'} <= visited, f'missing stages, got {sorted(visited)}'
+
+
+@pytest.mark.mpi4py
+@pytest.mark.parametrize('case', ['baseline_single', 'baseline_multi'])
+def test_pfasst_baseline(case, results):
+    """Same description, same answer, whichever transport ran it."""
+    serial, mpi = results[case]
+
+    assert np.array_equal(
+        serial['niter'], mpi['niter']
+    ), f'iteration counts differ for {case}: {serial["niter"].tolist()} vs {mpi["niter"].tolist()}'
+    assert np.allclose(
+        serial['uend'], mpi['uend'], atol=ATOL, rtol=RTOL
+    ), f'uend differs for {case} by {np.max(np.abs(serial["uend"] - mpi["uend"])):.3e} > {ATOL:.0e}'
+
+
+@pytest.mark.mpi4py
+def test_stats_emission_agrees(results):
+    """A user's post-processing must not depend on which transport produced the stats."""
+    serial, mpi = results['baseline_multi']
+    serial_types, mpi_types = list(serial['stats_types']), [str(me) for me in mpi['stats_types']]
+
+    assert serial_types == mpi_types, (
+        f'stats types differ:\n  only serial: {sorted(set(serial_types) - set(mpi_types))}'
+        f'\n  only MPI   : {sorted(set(mpi_types) - set(serial_types))}'
+    )
+
+
+@pytest.mark.mpi4py
+def test_block_hook_fires_once_per_iteration(results):
+    """
+    ``post_iteration_processing_block`` must fire once per iteration, in both transports.
+
+    This is the contract that lets a convergence controller hold block-global state at all. The
+    per-step hooks fire once per *step*, so a controller is called L times per iteration virtually
+    and once per iteration under MPI; anything recursive on ``self`` therefore advanced at a rate
+    that depended only on how the run was decomposed. The block hook is the fix, and this is what
+    makes it checkable.
+
+    Note what is deliberately *not* asserted: that a recursion driven from the block hook reaches the
+    same value in both transports. It does not, and should not. Under a pipelined method an early
+    step converges and drops out, so ranks legitimately take part in different numbers of iterations
+    -- ``niter`` here is [6, 7, 8, 9] across the block. That spread is the pipelining (C2), not
+    drift. The invariant that survives it is the per-rank one asserted below, and it is exactly
+    strong enough for the case that motivated the hook: in ParaDiag every step iterates together, so
+    once-per-iteration-per-rank is once-per-iteration full stop, which is why ``AdaptiveAlpha`` gets
+    identical answers either way (see ``test_adaptive_alpha.py`` and tutorial step_9 E, which pin
+    that and are not duplicated here).
+    """
+    serial, mpi = results['probe']
+
+    for name, r in (('virtual', serial), ('MPI', mpi)):
+        block_calls, iters_seen = int(r['block_calls']), int(r['iters_seen'])
+        assert block_calls > 1, f'the block hook never fired in the {name} controller'
+        assert block_calls == iters_seen, (
+            f'the block hook fired {block_calls} times over {iters_seen} iterations in the '
+            f'{name} controller -- it must fire once per iteration, not once per step'
+        )
+
+
+@pytest.mark.base
+@pytest.mark.xfail(strict=True, reason='use_iteration_estimator is implemented in controller_MPI only')
+def test_iteration_estimator_is_honoured():
+    """
+    ``use_iteration_estimator`` must do something, whichever controller is asked.
+
+    It is declared in the base controller's parameters, so *both* controllers accept it, but only
+    ``controller_MPI`` reads it. ``controller_nonMPI`` silently ignores the request and runs to
+    ``maxiter``, with no error and no warning -- the same description, two different programs.
+
+    This asks only whether the flag changes the virtual controller's behaviour, and deliberately
+    does not run the MPI implementation: switching that one on deadlocks (see the module
+    docstring), and a hanging test is worse than a missing one.
+    """
+    without = run(useMPI=False)['niter']
+    with_estimator = run(useMPI=False, errtol=1e-7)['niter']
+
+    assert not np.array_equal(without, with_estimator), (
+        'use_iteration_estimator=True changed nothing in controller_nonMPI: '
+        f'{without[:, 1].tolist()} iterations either way'
+    )
+
+
+if __name__ == '__main__':
+    from mpi4py import MPI
+
+    _out = sys.argv[1]
+    _payload = {}
+    for _name, _kwargs in CASES.items():
+        _result = run(useMPI=True, **_kwargs)
+        _payload.update({f'{_name}/{_k}': _v for _k, _v in _result.items()})
+
+    if MPI.COMM_WORLD.rank == 0:
+        np.savez(_out, **_payload)

--- a/pySDC/tests/test_convergence_controllers/test_adaptive_alpha.py
+++ b/pySDC/tests/test_convergence_controllers/test_adaptive_alpha.py
@@ -90,8 +90,10 @@ def test_adaptive_alpha_stays_better_conditioned():
 @pytest.mark.base
 def test_alpha_history_advances_once_per_iteration():
     """
-    The controller is called once per step in the virtual controller, but alpha must advance once per
-    iteration, otherwise the recursion runs L times too fast.
+    Alpha must advance exactly once per iteration.
+
+    It rides on `post_iteration_processing_block`, which fires once per iteration rather than once
+    per step, so this holds whether the block sits in one process or across ranks.
     """
     controller, _, niter = run_ParaDiag('adaptive')
     alphas = get_convergence_controller(controller).alphas
@@ -150,8 +152,7 @@ def test_zero_residual_is_ignored():
 
     for step in controller.steps:
         step.levels[0].status.residual = 0.0
-    cc.last_iter = None
-    cc.post_iteration_processing(controller, controller.steps[0])
+    cc.post_iteration_processing_block(controller)
 
     assert controller.params.alpha == alpha_before, 'ERROR: a zero residual moved alpha'
     assert len(cc.alphas) == n_before, 'ERROR: a zero residual was recorded as an update'


### PR DESCRIPTION
Each time-parallel algorithm in pySDC is implemented twice — every step in one process (`controller_nonMPI`), or one step per rank (`controller_MPI`). Swapping between them is meant to be a decomposition parameter, not a different program. Nothing asserted that, and they have drifted.

Two commits: a hook that removes one asymmetry, and a suite that will catch the next one.

## 1. A hook for block-global convergence controller state

A convergence controller is instantiated **once per controller**, so state on `self` spans a whole block in `controller_nonMPI` but a single rank under MPI — while the per-step hooks fire once per *step*. Anything recursive on `self` advanced at a rate that depended only on how the run was decomposed. `AdaptiveAlpha` papered over this with a `last_iter` guard; without it the run took 27 iterations at alpha 0.475 instead of 3. The guard was the symptom.

`post_iteration_processing_block` fires once per iteration, in all four controllers, after the per-step loop and before the done-cascade. `AdaptiveAlpha` moves onto it and the guard is deleted.

**What it does not promise**, documented on the hook itself because I got this wrong first:

> Under a pipelined method an early step converges and drops out, so ranks take part in different numbers of iterations *by design* — `niter` is `[6, 7, 8, 9]` across a four-step block. A recursion driven from this hook therefore still advances a different number of times on different ranks. That is the pipelining (C2), not drift.

It is exact where every step iterates together — ParaDiag, which cannot converge one step at a time because the transform needs all of them. That is the case that motivated the hook, and it is why `AdaptiveAlpha` gets identical answers from both controllers.

State that genuinely belongs to a *step* still belongs on `S.status` via `add_status_variable_to_step`, as in #674.

## 2. A conformance suite

`pySDC/tests/test_controllers/test_controller_conformance.py` — one test per axis on which the transports can drift:

| axis | result |
|---|---|
| multi-level run visits `IT_DOWN`/`IT_COARSE`/`IT_UP` | passes — guards that the baseline is not silently covering 4 of 7 stages |
| PFASST baseline, single- and multi-level | passes |
| stats emission | passes — a measured negative, kept as a guard |
| block hook fires once per iteration | passes |
| `use_iteration_estimator` is honoured | **xfail(strict)** |

The markers are strict, so fixing an asymmetry without removing its marker fails the suite. They are a to-do list, not a suppression.

### On the one xfail

`use_iteration_estimator` is declared in the **base** controller parameters, so both controllers accept it — but only `controller_MPI` reads it. `controller_nonMPI` silently ignores the request and runs to `maxiter`, no error, no warning.

Investigating it turned up more than expected, so the test covers only the virtual half and never launches the MPI implementation:

- **Nothing in the repository ever sets it to `True`** — every occurrence is `False` or commented out, and there are no tests.
- **It deadlocks when switched on.** At `controller_MPI.py:433` every rank except the last posts `Ibcast(root=size-1)`, but the last rank only posts a matching broadcast if the estimate happens to fire. Converge on the residual first and that collective is never matched — and line 455 then tries to `Cancel()` it, which is not valid for a nonblocking collective.
- The working, tested route is a third thing: the `CheckIterationEstimatorNonMPI` convergence controller, which tutorial step_8 C exercises.

A hanging test is worse than a missing one, hence the split. Follow-up PRs will remove the dead implementation and then give the convergence controller a real MPI path.

## Cost

It launches `mpirun` once for all cases rather than once per assertion. Starting an MPI job costs about a minute here and the solves themselves are milliseconds, so the obvious structure ran in 5m11s and this runs in **under 30 seconds** — the same principle as #675. Shrinking the problem, which I tried first, changed nothing.

## Not duplicated

Deliberate, and the module docstring names each exclusion: ParaDiag's cross-transport tests stay in `test_controller_ParaDiag_MPI.py`; `AdaptiveAlpha`'s agreement stays in `test_adaptive_alpha.py` and tutorial step_9 E; algorithm correctness stays where it is. This file asserts the *contract*, those check its users.

It also supersedes `test_controller_equivalence.py` on the unmerged `feat/timecomm-virtual` branch — that file should be **deleted** when the branch rebases, not kept alongside.

## Testing

188 base and 42 mpi4py tests pass across `test_controllers`, `test_convergence_controllers` and `tests_core`; `ruff` and `black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)