### PR TITLE
Remove the dead MPI iteration estimator

### DIFF
--- a/pySDC/core/check_convergence.py
+++ b/pySDC/core/check_convergence.py
@@ -139,7 +139,7 @@ class CheckConvergence(ConvergenceController):
                 hook.pre_comm(step=S, level_number=0)
 
             # check if an open request of the status send is pending
-            controller.wait_with_interrupt(request=controller.req_status)
+            controller.wait_for_request(request=controller.req_status)
             if S.status.force_done:
                 return None
 

--- a/pySDC/core/controller.py
+++ b/pySDC/core/controller.py
@@ -63,8 +63,16 @@ class Controller(object):
         self.__setup_custom_logger(self.params.logger_level, self.params.log_to_file, self.params.fname)
         self.logger: logging.Logger = logging.getLogger('controller')
 
-        if self.params.use_iteration_estimator and self.params.all_to_done:
-            self.logger.warning('all_to_done and use_iteration_estimator set, will ignore all_to_done')
+        if self.params.use_iteration_estimator:
+            raise ControllerError(
+                'The `use_iteration_estimator` controller parameter has been removed. Its only '
+                'implementation lived in `controller_MPI`, was never switched on anywhere, had no '
+                'tests, and deadlocked when used: every rank but the last posted a broadcast that '
+                'the last rank only matched if the estimate happened to fire. Use the '
+                '`CheckIterationEstimatorNonMPI` convergence controller instead, as '
+                '`pySDC/tutorial/step_8/C_iteration_estimator.py` does. Note it is, as its name '
+                'says, not yet available under MPI.'
+            )
 
         self.base_convergence_controllers: List[Type[Any]] = [CheckConvergence]
         self.setup_convergence_controllers(description)

--- a/pySDC/implementations/controller_classes/controller_MPI.py
+++ b/pySDC/implementations/controller_classes/controller_MPI.py
@@ -52,8 +52,6 @@ class controller_MPI(Controller):
         self.req_status = None
         # add request handle container for isend
         self.req_send = [None] * num_levels
-        self.req_ibcast = None
-        self.req_diff = None
 
         if num_procs > 1 and num_levels > 1:
             for L in self.S.levels:
@@ -209,9 +207,6 @@ class controller_MPI(Controller):
         for l in self.S.levels:
             l.tag = None
         self.req_status = None
-        self.req_diff = None
-        self.req_ibcast = None
-        self.req_diff = None
         self.req_send = [None] * len(self.S.levels)
         self.S.status.prev_done = False
         self.S.status.force_done = False
@@ -236,7 +231,7 @@ class controller_MPI(Controller):
             comm: communicator
         """
         req = target.u[0].irecv(source=source, tag=tag, comm=comm)
-        self.wait_with_interrupt(request=req)
+        self.wait_for_request(request=req)
         if self.S.status.force_done:
             return None
         # re-evaluate f on left interval boundary
@@ -260,7 +255,7 @@ class controller_MPI(Controller):
             hook.pre_comm(step=self.S, level_number=level)
 
         if not blocking:
-            self.wait_with_interrupt(request=self.req_send[level])
+            self.wait_for_request(request=self.req_send[level])
             if self.S.status.force_done:
                 return None
 
@@ -282,7 +277,7 @@ class controller_MPI(Controller):
                 dest=self.S.next, tag=level * 100 + self.S.status.iter, comm=comm
             )
             if blocking:
-                self.wait_with_interrupt(request=self.req_send[level])
+                self.wait_for_request(request=self.req_send[level])
                 if self.S.status.force_done:
                     return None
 
@@ -318,101 +313,21 @@ class controller_MPI(Controller):
         for hook in self.hooks:
             hook.post_comm(step=self.S, level_number=level, add_to_stats=add_to_stats)
 
-    def wait_with_interrupt(self, request):
+    def wait_for_request(self, request):
         """
