### PR TITLE
Let the iteration estimator run with one step per rank

### DIFF
--- a/pySDC/implementations/convergence_controller_classes/check_iteration_estimator.py
+++ b/pySDC/implementations/convergence_controller_classes/check_iteration_estimator.py
@@ -1,26 +1,58 @@
 import numpy as np
-from pySDC.core.convergence_controller import ConvergenceController, Status
+
+from pySDC.core.convergence_controller import ConvergenceController
 from pySDC.implementations.convergence_controller_classes.store_uold import StoreUOld
 
 
-class CheckIterationEstimatorNonMPI(ConvergenceController):
-    def __init__(self, controller, params, description, **kwargs):
+class CheckIterationEstimator(ConvergenceController):
+    r"""
+    Stop iterating once an estimate says the desired tolerance has been reached.
+
+    The estimate is the standard contraction argument. With :math:`d_k` the largest change between
+    the last two iterates,
+
+    .. math::
+        \tilde{L} = \min\left(\frac{d_k}{d_{k-1}}, 0.9\right), \quad
+        \alpha = \frac{d_1}{1 - \tilde{L}}, \quad
+        K = 1.05 \frac{\log(\text{errtol} / \alpha)}{\log \tilde{L}},
+
+    and once :math:`\lceil K \rceil` is no larger than the current iteration the block stops.
+
+    :math:`d_k` is the largest change anywhere in the block, so every step reaches the same verdict at
+    the same iteration. That maximum is the only thing here that is not step-local, and it is all the
+    two transports do differently: an ``MPI_Allreduce`` with ``MPI_MAX`` when there is one step per
+    rank, and a maximum over the steps when the block is in one process.
+
+    Taking it over the whole block rather than over the steps up to the one asking is what makes the
+    two agree. Checking convergence is a pass over the steps in order, so a verdict reached at the
+    last step arrives too late for the steps already visited, and the block would run an extra
+    iteration that the same problem on one step per rank does not -- a collective reaches every rank
+    at once, a loop does not. The maximum is therefore taken on the first step visited, which is also
+    the only moment it can be taken: `StoreUOld` overwrites ``uold`` step by step as the block is
+    walked, so by the last step the earlier ones can no longer say how far they moved.
+
+    Everything else lives on the steps rather than on this object, which is what lets one class serve
+    both transports -- an object here is shared by a whole block in one case and private to a rank in
+    the other.
+    """
+
+    def setup(self, controller, params, description, **kwargs):
         """
-        Initialization routine
+        Define default parameters here.
 
         Args:
             controller (pySDC.Controller): The controller
             params (dict): Parameters for the convergence controller
             description (dict): The description object used to instantiate the controller
+
+        Returns:
+            dict: The updated parameters
         """
-        super(CheckIterationEstimatorNonMPI, self).__init__(controller, params, description)
-        self.buffers = Status(["Kest_loc", "diff_new", "Ltilde_loc"])
-        self.status = Status(["diff_old_loc", "diff_first_loc"])
+        return {'control_order': -50, **super().setup(controller, params, description, **kwargs)}
 
     def check_parameters(self, controller, params, description, **kwargs):
         """
-        Check whether parameters are compatible with whatever assumptions went into the step size functions etc.
-        In this case, we need the user to supply a tolerance.
+        Check whether we have a tolerance to aim for, and whether the run is shaped so we can.
 
         Args:
             controller (pySDC.Controller): The controller
@@ -31,31 +63,21 @@ class CheckIterationEstimatorNonMPI(ConvergenceController):
             bool: Whether the parameters are compatible
             str: The error message
         """
