### PR TITLE
Write convergence communication once, for both controllers

### DIFF
--- a/pySDC/core/check_convergence.py
+++ b/pySDC/core/check_convergence.py
@@ -111,30 +111,56 @@ class CheckConvergence(ConvergenceController):
 
         return None
 
-    def communicate_convergence(self, controller, S, comm):
+    def communicate_convergence(self, controller, S, comm=None, **kwargs):
         """
-        Communicate the convergence status during `check_iteration_status` if MPI is used.
+        Share convergence status across the block.
+
+        Two ways to stop, and the same two whether the block is spread over ranks or sitting in one
+        process. Either every step has to agree, which is a reduction, or each step waits on its
+        predecessor, which is a cascade and is what lets an early step finish and drop out.
+
+        The only difference between the transports is how the neighbour is reached: an `allreduce`
+        and point-to-point messages with one step per rank, reading the other steps' status directly
+        when they are all here. Note the reduction is applied step by step in the second case rather
+        than all at once as `allreduce` does -- both operations are monotone, so the two agree.
 
         Args:
             controller (pySDC.Controller): The controller
             S (pySDC.Step.step): The current step
-            comm (mpi4py.MPI.Comm): MPI communicator
+            comm (mpi4py.MPI.Intracomm): Communicator, or None when the whole block is in one process
 
         Returns:
             None
         """
-        # Either gather information about all status or send forward own
+        block = kwargs.get('MS', controller.steps)
+
         if controller.params.all_to_done:
             for hook in controller.hooks:
                 hook.pre_comm(step=S, level_number=0)
-            S.status.done = comm.allreduce(sendobj=S.status.done, op=self.MPI_LAND)
-            S.status.force_done = comm.allreduce(sendobj=S.status.force_done, op=self.MPI_LOR)
+
+            if comm is None:
+                S.status.done = all(T.status.done for T in block)
+                S.status.force_done = any(T.status.force_done for T in block)
+            else:
+                S.status.done = comm.allreduce(sendobj=S.status.done, op=self.MPI_LAND)
+                S.status.force_done = comm.allreduce(sendobj=S.status.force_done, op=self.MPI_LOR)
+
             for hook in controller.hooks:
                 hook.post_comm(step=S, level_number=0, add_to_stats=True)
 
             S.status.done = S.status.done or S.status.force_done
 
         else:
+            if comm is None:
+                if not S.status.first:
+                    for hook in controller.hooks:
+                        hook.pre_comm(step=S, level_number=0)
+                    S.status.prev_done = S.prev.status.done
+                    for hook in controller.hooks:
+                        hook.post_comm(step=S, level_number=0, add_to_stats=True)
+                    S.status.done = S.status.done and S.status.prev_done
+                return None
+
             for hook in controller.hooks:
                 hook.pre_comm(step=S, level_number=0)
 

--- a/pySDC/core/convergence_controller.py
+++ b/pySDC/core/convergence_controller.py
@@ -381,6 +381,23 @@ class ConvergenceController(object):
 
         return None
 