-        Wrapper for waiting for the completion of a non-blocking communication, can be interrupted
+        Wait for a non-blocking communication to complete.
+
+        This used to poll for an interrupt while waiting, so that a rank could be told mid-wait that
+        the iteration estimator had decided everyone was done. That estimator has been removed, and
+        with it the only thing that could ever have interrupted a wait, so this is now a plain wait.
+        `force_done` is still honoured by the callers -- convergence controllers and hooks set it
+        between stages -- but nothing sets it *during* a wait any more.
 
         Args:
             request: request to wait for
         """
-        if request is not None and self.req_ibcast is not None:
-            while not request.Test():
-                if self.req_ibcast.Test():
-                    self.logger.debug(f'{self.S.status.slot} has been cancelled during {self.S.status.stage}..')
-                    self.S.status.stage = f'CANCELLED_{self.S.status.stage}'
-                    self.S.status.force_done = True
-                    return None
         if request is not None:
             request.Wait()
-
-    def check_iteration_estimate(self, comm):
-        """
-        Routine to compute and check error/iteration estimation
-
-        Args:
-            comm: time-communicator
-        """
-
-        # Compute diff between old and new values
-        diff_new = 0.0
-        L = self.S.levels[0]
-
-        for m in range(1, L.sweep.coll.num_nodes + 1):
-            diff_new = max(diff_new, abs(L.uold[m] - L.u[m]))
-
-        # Send forward diff
-        for hook in self.hooks:
-            hook.pre_comm(step=self.S, level_number=0)
-
-        self.wait_with_interrupt(request=self.req_diff)
-        if self.S.status.force_done:
-            return None
-
-        if not self.S.status.first:
-            prev_diff = np.empty(1, dtype=float)
-            req = comm.Irecv((prev_diff, MPI.DOUBLE), source=self.S.prev, tag=999)
-            self.wait_with_interrupt(request=req)
-            if self.S.status.force_done:
-                return None
-            self.logger.debug(
-                'recv diff: status %s, process %s, time %s, source %s, tag %s, iter %s'
-                % (prev_diff, self.S.status.slot, self.S.time, self.S.prev, 999, self.S.status.iter)
-            )
-            diff_new = max(prev_diff[0], diff_new)
-
-        if not self.S.status.last:
-            self.logger.debug(
-                'isend diff: status %s, process %s, time %s, target %s, tag %s, iter %s'
-                % (diff_new, self.S.status.slot, self.S.time, self.S.next, 999, self.S.status.iter)
-            )
-            tmp = np.array(diff_new, dtype=float)
-            self.req_diff = comm.Issend((tmp, MPI.DOUBLE), dest=self.S.next, tag=999)
-
-        for hook in self.hooks:
-            hook.post_comm(step=self.S, level_number=0)
-
-        # Store values from first iteration
-        if self.S.status.iter == 1:
-            self.S.status.diff_old_loc = diff_new
-            self.S.status.diff_first_loc = diff_new
-        # Compute iteration estimate
-        elif self.S.status.iter > 1:
-            Ltilde_loc = min(diff_new / self.S.status.diff_old_loc, 0.9)
-            self.S.status.diff_old_loc = diff_new
-            alpha = 1 / (1 - Ltilde_loc) * self.S.status.diff_first_loc
-            Kest_loc = np.log(self.S.params.errtol / alpha) / np.log(Ltilde_loc) * 1.05  # Safety factor!
-            self.logger.debug(
-                f'LOCAL: {L.time:8.4f}, {self.S.status.iter}: {int(np.ceil(Kest_loc))}, '
-                f'{Ltilde_loc:8.6e}, {Kest_loc:8.6e}, '
-                f'{Ltilde_loc ** self.S.status.iter * alpha:8.6e}'
-            )
-            Kest_glob = Kest_loc
-            # If condition is met, send interrupt
-            if np.ceil(Kest_glob) <= self.S.status.iter:
-                if self.S.status.last:
-                    self.logger.debug(f'{self.S.status.slot} is done, broadcasting..')
-                    for hook in self.hooks:
-                        hook.pre_comm(step=self.S, level_number=0)
-                    comm.Ibcast((np.array([1]), MPI.INT), root=self.S.status.slot).Wait()
-                    for hook in self.hooks:
-                        hook.post_comm(step=self.S, level_number=0, add_to_stats=True)
-                    self.logger.debug(f'{self.S.status.slot} is done, broadcasting done')
-                    self.S.status.done = True
-                else:
-                    for hook in self.hooks:
-                        hook.pre_comm(step=self.S, level_number=0)
-                    for hook in self.hooks:
-                        hook.post_comm(step=self.S, level_number=0, add_to_stats=True)
 
     def pfasst(self, comm, num_procs):
         """
