### PR TITLE
Make the two PFASST controllers read, and mean, the same thing

### DIFF
--- a/pySDC/implementations/controller_classes/controller_nonMPI.py
+++ b/pySDC/implementations/controller_classes/controller_nonMPI.py
@@ -514,21 +514,32 @@ class controller_nonMPI(Controller):
         for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
             C.post_iteration_processing_block(self, MS=local_MS_running)
 
+        # Either the block agrees or each step asks its predecessor -- never both, which is how
+        # `CheckConvergence` has always done it for one step per rank. The reduction is taken over the
+        # values every step arrived at, before any of them are overwritten, because that is what an
+        # `allreduce` does and the point is for the two to mean the same thing.
+        if self.params.all_to_done:
+            block_done = all(T.status.done for T in local_MS_running)
+            block_force_done = any(T.status.force_done for T in local_MS_running)
+
         for S in local_MS_running:
-            if not S.status.first:
+            if self.params.all_to_done:
+                for hook in self.hooks:
+                    hook.pre_comm(step=S, level_number=0)
+                S.status.done = block_done
+                S.status.force_done = block_force_done
+                for hook in self.hooks:
+                    hook.post_comm(step=S, level_number=0, add_to_stats=True)
+
+                S.status.done = S.status.done or S.status.force_done
+
+            elif not S.status.first:
                 for hook in self.hooks:
                     hook.pre_comm(step=S, level_number=0)
                 S.status.prev_done = S.prev.status.done  # "communicate"
                 for hook in self.hooks:
                     hook.post_comm(step=S, level_number=0, add_to_stats=True)
                 S.status.done = S.status.done and S.status.prev_done
-
-            if self.params.all_to_done:
-                for hook in self.hooks:
-                    hook.pre_comm(step=S, level_number=0)
-                S.status.done = all(T.status.done for T in local_MS_running)
-                for hook in self.hooks:
-                    hook.post_comm(step=S, level_number=0, add_to_stats=True)
 
             if not S.status.done:
                 # increment iteration count here (and only here)

--- a/pySDC/implementations/controller_classes/controller_nonMPI.py
+++ b/pySDC/implementations/controller_classes/controller_nonMPI.py
@@ -65,16 +65,19 @@ class controller_nonMPI(Controller):
         if self.nlevels == 0:
             raise ControllerError('need at least one level')
 
-        self.nsweeps = []
+        # The stages read `nsweeps` off a step they own, the same way `controller_MPI` reads it off
+        # the one step a rank has, so this only has to establish that any step will do.
         for nl in range(self.nlevels):
-            if all(S.levels[nl].params.nsweeps == self.MS[0].levels[nl].params.nsweeps for S in self.MS):
-                self.nsweeps.append(self.MS[0].levels[nl].params.nsweeps)
+            if not all(S.levels[nl].params.nsweeps == self.MS[0].levels[nl].params.nsweeps for S in self.MS):
+                raise ControllerError('all steps need to agree on the number of sweeps per level')
 
         # `it_coarse` sweeps the coarsest level exactly once. Single-level Gauss-like MSSDC routes
         # through it too, so reject multiple sweeps there as well instead of silently ignoring them.
         # `mssdc_jac` only decides the routing when there is more than one step: a single step is
         # plain SDC and always goes through `it_fine`, which honours nsweeps.
-        if self.nsweeps[-1] > 1 and (self.nlevels > 1 or (num_procs > 1 and not self.params.mssdc_jac)):
+        if self.MS[0].levels[-1].params.nsweeps > 1 and (
+            self.nlevels > 1 or (num_procs > 1 and not self.params.mssdc_jac)
+        ):
             raise ControllerError('this controller cannot do multiple sweeps on coarsest level')
 
         self.check_variable_coefficients(num_procs)
@@ -562,7 +565,9 @@ class controller_nonMPI(Controller):
         for S in local_MS_running:
             S.levels[0].status.sweep = 0
 
-        for k in range(self.nsweeps[0]):
+        nsweeps = local_MS_running[0].levels[0].params.nsweeps
+
+        for k in range(nsweeps):
             for S in local_MS_running:
                 S.levels[0].status.sweep += 1
 
@@ -570,7 +575,7 @@ class controller_nonMPI(Controller):
                 # send updated values forward
                 self.send_full(S, level=0)
                 # receive values
-                self.recv_full(S, level=0, add_to_stats=(k == self.nsweeps[0] - 1))
+                self.recv_full(S, level=0, add_to_stats=(k == nsweeps - 1))
 
             for S in local_MS_running:
                 # standard sweep workflow: update nodes, compute residual, log progress