+    def communicate_convergence(self, controller: 'Controller', S: 'Step', **kwargs: Any) -> None:
+        """
+        Share convergence status across the block, however the block happens to be spread out.
+
+        Called once per step after every step has decided for itself, which is the only point at
+        which a reduction over the block is meaningful. `CheckConvergence` is the one that does
+        something here.
+
+        Args:
+            controller (pySDC.Controller): The controller
+            S (pySDC.Step): The current step
+
+        Returns:
+            None
+        """
+        pass
+
     def post_spread_processing(self, controller: 'Controller', S: 'Step', **kwargs: Any) -> None:
         """
         This function is called at the end of the `SPREAD` stage in the controller

--- a/pySDC/implementations/controller_classes/controller_nonMPI.py
+++ b/pySDC/implementations/controller_classes/controller_nonMPI.py
@@ -514,32 +514,9 @@ class controller_nonMPI(Controller):
         for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
             C.post_iteration_processing_block(self, MS=local_MS_running)
 
-        # Either the block agrees or each step asks its predecessor -- never both, which is how
-        # `CheckConvergence` has always done it for one step per rank. The reduction is taken over the
-        # values every step arrived at, before any of them are overwritten, because that is what an
-        # `allreduce` does and the point is for the two to mean the same thing.
-        if self.params.all_to_done:
-            block_done = all(T.status.done for T in local_MS_running)
-            block_force_done = any(T.status.force_done for T in local_MS_running)
-
         for S in local_MS_running:
-            if self.params.all_to_done:
-                for hook in self.hooks:
-                    hook.pre_comm(step=S, level_number=0)
-                S.status.done = block_done
-                S.status.force_done = block_force_done
-                for hook in self.hooks:
-                    hook.post_comm(step=S, level_number=0, add_to_stats=True)
-
-                S.status.done = S.status.done or S.status.force_done
-
-            elif not S.status.first:
-                for hook in self.hooks:
-                    hook.pre_comm(step=S, level_number=0)
-                S.status.prev_done = S.prev.status.done  # "communicate"
-                for hook in self.hooks:
-                    hook.post_comm(step=S, level_number=0, add_to_stats=True)
-                S.status.done = S.status.done and S.status.prev_done
+            for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
+                C.communicate_convergence(self, S, MS=local_MS_running)
 
             if not S.status.done:
                 # increment iteration count here (and only here)

--- a/pySDC/implementations/convergence_controller_classes/adaptivity.py
+++ b/pySDC/implementations/convergence_controller_classes/adaptivity.py
@@ -35,10 +35,6 @@ class AdaptivityBase(ConvergenceController):
 
         controller.add_hook(LogStepSize)
 
-        from pySDC.core.check_convergence import CheckConvergence
-
-        self.communicate_convergence = CheckConvergence.communicate_convergence
-
         return {**defaults, **super().setup(controller, params, description, **kwargs)}
 
     def dependencies(self, controller, description, **kwargs):
@@ -253,7 +249,12 @@ class AdaptivityForConvergedCollocationProblems(AdaptivityBase):
             self.trigger_restart_upon_nonconvergence(S)
 
         if self.params.useMPI:
-            self.communicate_convergence(self, controller, S, **kwargs)
+            # borrow the reduction rather than storing it on the instance: an unbound function in an
+            # instance attribute shadows the hook of the same name, and needs an explicit `self` that
+            # nothing else in this API does
+            from pySDC.core.check_convergence import CheckConvergence
+
+            CheckConvergence.communicate_convergence(self, controller, S, **kwargs)
 
         self.res_last_iter = S.levels[0].status.residual * 1.0
 


### PR DESCRIPTION
Follow-up to #681, which made `all_to_done` mean the same thing in both controllers. That is what made this possible: while one cascaded *then* reduced and the other did either/or, there was nothing shared to hoist.

## The change

A block can stop two ways — every step agrees, or each step waits on its predecessor. Both were implemented twice: in `CheckConvergence` for one step per rank, and inline in `controller_nonMPI` for a block in one process. Only the means of reaching the neighbour differs:

| | reduction | cascade |
|---|---|---|
| one step per rank | `allreduce` | point-to-point |
| block in one process | read the other steps' status | read the predecessor's status |

`CheckConvergence.communicate_convergence` now handles both, and the controller reaches it through a hook on the base class, the same way it calls every other convergence-controller hook. **`controller_nonMPI.it_check` sheds 25 lines** and no longer implements convergence communication at all.

## It also fixes a trap in `Adaptivity`

Not incidental, and worth reading before approving. `Adaptivity` kept an **unbound function** in an instance attribute:

```python
self.communicate_convergence = CheckConvergence.communicate_convergence   # master
...
self.communicate_convergence(self, controller, S, **kwargs)               # explicit self
```

That works exactly as long as nothing else ever calls it by that name. The new hook does — on *every* convergence controller — so the borrowed copy swallowed the first argument and `test_InterpolateBetweenRestarts` failed with `missing 1 required positional argument`. It now borrows the implementation at the one MPI-only site that wants it, and leaves the name alone.

Worth noting the trap was already there: any future hook or subclass using that name would have hit it.

## Verification

- **0 of 44 configurations changed** — one and two levels, 1/2/4 steps, Jacobi and Gauss-Seidel MSSDC, single and multiple fine sweeps, both convergence modes; comparing `uend` and per-step iteration counts against a baseline captured before any of this work began.
- Communication stats emission identical.
- **260 passed** across `test_controllers`, `test_convergence_controllers`, `test_hooks`, `tests_core` and `test_step_8`. (`test_log_to_file::test_loggingMPI` errors locally for want of the `pytest-mpi` plugin — pre-existing, reproduces on master.)

## Effect

| stage | master (post-#681) | now |
|---|---|---|
| `it_check` | 56% | **68%** |
| weighted | 61% | **65%** |

`it_check` was the worst-matching stage and is now second-best. Measured with one consistent normaliser that erases the ownership difference; only same-normaliser numbers are comparable.

## One risk worth stating

The reduction is applied step by step in the virtual branch rather than all at once as `allreduce` does. `all` and `any` are monotone here so the two agree, and the 44-configuration probe confirms it — but that is an argument plus a sample, not a proof. Restoring an explicit pre-loop reduction costs two lines if you would rather not rely on the reasoning.

## What is left

The remaining difference between the two controllers is now mostly ownership plumbing — `send_full(S, level=0)` against `send_full(level=0)` — plus the `force_done` abort points that only the MPI bodies carry, and a genuinely different `predict`. The first is what `TimeComm.local_steps()` erases, and is already written on the unmerged `feat/timecomm-virtual`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)