@@ -429,48 +344,17 @@ class controller_MPI(Controller):
 
         self.logger.debug(stage + ' - process ' + str(self.S.status.slot))
 
-        # Wait for interrupt, if iteration estimator is used
-        if self.params.use_iteration_estimator and stage == 'SPREAD' and not self.S.status.last:
-            done = np.empty(1)
-            self.req_ibcast = comm.Ibcast((done, MPI.INT), root=comm.Get_size() - 1)
+        switcher = {
+            'SPREAD': self.spread,
+            'PREDICT': self.predict,
+            'IT_CHECK': self.it_check,
+            'IT_FINE': self.it_fine,
+            'IT_DOWN': self.it_down,
+            'IT_COARSE': self.it_coarse,
+            'IT_UP': self.it_up,
+        }
 
-        # If interrupt is there, cleanup and finish
-        if self.params.use_iteration_estimator and not self.S.status.last and self.req_ibcast.Test():
-            self.logger.debug(f'{self.S.status.slot} is done..')
-            self.S.status.done = True
-
-            if not stage == 'IT_CHECK':
-                self.logger.debug(f'Rewinding {self.S.status.slot} after {stage}..')
-                self.S.levels[0].u[1:] = self.S.levels[0].uold[1:]
-
-            for hook in self.hooks:
-                hook.post_iteration(step=self.S, level_number=0)
-
-            for req in self.req_send:
-                if req is not None and req != MPI.REQUEST_NULL:
-                    req.Cancel()
-            if self.req_status is not None and self.req_status != MPI.REQUEST_NULL:
-                self.req_status.Cancel()
-            if self.req_diff is not None and self.req_diff != MPI.REQUEST_NULL:
-                self.req_diff.Cancel()
-
-            self.S.status.stage = 'DONE'
-            for hook in self.hooks:
-                hook.post_step(step=self.S, level_number=0)
-
-        else:
-            # Start cycling, if not interrupted
-            switcher = {
-                'SPREAD': self.spread,
-                'PREDICT': self.predict,
-                'IT_CHECK': self.it_check,
-                'IT_FINE': self.it_fine,
-                'IT_DOWN': self.it_down,
-                'IT_COARSE': self.it_coarse,
-                'IT_UP': self.it_up,
-            }
-
-            switcher.get(stage, self.default)(comm, num_procs)
+        switcher.get(stage, self.default)(comm, num_procs)
 
     def spread(self, comm, num_procs):
         """
@@ -483,10 +367,6 @@ class controller_MPI(Controller):
 
         # call predictor from sweeper
         self.S.levels[0].sweep.predict()
-
-        if self.params.use_iteration_estimator:
-            # store previous iterate to compute difference later on
-            self.S.levels[0].uold[1:] = self.S.levels[0].u[1:]
 
         # update stage
         if len(self.S.levels) > 1:  # MLSDC or PFASST with predict
@@ -615,10 +495,6 @@ class controller_MPI(Controller):
         # compute the residual
         self.S.levels[0].sweep.compute_residual(stage='IT_CHECK')
 
-        if self.params.use_iteration_estimator:
-            # TODO: replace with convergence controller
-            self.check_iteration_estimate(comm=comm)
-
         if self.S.status.force_done:
             return None
 
@@ -644,10 +520,6 @@ class controller_MPI(Controller):
             for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
                 C.pre_iteration_processing(self, self.S, comm=comm)
 
-            if self.params.use_iteration_estimator:
-                # store previous iterate to compute difference later on
-                self.S.levels[0].uold[1:] = self.S.levels[0].u[1:]
-
             if len(self.S.levels) > 1:  # MLSDC or PFASST
                 self.S.status.stage = 'IT_DOWN'
             else:
@@ -657,24 +529,13 @@ class controller_MPI(Controller):
                     self.S.status.stage = 'IT_COARSE'  # serial MSSDC (Gauss-like)
 
         else:
-            if not self.params.use_iteration_estimator:
-                # Need to finish all pending isend requests. These will occur for the first active process, since
-                # in the last iteration the wait statement will not be called ("send and forget")
-                for req in self.req_send:
-                    if req is not None:
-                        req.Wait()
-                if self.req_status is not None:
-                    self.req_status.Wait()
-                if self.req_diff is not None:
-                    self.req_diff.Wait()
-            else:
-                for req in self.req_send:
-                    if req is not None:
-                        req.Cancel()
-                if self.req_status is not None:
-                    self.req_status.Cancel()
-                if self.req_diff is not None:
-                    self.req_diff.Cancel()
+            # Need to finish all pending isend requests. These will occur for the first active process, since
+            # in the last iteration the wait statement will not be called ("send and forget")
+            for req in self.req_send:
+                if req is not None:
+                    req.Wait()
+            if self.req_status is not None:
+                self.req_status.Wait()
 
             for hook in self.hooks:
                 hook.post_step(step=self.S, level_number=0)

--- a/pySDC/tests/test_controllers/test_controller_conformance.py
+++ b/pySDC/tests/test_controllers/test_controller_conformance.py
@@ -25,12 +25,13 @@ What this file deliberately does NOT duplicate:
 Axes marked ``xfail`` are known asymmetries with a documented cause. They are strict, so fixing one
 without removing its marker fails the suite: the marker is a to-do list, not a suppression.
 
-A note on the iteration estimator, since that asymmetry is not the obvious shape.
-``controller_MPI`` implements it inline, ``controller_nonMPI`` not at all, and the supported
-route is a third thing -- the ``CheckIterationEstimatorNonMPI`` convergence controller, which
-tutorial step_8 C exercises. Only that third one is tested: nothing in the repository ever sets
-``use_iteration_estimator`` to ``True``, and switching it on under MPI deadlocks. So this file
-covers the virtual half of that axis only and never launches the MPI implementation.
+A note on the iteration estimator, since that axis asserts something weaker than parity.
+``controller_MPI`` used to implement it inline while ``controller_nonMPI`` did not implement it at
+all, and the supported route was a third thing -- the ``CheckIterationEstimatorNonMPI`` convergence
+controller, which tutorial step_8 C exercises. Only that third one ever worked, so the inline
+implementation was removed and both controllers now refuse the parameter identically. The
+convergence controller remains nonMPI-only, so the *feature* is still not symmetric; what the axis
+pins is that the two controllers no longer disagree in silence.
 """
 
 import os