-        if "errtol" not in params.keys():
-            return (
-                False,
-                "Please give the iteration estimator a tolerance in the form of `errtol`. Thanks!",
+        if 'errtol' not in params.keys():
+            return False, 'Please give the iteration estimator a tolerance in the form of `errtol`. Thanks!'
+
+        if self.params.useMPI and not controller.params.all_to_done:
+            return False, (
+                'The iteration estimator predicts when the whole block has converged and stops it in '
+                'one go, so every rank has to take part in every iteration for the running maximum to '
+                'be well defined. Please set `all_to_done = True` in the controller parameters.'
             )
 
-        return True, ""
-
-    def setup(self, controller, params, description, **kwargs):
-        """
-        Setup parameters. Here we only give a default value for the control order.
-
-        Args:
-            controller (pySDC.Controller): The controller
-            params (dict): Parameters for the convergence controller
-            description (dict): The description object used to instantiate the controller
-
-        Returns:
-            dict: The updated parameters
-        """
-        return {"control_order": -50, **super().setup(controller, params, description, **kwargs)}
+        return True, ''
 
     def dependencies(self, controller, description, **kwargs):
         """
-        Need to store the solution of previous iterations.
+        Need the solution of the previous iteration, and a maximum under MPI.
 
         Args:
             controller (pySDC.Controller): The controller
@@ -65,25 +87,32 @@ class CheckIterationEstimatorNonMPI(ConvergenceController):
             None
         """
         controller.add_convergence_controller(StoreUOld, description=description)
+
+        if self.params.useMPI:
+            from mpi4py import MPI
+
+            self.MPI_MAX = MPI.MAX
+
+        super().dependencies(controller, description, **kwargs)
         return None
 
-    def reset_buffers_nonMPI(self, controller, **kwargs):
+    @staticmethod
+    def local_difference(S):
         """
-        Reset buffers used to immitate communication in non MPI version.
+        How far this step moved in the last iteration.
 
         Args:
-            controller (pySDC.controller): The controller
+            S (pySDC.Step): The step to measure
 
         Returns:
-            None
+            float: the largest change across the collocation nodes
         """
-        self.buffers.Kest_loc = [99] * len(controller.MS)
-        self.buffers.diff_new = 0.0
-        self.buffers.Ltilde_loc = 0.0
+        L = S.levels[0]
+        return max(abs(L.uold[m] - L.u[m]) for m in range(1, L.sweep.coll.num_nodes + 1))
 
     def setup_status_variables(self, controller, **kwargs):
         """
-        Setup storage variables for the differences between sweeps for all steps.
+        Store the differences on the steps, where they belong.
 
         Args:
             controller (pySDC.Controller): The controller
@@ -91,46 +120,62 @@ class CheckIterationEstimatorNonMPI(ConvergenceController):
         Returns:
             None
         """
-        self.status.diff_old_loc = [0.0] * len(controller.MS)
-        self.status.diff_first_loc = [0.0] * len(controller.MS)
+        self.add_status_variable_to_step('diff_local', 0.0)
+        self.add_status_variable_to_step('diff_block', 0.0)
+        self.add_status_variable_to_step('diff_old', 0.0)
+        self.add_status_variable_to_step('diff_first', 0.0)
         return None
 
-    def check_iteration_status(self, controller, S, **kwargs):
+    def check_iteration_status(self, controller, S, comm=None, **kwargs):
         """
+        Estimate the number of iterations still needed and stop the block if it has had enough.
+
         Args:
             controller (pySDC.Controller): The controller
-            S (pySDC.step): The current step
+            S (pySDC.Step): The current step
+            comm (mpi4py.MPI.Intracomm): Communicator, or None when the block is in one process
 
         Returns:
             None
         """
         L = S.levels[0]
-        slot = S.status.slot
+        S.status.diff_local = self.local_difference(S)
 
-        # find the global maximum difference between iterations
-        for m in range(1, L.sweep.coll.num_nodes + 1):
-            self.buffers.diff_new = max(self.buffers.diff_new, abs(L.uold[m] - L.u[m]))
+        if comm is not None:
+            diff_new = comm.allreduce(S.status.diff_local, op=self.MPI_MAX)
+        else:
+            block = kwargs.get('MS', controller.steps)
+            # Every step has to reach the same verdict in the same pass, so the maximum is taken over
+            # the whole block and taken once. It has to be taken here, on the first step visited,
+            # because `StoreUOld` overwrites `uold` step by step as the block is walked -- by the time
+            # the last step is visited the earlier ones can no longer say how far they moved. Handing
+            # the answer to every step keeps it off this object, which a whole block shares.
+            if S.status.slot == block[0].status.slot:
+                diff_block = max(self.local_difference(T) for T in block)
+                for T in block:
+                    T.status.diff_block = diff_block
+            diff_new = S.status.diff_block
 
         if S.status.iter == 1:
-            self.status.diff_old_loc[slot] = self.buffers.diff_new
-            self.status.diff_first_loc[slot] = self.buffers.diff_new
+            S.status.diff_old = diff_new
+            S.status.diff_first = diff_new
         elif S.status.iter > 1:
-            # approximate contraction factor
-            self.buffers.Ltilde_loc = min(self.buffers.diff_new / self.status.diff_old_loc[slot], 0.9)
-
-            self.status.diff_old_loc[slot] = self.buffers.diff_new
-
-            # estimate how many more iterations we need for this step to converge to the desired tolerance
-            alpha = 1 / (1 - self.buffers.Ltilde_loc) * self.status.diff_first_loc[slot]
-            self.buffers.Kest_loc = np.log(self.params.errtol / alpha) / np.log(self.buffers.Ltilde_loc) * 1.05
-            self.logger.debug(
-                f'LOCAL: {L.time:8.4f}, {S.status.iter}: {int(np.ceil(self.buffers.Kest_loc))}, '
-                f'{self.buffers.Ltilde_loc:8.6e}, {self.buffers.Kest_loc:8.6e}, \
-{self.buffers.Ltilde_loc ** S.status.iter * alpha:8.6e}'
+            Ltilde_loc = min(diff_new / S.status.diff_old, 0.9)
+            S.status.diff_old = diff_new
+            alpha = 1 / (1 - Ltilde_loc) * S.status.diff_first
+            Kest_loc = np.log(self.params.errtol / alpha) / np.log(Ltilde_loc) * 1.05  # Safety factor!
+            self.debug(
+                f'LOCAL: {L.time:8.4f}, {S.status.iter}: {int(np.ceil(Kest_loc))}, '
+                f'{Ltilde_loc:8.6e}, {Kest_loc:8.6e}, {Ltilde_loc ** S.status.iter * alpha:8.6e}',
+                S,
             )
 
-            # set global Kest as last local one, force stop if done
-            if S.status.last:
-                Kest_glob = self.buffers.Kest_loc
-                if np.ceil(Kest_glob) <= S.status.iter:
-                    S.status.force_done = True
+            # every step saw the same maximum, so every step reaches the same verdict
+            if np.ceil(Kest_loc) <= S.status.iter:
+                S.status.force_done = True
+
+        return None
+
+
+# the estimator used to be available only with the whole block in one process, and was named for it
+CheckIterationEstimatorNonMPI = CheckIterationEstimator

--- a/pySDC/tests/test_controllers/test_controller_conformance.py
+++ b/pySDC/tests/test_controllers/test_controller_conformance.py
@@ -25,13 +25,13 @@ What this file deliberately does NOT duplicate:
 Axes marked ``xfail`` are known asymmetries with a documented cause. They are strict, so fixing one
 without removing its marker fails the suite: the marker is a to-do list, not a suppression.
 
-A note on the iteration estimator, since that axis asserts something weaker than parity.
+A note on the iteration estimator, which took three goes to make symmetric.
 ``controller_MPI`` used to implement it inline while ``controller_nonMPI`` did not implement it at
-all, and the supported route was a third thing -- the ``CheckIterationEstimatorNonMPI`` convergence
-controller, which tutorial step_8 C exercises. Only that third one ever worked, so the inline
-implementation was removed and both controllers now refuse the parameter identically. The
-convergence controller remains nonMPI-only, so the *feature* is still not symmetric; what the axis
-pins is that the two controllers no longer disagree in silence.
+all, and the supported route was a third thing -- a convergence controller that only ran with the
+whole block in one process. The inline one was never switched on anywhere and deadlocked when it
+was, so it went; the ``use_iteration_estimator`` parameter now raises in both controllers alike; and
+the convergence controller serves both transports. Two axes cover it here: that the parameter is
+refused identically, and that the estimator itself stops the block at the same point either way.
 """
 
 import os
@@ -101,7 +101,7 @@ def get_description(config):
     return description
 
 
-def run(useMPI, config='single_level', probe=False, num_procs=NUM_PROCS):
+def run(useMPI, config='single_level', probe=False, errtol=None, num_procs=NUM_PROCS):
     """
     Run one configuration through one of the two transports and return everything the axes compare.
 
@@ -112,8 +112,19 @@ def run(useMPI, config='single_level', probe=False, num_procs=NUM_PROCS):
 
     description = get_description(config)
     controller_params = {'logger_level': 30}
+    convergence_controllers = {}
     if probe:
-        description['convergence_controllers'] = {RecursionProbe: {}}
+        convergence_controllers[RecursionProbe] = {}
+    if errtol is not None:
+        from pySDC.implementations.convergence_controller_classes.check_iteration_estimator import (
+            CheckIterationEstimator,
+        )
+
+        convergence_controllers[CheckIterationEstimator] = {'errtol': errtol}
+        # the estimator stops the whole block at once, so the block has to iterate as one
+        controller_params['all_to_done'] = True
+    if convergence_controllers:
+        description['convergence_controllers'] = convergence_controllers
 
     if useMPI:
         from mpi4py import MPI
@@ -174,6 +185,7 @@ CASES = {
     'baseline_single': {'config': 'single_level'},
     'baseline_multi': {'config': 'multi_level'},
     'probe': {'config': 'single_level', 'probe': True},
+    'estimator': {'config': 'single_level', 'errtol': 1e-7},
 }
 
 
@@ -308,6 +320,47 @@ def test_iteration_estimator_flag_treated_identically(results):
     """
     assert iteration_estimator_rejected(useMPI=False), 'controller_nonMPI accepted use_iteration_estimator'
     assert results['estimator_rejected_mpi'], 'controller_MPI accepted use_iteration_estimator'
+
+
+@pytest.mark.mpi4py
+def test_iteration_estimator_agrees(results):
+    """
+    The iteration estimator must stop the block at the same point in either transport.
+
+    This is the parity the previous two PRs did not have. The estimator used to exist twice -- inline
+    in ``controller_MPI``, which was never switched on and deadlocked, and as a convergence controller
+    that only ran with the whole block in one process. The inline one is gone and the convergence
+    controller now serves both, taking its running maximum from an ``MPI_Scan`` when there is one step
+    per rank and from the steps up to this one when there is not.
+
+    Stopping early on an estimate is exactly where the two transports could disagree without anything
+    looking wrong -- the run still converges, just after a different number of iterations -- so this
+    compares the iteration counts and not only the answer.
+    """
+    serial, mpi = results['estimator']
+
+    assert np.array_equal(serial['niter'], mpi['niter']), (
+        f'the estimator stopped at different points: virtual {serial["niter"][:, 1].tolist()} '
+        f'vs MPI {mpi["niter"][:, 1].tolist()}'
+    )
+    assert np.allclose(
+        serial['uend'], mpi['uend'], atol=ATOL, rtol=RTOL
+    ), f'uend differs by {np.max(np.abs(serial["uend"] - mpi["uend"])):.3e} > {ATOL:.0e}'
+
+
+@pytest.mark.base
+def test_iteration_estimator_actually_stops_early():
+    """
+    The estimator has to change the answer, or the parity test above proves nothing.
+
+    An estimator that never fires would make both transports agree trivially.
+    """
+    without = run(useMPI=False)['niter'][:, 1]
+    with_estimator = run(useMPI=False, errtol=1e-7)['niter'][:, 1]
+
+    assert with_estimator.max() < without.max(), (
+        f'the estimator did not save any iterations: {without.tolist()} without, ' f'{with_estimator.tolist()} with'
+    )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Last of three. #677 added the conformance suite and marked this asymmetry, #678 removed the broken half, and this closes it: the iteration estimator now works in both transports and stops the block at the same iteration either way.

## What was wrong

The estimator existed twice and worked once.

- `controller_MPI` had an inline copy that was never switched on anywhere, had no tests, and deadlocked when used. Removed in #678.
- The `CheckIterationEstimatorNonMPI` convergence controller worked, and tutorial step_8 C exercises it — but only with the whole block in one process. It took its running maximum from a buffer on itself, accumulated as the block was walked, which is a thing a rank cannot do: an object here is shared by a whole block in one case and private to a rank in the other.

## What it looks like now

One implementation, `CheckIterationEstimator`. The only quantity that is not step-local is the largest change anywhere in the block:

| transport | reduction |
|---|---|
| one step per rank | `MPI_Allreduce` with `MPI_MAX` |
| block in one process | maximum over the steps |

Everything else — `diff_local`, `diff_old`, `diff_first` — moved onto the steps via `add_status_variable_to_step`, where it belongs and where both transports reach it.

## The part that took three goes, because it is not obvious

My first version used `MPI_Scan`, a prefix maximum, which is the faithful translation of the old code. The estimator's inputs then matched **exactly** — I instrumented both sides and `diff_local` and `diff_old` agreed to every digit on every iteration — and it still stopped at 8 iterations against 6.

Checking convergence with the block in one process is a pass over the steps in order. A verdict reached at the last step arrives too late for the steps already visited in that pass, so the block runs one more iteration than the same problem on one step per rank: **a collective reaches every rank at once, a loop does not.** No amount of matching the arithmetic fixes that; the shape of the reduction has to change.

Taking the maximum over the whole block instead means every step holds the same number, reaches the same verdict in the same pass, and nothing has to be propagated between steps. It is taken on the *first* step visited, which is also the only moment it can be taken: `StoreUOld` overwrites `uold` step by step as the block is walked, so by the last step the earlier ones can no longer say how far they moved.

(An intermediate attempt reduced `force_done` inside `CheckConvergence` instead. It got to 7 against 6 and timed `test_step_8::test_A` out, because it ran `all(T.status.done ...)` inside the per-step loop where the not-yet-visited steps still hold last iteration's values. The controller already does that reduction correctly, afterwards. Reverted — and with the whole-block maximum it is not needed at all.)

## Requirement

Under MPI the estimator stops the whole block at once, so every rank has to take part in every iteration for the maximum to be defined. `check_parameters` asks for `all_to_done = True` with an explanation rather than assuming it. Nothing changes for the single-process case.

## Compatibility

`CheckIterationEstimatorNonMPI` stays as an alias. Tutorial step_8 C passes with its expected iteration counts unchanged, so no documented numbers move.

## Testing

**263 passed** across `test_controllers`, `test_convergence_controllers`, `test_tutorials` and `tests_core` (base + mpi4py); `ruff` and `black` clean.

Two new axes in the conformance suite, both folded into its existing single `mpirun` launch:

- `test_iteration_estimator_agrees` — the estimator stops at the same iteration and reaches the same answer in both transports. This is the parity the previous two PRs did not have, and it compares iteration counts rather than only the answer, since stopping early on an estimate is exactly where the two could disagree with nothing looking wrong.
- `test_iteration_estimator_actually_stops_early` — because an estimator that never fires would make both transports agree trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)