@@ -602,7 +607,9 @@ class controller_nonMPI(Controller):
         for l in range(1, self.nlevels - 1):
             # sweep on middle levels (not on finest, not on coarsest, though)
 
-            for _ in range(self.nsweeps[l]):
+            nsweeps = local_MS_running[0].levels[l].params.nsweeps
+
+            for _ in range(nsweeps):
                 for S in local_MS_running:
                     # send updated values forward
                     self.send_full(S, level=l)
@@ -669,12 +676,14 @@ class controller_nonMPI(Controller):
 
             # on middle levels: do communication and sweep as usual
             if l - 1 > 0:
-                for k in range(self.nsweeps[l - 1]):
+                nsweeps = local_MS_running[0].levels[l - 1].params.nsweeps
+
+                for k in range(nsweeps):
                     for S in local_MS_running:
                         # send updated values forward
                         self.send_full(S, level=l - 1)
                         # receive values
-                        self.recv_full(S, level=l - 1, add_to_stats=(k == self.nsweeps[l - 1] - 1))
+                        self.recv_full(S, level=l - 1, add_to_stats=(k == nsweeps - 1))
 
                     for S in local_MS_running:
                         for hook in self.hooks:


### PR DESCRIPTION
Two commits toward the two PFASST controllers reading alike. Both verified behaviour-neutral, one of them unexpectedly so.

## 1. Read `nsweeps` off a step, the way the MPI controller does

`controller_nonMPI` cached per-level sweep counts in `self.nsweeps` at construction; `controller_MPI` reads them off the one step a rank owns. Same value, two idioms:

```python
for k in range(self.nsweeps[0]):                    # nonMPI
nsweeps = self.S.levels[0].params.nsweeps           # MPI
```

The cached list goes. The check its construction was quietly performing — that every step agrees per level — stays and now says so: it previously had no `else`, so on disagreement it silently skipped a level and left `self.nsweeps[-1]` pointing at the wrong one.

## 2. Make `all_to_done` mean the same thing in both

`controller_nonMPI` ran the cascade **and then**, if `all_to_done` was set, overwrote the result with a reduction over the block. `CheckConvergence` has always done one **or** the other. And that reduction sat *inside* the per-step loop, so it saw earlier steps already cascaded and later ones not — order-dependent in a way an `allreduce` can never be.

A parameter kept specifically so a run can be compared against itself meant two different things in the two things being compared.

Now: either the block agrees or each step asks its predecessor, never both, with the reduction taken over the values every step arrived at before any are overwritten. `force_done` is ORd across the block too, which the virtual controller never did and the MPI one always has.

## Verification

Numerics pinned **before** any change across **44 configurations** — one and two levels, 1/2/4 steps, Jacobi and Gauss-Seidel MSSDC, single and multiple fine sweeps, both convergence modes — comparing `uend` and per-step iteration counts.

| after | changed |
|---|---|
| commit 1 | **0 / 44** |
| commit 2 | **0 / 44** |

Commit 2 was expected to cost bit-identical results and did not. Communication stats emission is identical too (44 `timing_comm` entries either way), which I checked separately because the hook path changes shape — pySDCs keyed stats were collapsing the duplicate pair anyway.

So the order-dependence was real but **latent**: it never bit anything reachable. Commit 2 is a correctness fix against a future case, not a present one.

251 passed across `test_controllers`, `test_convergence_controllers` and `test_hooks`; `ruff` and `black` clean. (`test_log_to_file::test_loggingMPI` errors locally for want of the `pytest-mpi` plugin — pre-existing, reproduces on master.)

## Effect on similarity, including where it went the wrong way

Weighted similarity of the two stage machines, ownership difference normalised away:

| stage | master | now |
|---|---|---|
| `it_fine` | 61% | **65%** |
| `it_down` | 55% | **65%** |
| `it_up` | 55% | **65%** |
| `it_check` | 49% | **47%** |
| weighted | 56% | **58%** |

`it_check` measures slightly *worse*, and that is not noise. Matching the MPI **meaning** adds code here — the pre-loop reduction, the `force_done` OR — while the MPI **implementation** of it lives in `CheckConvergence`, so its own `it_check` contains none of it. Semantic alignment and structural alignment are separate problems.

## What this unlocks

Hoisting the cascade into `CheckConvergence`, so both controllers share one implementation, was blocked precisely because the semantics differed. It is not now. That is the step that would actually close the `it_check` gap, and it is deliberately not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)