@@ -78,7 +79,7 @@ class RecursionProbe(ConvergenceController):
         return None
 
 
-def get_description(config, errtol=None):
+def get_description(config):
     """Single-level IMEX SDC, or the same problem as two-level MLSDC/PFASST."""
     from pySDC.implementations.problem_classes.HeatEquation_ND_FD import heatNd_forced
     from pySDC.implementations.sweeper_classes.imex_1st_order import imex_1st_order
@@ -97,12 +98,10 @@ def get_description(config, errtol=None):
         description['sweeper_params']['num_nodes'] = [3, 2]
         description['space_transfer_class'] = mesh_to_mesh
         description['space_transfer_params'] = {'rorder': 2, 'iorder': 6}
-    if errtol is not None:
-        description['step_params']['errtol'] = errtol
     return description
 
 
-def run(useMPI, config='single_level', probe=False, errtol=None, num_procs=NUM_PROCS):
+def run(useMPI, config='single_level', probe=False, num_procs=NUM_PROCS):
     """
     Run one configuration through one of the two transports and return everything the axes compare.
 
@@ -111,11 +110,8 @@ def run(useMPI, config='single_level', probe=False, errtol=None, num_procs=NUM_P
     """
     from pySDC.helpers.stats_helper import get_sorted
 
-    description = get_description(config, errtol=errtol)
+    description = get_description(config)
     controller_params = {'logger_level': 30}
-    if errtol is not None:
-        controller_params['use_iteration_estimator'] = True
-        controller_params['all_to_done'] = False
     if probe:
         description['convergence_controllers'] = {RecursionProbe: {}}
 
@@ -145,6 +141,33 @@ def run(useMPI, config='single_level', probe=False, errtol=None, num_procs=NUM_P
         'block_calls': probes[0].block_calls if probes else -1,
         'iters_seen': len({it for _, it in probes[0].calls}) if probes else -1,
     }
+
+
+def iteration_estimator_rejected(useMPI, num_procs=NUM_PROCS):
+    """
+    Ask a controller to build with ``use_iteration_estimator`` and report whether it refused.
+
+    Returns:
+        bool: True if the controller raised rather than accepting the parameter
+    """
+    from pySDC.core.errors import ControllerError
+
+    description = get_description('single_level')
+    controller_params = {'logger_level': 30, 'use_iteration_estimator': True}
+
+    try:
+        if useMPI:
+            from mpi4py import MPI
+            from pySDC.implementations.controller_classes.controller_MPI import controller_MPI
+
+            controller_MPI(comm=MPI.COMM_WORLD, controller_params=controller_params, description=description)
+        else:
+            from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
+
+            controller_nonMPI(num_procs=num_procs, controller_params=controller_params, description=description)
+    except ControllerError:
+        return True
+    return False
 
 
 CASES = {
@@ -181,6 +204,7 @@ def results(tmp_path_factory):
     for name, kwargs in CASES.items():
         mpi = {k.split('/', 1)[1]: loaded[k] for k in loaded.files if k.startswith(f'{name}/')}
         out_dict[name] = (run(useMPI=False, **kwargs), mpi)
+    out_dict['estimator_rejected_mpi'] = bool(loaded['estimator/rejected'])
     return out_dict
 
 
@@ -267,27 +291,23 @@ def test_block_hook_fires_once_per_iteration(results):
         )
 
 
-@pytest.mark.base
-@pytest.mark.xfail(strict=True, reason='use_iteration_estimator is implemented in controller_MPI only')
-def test_iteration_estimator_is_honoured():
+@pytest.mark.mpi4py
+def test_iteration_estimator_flag_treated_identically(results):
     """
-    ``use_iteration_estimator`` must do something, whichever controller is asked.
+    Both controllers must do the same thing with ``use_iteration_estimator``.
 
-    It is declared in the base controller's parameters, so *both* controllers accept it, but only
-    ``controller_MPI`` reads it. ``controller_nonMPI`` silently ignores the request and runs to
-    ``maxiter``, with no error and no warning -- the same description, two different programs.
+    They did not. It is declared in the *base* controller's parameters, so both accepted it, but only
+    ``controller_MPI`` read it -- and that implementation was never switched on anywhere, had no
+    tests, and deadlocked when used. ``controller_nonMPI`` ignored the flag in silence and ran to
+    ``maxiter``. Same description, two different programs, no error either way.
 
-    This asks only whether the flag changes the virtual controller's behaviour, and deliberately
-    does not run the MPI implementation: switching that one on deadlocks (see the module
-    docstring), and a hanging test is worse than a missing one.
+    Both now refuse it and point at the ``CheckIterationEstimatorNonMPI`` convergence controller,
+    which is the route that actually works. That is agreement, not yet parity: the convergence
+    controller is still nonMPI-only, which is the next thing to fix. Refusing loudly is what makes
+    the remaining gap visible instead of silent.
     """
-    without = run(useMPI=False)['niter']
-    with_estimator = run(useMPI=False, errtol=1e-7)['niter']
-
-    assert not np.array_equal(without, with_estimator), (
-        'use_iteration_estimator=True changed nothing in controller_nonMPI: '
-        f'{without[:, 1].tolist()} iterations either way'
-    )
+    assert iteration_estimator_rejected(useMPI=False), 'controller_nonMPI accepted use_iteration_estimator'
+    assert results['estimator_rejected_mpi'], 'controller_MPI accepted use_iteration_estimator'
 
 
 if __name__ == '__main__':
@@ -298,6 +318,7 @@ if __name__ == '__main__':
     for _name, _kwargs in CASES.items():
         _result = run(useMPI=True, **_kwargs)
         _payload.update({f'{_name}/{_k}': _v for _k, _v in _result.items()})
+    _payload['estimator/rejected'] = iteration_estimator_rejected(useMPI=True)
 
     if MPI.COMM_WORLD.rank == 0:
         np.savez(_out, **_payload)


### PR DESCRIPTION
Follow-up to #677, which added the conformance suite and marked this asymmetry `xfail(strict)`. This fixes it and removes the marker.

## The asymmetry

`use_iteration_estimator` is declared in the **base** controller parameters, so both controllers accept it — but only `controller_MPI` read it. `controller_nonMPI` ignored the request in silence and ran to `maxiter`. Same description, two different programs, no error either way.

## Why the MPI implementation goes rather than gets ported

Three things turned up when I looked at it:

- **Nothing in the repository ever sets it to `True`.** Every occurrence is `False` or commented out. There are no tests.
- **It deadlocks when switched on.** At `SPREAD`, every rank except the last posts `Ibcast(root=size-1)`. The last rank only posts a matching broadcast if the estimate happens to fire — so converge on the residual first and that collective is never matched. Cleanup then calls `Cancel()` on it, which is not valid for a nonblocking collective. I hit this while writing #677's test, which is why that test covers only the virtual half and never launches the MPI path.
- **The route that works is a third thing** — the `CheckIterationEstimatorNonMPI` convergence controller, exercised by `pySDC/tutorial/step_8/C_iteration_estimator.py`.

So there was nothing worth porting *from*. The implementation is removed: **117 lines across 25 sites**, `controller_MPI.py` 656 → 539 non-blank lines.

## What replaces it

`use_iteration_estimator=True` now raises from the base `Controller`, so both controllers refuse it identically and the message names the deadlock and points at the convergence controller.

**This is agreement, not parity**, and both the test and the module docstring say so. The convergence controller is still nonMPI-only, so the *feature* remains asymmetric. Refusing loudly is what makes that gap visible instead of silent. Giving it a real MPI path is the next PR — the block hook from #677 is the natural home, where a single `comm.Scan(MAX)` gives the prefix-max the estimator needs, instead of the unmatched broadcast.

## Collateral

`wait_with_interrupt` → `wait_for_request`, reduced to a plain wait. The interrupt it polled for *was* the estimator's broadcast; with that gone the method was a busy-wait with an empty body followed by `Wait()`. Callers still honour `force_done`, which `adaptivity.py`, `switch_estimator.py` and others set between stages — I left those guards alone rather than widen this PR.

Note it had a caller outside `controller_MPI` (`pySDC/core/check_convergence.py`), updated here.

The cut also left a dangling `else:` — the removed interrupt block was the `if` half of a conditional whose `else` held the normal stage switcher. Switcher dedented, `else` dropped.

## Testing

233 passed across `test_controllers`, `test_convergence_controllers`, `test_step_8` and `tests_core` (base + mpi4py); `ruff` and `black` clean. `test_controller_conformance.py::test_iteration_estimator_flag_treated_identically` replaces the xfail and asserts both controllers refuse, with the MPI half folded into the existing single `mpirun` launch rather than adding another.

🤖 Generated with [Claude Code](https://claude.com/claude-code)