### PR TITLE
Make ParaDiag an iteration rather than a controller, and cover Gauss-Seidel MSSDC

### DIFF
--- a/pySDC/core/controller.py
+++ b/pySDC/core/controller.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import sys
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Type
 import numpy as np
 
 from pySDC.core.base_transfer import BaseTransfer
@@ -336,6 +336,24 @@ class Controller(object):
                         f'step(s). Use a preconditioner with fixed coefficients, e.g. MIN-SR-S or LU.'
                     )
 
+    def step_is_active(self, time: float, block_start: float, Tend: float) -> bool:
+        """
+        Whether a step starting at `time`, in a block starting at `block_start`, still has work.
+
+        The default is that a step runs if it starts before the end of the interval, so a block
+        may be run partially. An algorithm that couples its steps too tightly to drop one of them
+        answers this from `block_start` instead and runs the block whole.
+
+        Args:
+            time (float): when this step starts
+            block_start (float): when the first step of this step's block starts
+            Tend (float): ending time
+
+        Returns:
+            bool: whether this step takes part
+        """
+        return time < Tend - 10 * np.finfo(float).eps
+
     def setup_convergence_controllers(self, description: Dict[str, Any]) -> None:
         '''
         Setup variables needed for convergence controllers, notably a list containing all of them and a list containing
@@ -431,137 +449,3 @@ class Controller(object):
         for hook in self.hooks:
             stats = {**stats, **hook.return_stats()}
         return stats
-
-
-class ParaDiagController(Controller):
-    """
-    What a ParaDiag controller needs on top of the controller it inherits its driver from.
-
-    This carries no `__init__` of its own. A concrete ParaDiag controller calls
-    `prepare_ParaDiag_params` on the two dictionaries and then hands them to the driver's
-    initialisation, so that ParaDiag can be mixed into either transport's controller without the
-    two having to agree on a constructor signature.
-    """
-
-    @staticmethod
-    def prepare_ParaDiag_params(controller_params: Dict[str, Any], description: Dict[str, Any]) -> None:
-        """
-        Check and complete the parameters ParaDiag needs, in place.
-
-        Call this *before* the controller's own initialisation: it only reads and writes the two
-        dictionaries, and must have run by the time the steps are built.
-
-        Args:
-            controller_params (dict): parameter set for the controller and the steps
-            description (dict): all the parameters to set up the rest (levels, problems, ...)
-        """
-        from pySDC.implementations.sweeper_classes.ParaDiagSweepers import QDiagonalization
-
-        if QDiagonalization in description['sweeper_class'].__mro__:
-            description['sweeper_params']['ignore_ic'] = True
-            description['sweeper_params']['update_f_evals'] = False
-        else:
-            logging.getLogger('controller').warning(
-                f'Warning: Your sweeper class {description["sweeper_class"]} is not derived from {QDiagonalization}. You probably want to use another sweeper class.'
-            )
-
-        if not controller_params.get('all_to_done', True):
-            raise NotImplementedError('ParaDiag only implemented with option `all_to_done=True`')
-        if 'alpha' not in controller_params.keys():
-            from pySDC.core.errors import ParameterError
-
-            raise ParameterError('Please supply alpha as a parameter to the ParaDiag controller!')
-        controller_params['average_jacobian'] = controller_params.get('average_jacobian', True)
-
-        controller_params['all_to_done'] = True
-
-    @staticmethod
-    def resolve_alpha(alpha: Any, k: int = 0) -> float:
-        """
-        Read the alpha for iteration `k` out of whatever the user supplied.
-
-        `alpha` may be a single number, a sequence indexed by iteration (the last entry is reused once
-        it runs out), or a callable taking the iteration index. Making it iteration dependent lets the
-        outer iteration start with a well-conditioned alpha and tighten it later.
-
-        Static because the steps need an alpha before the controller has parameters to read it from.
-
-        Args:
-            alpha: the alpha parameter as supplied by the user
-            k (int): iteration index
-
-        Returns:
-            float: alpha to use for this iteration
-        """
-        if callable(alpha):
-            return float(alpha(k))
-        if hasattr(alpha, '__len__'):
-            return float(alpha[min(k, len(alpha) - 1)])
-        return float(alpha)
-
-    def get_alpha(self, k: int = 0) -> float:
-        """
-        Get the ParaDiag alpha parameter for iteration `k`.
-
-        Args:
-            k (int): iteration index
-
-        Returns:
-            float: alpha to use for this iteration
-        """
-        return self.resolve_alpha(self.params.alpha, k)
-
-    def get_FFT_matrices(self, k: int = 0) -> Any:
-        """
-        Get the weighted FFT and iFFT matrices for iteration `k`, rebuilding them only when alpha
-        actually changes.
-
-        Args:
-            k (int): iteration index
-
-        Returns:
-            tuple: the forward and backward weighted FFT matrices
-        """
-        alpha = self.get_alpha(k)
-        if getattr(self, '_cached_alpha', None) != alpha:
-            from pySDC.helpers.ParaDiagHelper import get_weighted_FFT_matrix, get_weighted_iFFT_matrix
-
-            self._FFT_matrix = get_weighted_FFT_matrix(self.n_steps, alpha)
-            self._iFFT_matrix = get_weighted_iFFT_matrix(self.n_steps, alpha)
-            self._cached_alpha = alpha
-        return self._FFT_matrix, self._iFFT_matrix
-
-    def update_G_inv(self, k: int = 0) -> None:
-        """
-        Rebuild G^-1 on the local step(s) when alpha changes with the iteration.
-
-        G^-1 depends on alpha, so an iteration dependent alpha means the sweeper's diagonalization has
-        to be recomputed. Subclasses implement this because only they know which steps they own.
-
-        Args:
-            k (int): iteration index
-        """
-        raise NotImplementedError('ParaDiag controllers have to implement update_G_inv')
-
-    def FFT_in_time(self, quantity: Any, k: int = 0) -> None:
-        """
-        Compute weighted forward FFT in time. The weighting is determined by the alpha parameter in ParaDiag
-
-        Note: The implementation via matrix-vector multiplication may be inefficient and less stable compared to an FFT
-              with transposes!
-
-        Args:
-            quantity (str): the level attribute to transform
-            k (int): iteration index, for an iteration dependent alpha
-        """
-        self.apply_matrix(self.get_FFT_matrices(k)[0], quantity)
-
-    def iFFT_in_time(self, quantity: Any, k: int = 0) -> None:
-        """
-        Compute weighted backward FFT in time. The weighting is determined by the alpha parameter in ParaDiag
-
-        Args:
-            quantity (str): the level attribute to transform
-            k (int): iteration index, for an iteration dependent alpha
-        """
-        self.apply_matrix(self.get_FFT_matrices(k)[1], quantity)

--- a/pySDC/core/controller.py
+++ b/pySDC/core/controller.py
@@ -434,23 +434,26 @@ class Controller(object):
 
 
 class ParaDiagController(Controller):
+    """
+    What a ParaDiag controller needs on top of the controller it inherits its driver from.
 
-    def __init__(
-        self,
-        controller_params: Dict[str, Any],
-        description: Dict[str, Any],
-        n_steps: int,
-        useMPI: Optional[bool] = None,
-    ) -> None:
+    This carries no `__init__` of its own. A concrete ParaDiag controller calls
+    `prepare_ParaDiag_params` on the two dictionaries and then hands them to the driver's
+    initialisation, so that ParaDiag can be mixed into either transport's controller without the
+    two having to agree on a constructor signature.
+    """
+
+    @staticmethod
+    def prepare_ParaDiag_params(controller_params: Dict[str, Any], description: Dict[str, Any]) -> None:
         """
-        Initialization routine for ParaDiag controllers
+        Check and complete the parameters ParaDiag needs, in place.
+
+        Call this *before* the controller's own initialisation: it only reads and writes the two
+        dictionaries, and must have run by the time the steps are built.
 
         Args:
-           num_procs: number of parallel time steps (still serial, though), can be 1
-           controller_params: parameter set for the controller and the steps
-           description: all the parameters to set up the rest (levels, problems, transfer, ...)
-           n_steps (int): Number of parallel steps
-           alpha (float): alpha parameter for ParaDiag
+            controller_params (dict): parameter set for the controller and the steps
+            description (dict): all the parameters to set up the rest (levels, problems, ...)
         """
         from pySDC.implementations.sweeper_classes.ParaDiagSweepers import QDiagonalization
 
@@ -471,17 +474,34 @@ class ParaDiagController(Controller):
         controller_params['average_jacobian'] = controller_params.get('average_jacobian', True)
 
         controller_params['all_to_done'] = True
-        super().__init__(controller_params=controller_params, description=description, useMPI=useMPI)
 
-        self.n_steps: int = n_steps
-
-    def get_alpha(self, k: int = 0) -> float:
+    @staticmethod
+    def resolve_alpha(alpha: Any, k: int = 0) -> float:
         """
-        Get the ParaDiag alpha parameter for iteration `k`.
+        Read the alpha for iteration `k` out of whatever the user supplied.
 
         `alpha` may be a single number, a sequence indexed by iteration (the last entry is reused once
         it runs out), or a callable taking the iteration index. Making it iteration dependent lets the
         outer iteration start with a well-conditioned alpha and tighten it later.
+
+        Static because the steps need an alpha before the controller has parameters to read it from.
+
+        Args:
+            alpha: the alpha parameter as supplied by the user
+            k (int): iteration index
+
+        Returns:
+            float: alpha to use for this iteration
+        """
+        if callable(alpha):
+            return float(alpha(k))
+        if hasattr(alpha, '__len__'):
+            return float(alpha[min(k, len(alpha) - 1)])
+        return float(alpha)
+
+    def get_alpha(self, k: int = 0) -> float:
+        """
+        Get the ParaDiag alpha parameter for iteration `k`.
 
         Args:
             k (int): iteration index
@@ -489,12 +509,7 @@ class ParaDiagController(Controller):
         Returns:
             float: alpha to use for this iteration
         """
-        alpha = self.params.alpha
-        if callable(alpha):
-            return float(alpha(k))
-        if hasattr(alpha, '__len__'):
-            return float(alpha[min(k, len(alpha) - 1)])
-        return float(alpha)
+        return self.resolve_alpha(self.params.alpha, k)
 
     def get_FFT_matrices(self, k: int = 0) -> Any:
         """

--- a/pySDC/implementations/controller_classes/ParaDiag.py
+++ b/pySDC/implementations/controller_classes/ParaDiag.py
@@ -1,0 +1,235 @@
+import logging
+from typing import Any, Dict
+
+import numpy as np
+
+
+class ParaDiag:
+    """
+    What ParaDiag is, independently of how the block is spread over processes.
+
+    Mixed into a controller, this replaces its iteration and leaves everything around it alone:
+
+        class controller_ParaDiag_nonMPI(ParaDiag, controller_nonMPI)
+        class controller_ParaDiag_MPI(ParaDiag, controller_MPI)
+
+    It deliberately has no `__init__` and no controller of its own to inherit from, so that it can
+    be mixed into either transport's controller without the two having to agree on a constructor
+    signature. A concrete ParaDiag controller calls `prepare_ParaDiag_params` on the two
+    dictionaries and then hands them to its controller's initialisation.
+
+    What stays with the concrete classes is everything whose implementation depends on where the
+    other steps are: `apply_matrix`, `prepare_Jacobians`, `compute_all_at_once_residual`,
+    `update_G_inv` and the block driver.
+    """
+
+    @staticmethod
+    def prepare_ParaDiag_params(controller_params: Dict[str, Any], description: Dict[str, Any]) -> None:
+        """
+        Check and complete the parameters ParaDiag needs, in place.
+
+        Call this *before* the controller's own initialisation: it only reads and writes the two
+        dictionaries, and must have run by the time the steps are built.
+
+        Args:
+            controller_params (dict): parameter set for the controller and the steps
+            description (dict): all the parameters to set up the rest (levels, problems, ...)
+        """
+        from pySDC.implementations.sweeper_classes.ParaDiagSweepers import QDiagonalization
+
+        if QDiagonalization in description['sweeper_class'].__mro__:
+            description['sweeper_params']['ignore_ic'] = True
+            description['sweeper_params']['update_f_evals'] = False
+        else:
+            logging.getLogger('controller').warning(
+                f'Warning: Your sweeper class {description["sweeper_class"]} is not derived from {QDiagonalization}. You probably want to use another sweeper class.'
+            )
+
+        if not controller_params.get('all_to_done', True):
+            raise NotImplementedError('ParaDiag only implemented with option `all_to_done=True`')
+        if 'alpha' not in controller_params.keys():
+            from pySDC.core.errors import ParameterError
+
+            raise ParameterError('Please supply alpha as a parameter to the ParaDiag controller!')
+        controller_params['average_jacobian'] = controller_params.get('average_jacobian', True)
+
+        controller_params['all_to_done'] = True
+
+    # ------------------------------------------------------------------ the iteration
+
+    def get_stages(self) -> Dict[str, Any]:
+        """
+        ParaDiag has one iteration stage, and no predictor because it has no coarse level.
+
+        Returns:
+            dict: stage name -> the method that runs it
+        """
+        return {
+            'SPREAD': self.spread,
+            'IT_CHECK': self.it_check,
+            'IT_PARADIAG': self.it_ParaDiag,
+        }
+
+    def next_iteration_stage(self, S: Any) -> str:
+        """
+        Args:
+            S (pySDC.Step.step): The current step
+
+        Returns:
+            str: name of the stage to enter
+        """
+        return 'IT_PARADIAG'
+
+    def compute_residual_after_spread(self, S: Any) -> None:
+        """
+        ParaDiag's residual is the one of the composite collocation problem, which `it_ParaDiag`
+        computes as part of the iteration. The convergence check runs before the first iteration,
+        so the initial guess needs its residual here.
+
+        Args:
+            S (pySDC.Step.step): The current step
+        """
+        S.levels[0].sweep.compute_residual()
+
+    def step_is_active(self, time: float, block_start: float, Tend: float) -> bool:
+        """
+        ParaDiag diagonalizes across the whole block, so it cannot drop a step out of one. A block
+        that starts before `Tend` is run whole, past `Tend` if need be.
+
+        Args:
+            time (float): when this step starts
+            block_start (float): when the first step of this step's block starts
+            Tend (float): ending time
+
+        Returns:
+            bool: whether this step takes part
+        """
+        active = block_start < Tend - 10 * np.finfo(float).eps
+
+        if active and time >= Tend - 10 * np.finfo(float).eps:
+            self.logger.warning(
+                'Warning: This controller will solve past your desired end time until the end of its block!'
+            )
+
+        return active
+
+    def prepare_convergence_check(self, *args: Any, **kwargs: Any) -> None:
+        """
+        The residual is already current -- `it_ParaDiag` computed it, and recomputing it the way a
+        sweep-based algorithm does would need initial conditions that have not been communicated
+        yet. The end point is not, because nothing sent it anywhere, so compute it here: `it_check`
+        is what publishes `uend` when a step is done.
+
+        Takes whatever its controller passes -- a block of steps or a communicator -- and needs
+        none of it, because the steps to do this for are the ones this controller owns.
+        """
+        for S in self.steps:
+            S.levels[0].sweep.compute_end_point()
+
+    # ------------------------------------------------------------------ alpha and the transform
+
+    @staticmethod
+    def resolve_alpha(alpha: Any, k: int = 0) -> float:
+        """
+        Read the alpha for iteration `k` out of whatever the user supplied.
+
+        `alpha` may be a single number, a sequence indexed by iteration (the last entry is reused once
+        it runs out), or a callable taking the iteration index. Making it iteration dependent lets the
+        outer iteration start with a well-conditioned alpha and tighten it later.
+
+        Static because the steps need an alpha before the controller has parameters to read it from.
+
+        Args:
+            alpha: the alpha parameter as supplied by the user
+            k (int): iteration index
+
+        Returns:
+            float: alpha to use for this iteration
+        """
+        if callable(alpha):
+            return float(alpha(k))
+        if hasattr(alpha, '__len__'):
+            return float(alpha[min(k, len(alpha) - 1)])
+        return float(alpha)
+
+    def get_alpha(self, k: int = 0) -> float:
+        """
+        Get the ParaDiag alpha parameter for iteration `k`.
+
+        Args:
+            k (int): iteration index
+
+        Returns:
+            float: alpha to use for this iteration
+        """
+        return self.resolve_alpha(self.params.alpha, k)
+
+    def get_FFT_matrices(self, k: int = 0) -> Any:
+        """
+        Get the weighted FFT and iFFT matrices for iteration `k`, rebuilding them only when alpha
+        actually changes.
+
+        Args:
+            k (int): iteration index
+
+        Returns:
+            tuple: the forward and backward weighted FFT matrices
+        """
+        alpha = self.get_alpha(k)
+        if getattr(self, '_cached_alpha', None) != alpha:
+            from pySDC.helpers.ParaDiagHelper import get_weighted_FFT_matrix, get_weighted_iFFT_matrix
+
+            self._FFT_matrix = get_weighted_FFT_matrix(self.n_steps, alpha)
+            self._iFFT_matrix = get_weighted_iFFT_matrix(self.n_steps, alpha)
+            self._cached_alpha = alpha
+        return self._FFT_matrix, self._iFFT_matrix
+
+    def FFT_in_time(self, quantity: Any, k: int = 0) -> None:
+        """
+        Compute weighted forward FFT in time. The weighting is determined by the alpha parameter in ParaDiag
+
+        Note: The implementation via matrix-vector multiplication may be inefficient and less stable compared to an FFT
+              with transposes!
+
+        Args:
+            quantity (str): the level attribute to transform
+            k (int): iteration index, for an iteration dependent alpha
+        """
+        self.apply_matrix(self.get_FFT_matrices(k)[0], quantity)
+
+    def iFFT_in_time(self, quantity: Any, k: int = 0) -> None:
+        """
+        Compute weighted backward FFT in time. The weighting is determined by the alpha parameter in ParaDiag
+
+        Args:
+            quantity (str): the level attribute to transform
+            k (int): iteration index, for an iteration dependent alpha
+        """
+        self.apply_matrix(self.get_FFT_matrices(k)[1], quantity)
+
+    # ------------------------------------------------------------------ what the transport supplies
+
+    def apply_matrix(self, mat: Any, quantity: str) -> None:
+        """
+        Apply a square matrix across the steps, in place.
+
+        How this is done depends entirely on where the other steps are, so the concrete controllers
+        implement it.
+
+        Args:
+            mat: square matrix with as many rows as there are steps
+            quantity (str): 'residual' or 'increment', the level attribute to transform
+        """
+        raise NotImplementedError('ParaDiag controllers have to implement apply_matrix')
+
+    def update_G_inv(self, k: int = 0) -> None:
+        """
+        Rebuild G^-1 on the local step(s) when alpha changes with the iteration.
+
+        G^-1 depends on alpha, so an iteration dependent alpha means the sweeper's diagonalization has
+        to be recomputed. Subclasses implement this because only they know which steps they own.
+
+        Args:
+            k (int): iteration index
+        """
+        raise NotImplementedError('ParaDiag controllers have to implement update_G_inv')

--- a/pySDC/implementations/controller_classes/controller_MPI.py
+++ b/pySDC/implementations/controller_classes/controller_MPI.py
@@ -392,43 +392,6 @@ class controller_MPI(Controller):
             # do a fine sweep only
             self.S.levels[0].sweep.update_nodes()
 
-        # elif self.params.predict_type == 'libpfasst_style':
-        #
-        #     # restrict to coarsest level
-        #     for l in range(1, len(self.S.levels)):
-        #         self.S.transfer(source=self.S.levels[l - 1], target=self.S.levels[l])
-        #
-        #     self.hooks.pre_comm(step=self.S, level_number=len(self.S.levels) - 1)
-        #     if not self.S.status.first:
-        #         self.logger.debug('recv data predict: process %s, stage %s, time, %s, source %s, tag %s' %
-        #                           (self.S.status.slot, self.S.status.stage, self.S.time, self.S.prev,
-        #                            self.S.status.iter))
-        #         self.recv(target=self.S.levels[-1], source=self.S.prev, tag=self.S.status.iter, comm=comm)
-        #     self.hooks.post_comm(step=self.S, level_number=len(self.S.levels) - 1)
-        #
-        #     # do the sweep with new values
-        #     self.S.levels[-1].sweep.update_nodes()
-        #     self.S.levels[-1].sweep.compute_end_point()
-        #
-        #     self.hooks.pre_comm(step=self.S, level_number=len(self.S.levels) - 1)
-        #     if not self.S.status.last:
-        #         self.logger.debug('send data predict: process %s, stage %s, time, %s, target %s, tag %s' %
-        #                           (self.S.status.slot, self.S.status.stage, self.S.time, self.S.next,
-        #                            self.S.status.iter))
-        #         self.S.levels[-1].uend.isend(dest=self.S.next, tag=self.S.status.iter, comm=comm).Wait()
-        #     self.hooks.post_comm(step=self.S, level_number=len(self.S.levels) - 1, add_to_stats=True)
-        #
-        #     # go back to fine level, sweeping
-        #     for l in range(len(self.S.levels) - 1, 0, -1):
-        #         # prolong values
-        #         self.S.transfer(source=self.S.levels[l], target=self.S.levels[l - 1])
-        #         # on middle levels: do sweep as usual
-        #         if l - 1 > 0:
-        #             self.S.levels[l - 1].sweep.update_nodes()
-        #
-        #     # end with a fine sweep
-        #     self.S.levels[0].sweep.update_nodes()
-
         elif self.params.predict_type == 'pfasst_burnin':
             # restrict to coarsest level
             for l in range(1, len(self.S.levels)):

--- a/pySDC/implementations/controller_classes/controller_MPI.py
+++ b/pySDC/implementations/controller_classes/controller_MPI.py
@@ -76,6 +76,8 @@ class controller_MPI(Controller):
         for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
             C.setup_status_variables(self, comm=comm)
 
+        self.stages = self.get_stages()
+
     def run(self, u0, t0, Tend):
         """
         Main driver for running the parallel version of SDC, MSSDC, MLSDC and PFASST
@@ -344,7 +346,20 @@ class controller_MPI(Controller):
 
         self.logger.debug(stage + ' - process ' + str(self.S.status.slot))
 
-        switcher = {
+        self.stages.get(stage, self.default)(comm, num_procs)
+
+    def get_stages(self):
+        """
+        The stages this controller can be in, and what to run in each.
+
+        A subclass that iterates differently replaces the iteration stages here and says which one
+        to enter in `next_iteration_stage`; everything around the iteration is the same for any
+        algorithm this controller runs.
+
+        Returns:
+            dict: stage name -> the method that runs it
+        """
+        return {
             'SPREAD': self.spread,
             'PREDICT': self.predict,
             'IT_CHECK': self.it_check,
@@ -354,7 +369,22 @@ class controller_MPI(Controller):
             'IT_UP': self.it_up,
         }
 
-        switcher.get(stage, self.default)(comm, num_procs)
+    def next_iteration_stage(self, S):
+        """
+        The stage that starts one iteration of the algorithm.
+
+        Args:
+            S (pySDC.Step.step): The current step
+
+        Returns:
+            str: name of the stage to enter
+        """
+        if len(S.levels) > 1:  # MLSDC or PFASST
+            return 'IT_DOWN'
+        elif S.status.time_size == 1 or self.params.mssdc_jac:  # SDC or parallel MSSDC (Jacobi-like)
+            return 'IT_FINE'
+        else:
+            return 'IT_COARSE'  # serial MSSDC (Gauss-like)
 
     def spread(self, comm, num_procs):
         """
@@ -367,6 +397,8 @@ class controller_MPI(Controller):
 
         # call predictor from sweeper
         self.S.levels[0].sweep.predict()
+
+        self.compute_residual_after_spread(self.S)
 
         # update stage
         if len(self.S.levels) > 1:  # MLSDC or PFASST with predict
@@ -446,17 +478,7 @@ class controller_MPI(Controller):
         Key routine to check for convergence/termination
         """
 
-        # Update values to compute the residual
-        self.send_full(comm=comm, level=0)
-        if self.S.status.force_done:
-            return None
-
-        self.recv_full(comm=comm, level=0)
-        if self.S.status.force_done:
-            return None
-
-        # compute the residual
-        self.S.levels[0].sweep.compute_residual(stage='IT_CHECK')
+        self.update_residual_for_check(comm)
 
         if self.S.status.force_done:
             return None
@@ -483,13 +505,7 @@ class controller_MPI(Controller):
             for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
                 C.pre_iteration_processing(self, self.S, comm=comm)
 
-            if len(self.S.levels) > 1:  # MLSDC or PFASST
-                self.S.status.stage = 'IT_DOWN'
-            else:
-                if num_procs == 1 or self.params.mssdc_jac:  # SDC or parallel MSSDC (Jacobi-like)
-                    self.S.status.stage = 'IT_FINE'
-                else:
-                    self.S.status.stage = 'IT_COARSE'  # serial MSSDC (Gauss-like)
+            self.S.status.stage = self.next_iteration_stage(self.S)
 
         else:
             # Need to finish all pending isend requests. These will occur for the first active process, since
@@ -503,6 +519,41 @@ class controller_MPI(Controller):
             for hook in self.hooks:
                 hook.post_step(step=self.S, level_number=0)
             self.S.status.stage = 'DONE'
+
+    def compute_residual_after_spread(self, S):
+        """
+        Make the residual current right after the initial guess, for algorithms that need it there.
+
+        This controller computes the residual at the top of `it_check` instead, so there is nothing
+        to do; an algorithm whose residual is not available at that point overrides this. Called
+        before `post_spread_processing`, because convergence controllers there may still change the
+        initial iterate.
+
+        Args:
+            S (pySDC.Step.step): The current step
+        """
+        pass
+
+    def update_residual_for_check(self, comm):
+        """
+        Refresh the residual that `it_check` is about to look at.
+
+        For a sweep-based algorithm the residual depends on the initial condition, so the end points
+        have to be exchanged first. An algorithm that computes its residual as part of the iteration
+        overrides this and does nothing here.
+
+        Args:
+            comm: the communicator
+        """
+        self.send_full(comm=comm, level=0)
+        if self.S.status.force_done:
+            return None
+
+        self.recv_full(comm=comm, level=0)
+        if self.S.status.force_done:
+            return None
+
+        self.S.levels[0].sweep.compute_residual(stage='IT_CHECK')
 
     def it_fine(self, comm, num_procs):
         """

--- a/pySDC/implementations/controller_classes/controller_MPI.py
+++ b/pySDC/implementations/controller_classes/controller_MPI.py
@@ -98,7 +98,7 @@ class controller_MPI(Controller):
         all_dt = self.comm.allgather(self.S.dt)
         time = t0 + sum(all_dt[: self.comm.rank])
 
-        active = time < Tend - 10 * np.finfo(float).eps
+        active = self.step_is_active(time, t0, Tend)
         comm_active = self.comm.Split(active)
         self.S.status.slot = comm_active.rank
 
@@ -150,7 +150,7 @@ class controller_MPI(Controller):
             all_dt = comm_active.allgather(self.S.dt)
             time = tend + sum(all_dt[: self.S.status.slot])
 
-            active = time < Tend - 10 * np.finfo(float).eps
+            active = self.step_is_active(time, tend, Tend)
 
             # check if we need to split the communicator
             if tend + sum(all_dt[: comm_active.size - 1]) >= Tend - 10 * np.finfo(float).eps:
@@ -476,7 +476,7 @@ class controller_MPI(Controller):
         Key routine to check for convergence/termination
         """
 
-        self.update_residual_for_check(comm)
+        self.prepare_convergence_check(comm)
 
         if self.S.status.force_done:
             return None
@@ -532,13 +532,13 @@ class controller_MPI(Controller):
         """
         pass
 
-    def update_residual_for_check(self, comm):
+    def prepare_convergence_check(self, comm):
         """
-        Refresh the residual that `it_check` is about to look at.
+        Make current what `it_check` is about to read: the end point and the residual.
 
-        For a sweep-based algorithm the residual depends on the initial condition, so the end points
-        have to be exchanged first. An algorithm that computes its residual as part of the iteration
-        overrides this and does nothing here.
+        For a sweep-based algorithm both come out of the exchange with the neighbours, so this is
+        the send and receive plus the residual it enables. An algorithm that gets its residual from
+        the iteration instead overrides this, and still owes the end point.
 
         Args:
             comm: the communicator

--- a/pySDC/implementations/controller_classes/controller_MPI.py
+++ b/pySDC/implementations/controller_classes/controller_MPI.py
@@ -1,6 +1,4 @@
 import numpy as np
-from mpi4py import MPI
-
 from pySDC.core.controller import Controller
 from pySDC.core.errors import ControllerError
 from pySDC.core.step import Step

--- a/pySDC/implementations/controller_classes/controller_ParaDiag_MPI.py
+++ b/pySDC/implementations/controller_classes/controller_ParaDiag_MPI.py
@@ -1,16 +1,20 @@
 import numpy as np
 from mpi4py import MPI
 
-from pySDC.core.controller import ParaDiagController
 from pySDC.core.errors import ControllerError
-from pySDC.core.step import Step
 from pySDC.helpers.ParaDiagHelper import get_G_inv_matrix
-from pySDC.implementations.convergence_controller_classes.basic_restarting import BasicRestarting
+from pySDC.implementations.controller_classes.ParaDiag import ParaDiag
+from pySDC.implementations.controller_classes.controller_MPI import controller_MPI
 
 
-class controller_ParaDiag_MPI(ParaDiagController):
+class controller_ParaDiag_MPI(ParaDiag, controller_MPI):
     """
     ParaDiag controller with MPI parallelism across time steps: one step per rank.
+
+    This is `controller_MPI` with a different iteration: where PFASST sweeps and cascades through
+    the levels, ParaDiag diagonalizes across the steps. Everything around the iteration -- blocks,
+    windowing, restarts, convergence -- is the driver it inherits, which is why the dispatcher it
+    uses is still called `pfasst`.
 
     Everything here is written from a single processor's point of view. A rank owns exactly one step
     and never inspects another rank's data; the places where ParaDiag genuinely needs information
@@ -19,11 +23,13 @@ class controller_ParaDiag_MPI(ParaDiagController):
     - ``prepare_Jacobians``          -> Allreduce(SUM) over the step communicator
     - ``compute_all_at_once_residual`` -> point-to-point exchange with the previous/next rank
     - ``apply_matrix`` (the weighted FFT/iFFT in time) -> a ring reduction, see below
-    - convergence                   -> allreduce(LAND), because ParaDiag converges collectively
+    - convergence                   -> the inherited `it_check`, which allreduces because
+                                       `all_to_done` is forced on for ParaDiag
 
     Note that ParaDiag steps can only converge together, so every rank always participates in every
     iteration. That is not a policy choice: a rank that stopped early would never enter the
-    collectives below and the run would hang.
+    collectives below and the run would hang. `step_is_active` says the same thing about blocks --
+    a block is never run partially, so the driver's windowing never splits one.
     """
 
     def __init__(self, controller_params, description, comm=None):
@@ -35,32 +41,21 @@ class controller_ParaDiag_MPI(ParaDiagController):
         """
         comm = MPI.COMM_WORLD if comm is None else comm
         self.prepare_ParaDiag_params(controller_params, description)
-        super().__init__(controller_params=controller_params, description=description, useMPI=True)
 
-        self.comm = comm
-        self.n_steps = comm.size
         self.sweeper_params = description['sweeper_params']
 
         # each step needs its own G^-1, determined by where it sits in the block
-        self._G_inv_alpha = self.get_alpha(0)
+        self._G_inv_alpha = self.resolve_alpha(controller_params['alpha'], 0)
         description['sweeper_params']['G_inv'] = get_G_inv_matrix(
             comm.rank, comm.size, self._G_inv_alpha, description['sweeper_params']
         )
-        self.S = Step(description)
-        self.S.status.time_size = comm.size
 
-        self.base_convergence_controllers += [BasicRestarting.get_implementation(useMPI=True)]
-        for convergence_controller in self.base_convergence_controllers:
-            self.add_convergence_controller(convergence_controller, description)
+        super().__init__(controller_params, description, comm)
+
+        self.n_steps = comm.size
 
         if len(self.S.levels) > 1:
             raise ControllerError('Multi-level SDC not implemented in ParaDiag!')
-
-        if self.params.dump_setup and comm.rank == 0:
-            self.dump_setup(step=self.S, controller_params=controller_params, description=description)
-
-        for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
-            C.setup_status_variables(self, comm=comm)
 
     # ------------------------------------------------------------------ collectives
 
@@ -182,56 +177,9 @@ class controller_ParaDiag_MPI(ParaDiagController):
         for m in range(lvl.sweep.coll.num_nodes):
             lvl.u[m + 1] += lvl.increment[m]
 
-    # ------------------------------------------------------------------ stages
+    # ------------------------------------------------------------------ the ParaDiag iteration
 
-    def spread(self):
-        """Spreading phase"""
-        S = self.S
-        for hook in self.hooks:
-            hook.pre_step(step=S, level_number=0)
-
-        S.levels[0].sweep.predict()
-        S.levels[0].sweep.compute_residual()
-        S.status.stage = 'IT_CHECK'
-
-        for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
-            C.post_spread_processing(self, S, comm=self.comm)
-
-    def it_check(self):
-        """Check for convergence. ParaDiag converges collectively, hence the allreduce."""
-        S, comm = self.S, self.comm
-
-        if S.status.iter > 0:
-            for hook in self.hooks:
-                hook.post_iteration(step=S, level_number=0)
-
-        for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
-            C.post_iteration_processing(self, S, comm=comm)
-            C.convergence_control(self, S, comm=comm)
-
-        for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
-            C.post_iteration_processing_block(self, comm=comm)
-
-        for hook in self.hooks:
-            hook.pre_comm(step=S, level_number=0)
-        S.status.done = comm.allreduce(S.status.done, op=MPI.LAND)
-        for hook in self.hooks:
-            hook.post_comm(step=S, level_number=0, add_to_stats=True)
-
-        if not S.status.done:
-            S.status.iter += 1
-            for hook in self.hooks:
-                hook.pre_iteration(step=S, level_number=0)
-            for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
-                C.pre_iteration_processing(self, S, comm=comm)
-            S.status.stage = 'IT_PARADIAG'
-        else:
-            S.levels[0].sweep.compute_end_point()
-            for hook in self.hooks:
-                hook.post_step(step=S, level_number=0)
-            S.status.stage = 'DONE'
-
-    def it_ParaDiag(self):
+    def it_ParaDiag(self, comm, num_procs):
         """A single ParaDiag iteration, from this rank's point of view."""
         S = self.S
 
@@ -255,96 +203,3 @@ class controller_ParaDiag_MPI(ParaDiagController):
             hook.post_sweep(step=S, level_number=0)
 
         S.status.stage = 'IT_CHECK'
-
-    def ParaDiag(self):
-        """Dispatch on the current stage. All ranks are always in the same stage."""
-        stage = self.S.status.stage
-        self.logger.debug(stage)
-
-        switcher = {'SPREAD': self.spread, 'IT_CHECK': self.it_check, 'IT_PARADIAG': self.it_ParaDiag}
-        assert stage in switcher, f'Got unexpected stage {stage!r}'
-        switcher[stage]()
-
-        return self.S.status.done
-
-    # ------------------------------------------------------------------ driver
-
-    def restart_block(self, time, u0):
-        """Reset this rank's step for a new block."""
-        S, comm = self.S, self.comm
-
-        S.status.slot = comm.rank
-        S.reset_step()
-        S.status.first = comm.rank == 0
-        S.status.last = comm.rank == comm.size - 1
-        S.init_step(u0)
-        S.status.done = False
-        S.status.prev_done = False
-        S.status.iter = 0
-        S.status.stage = 'SPREAD'
-        S.status.force_done = False
-        S.status.time_size = comm.size
-
-        for lvl in S.levels:
-            lvl.tag = None
-            lvl.status.sweep = 1
-            lvl.status.time = time
-
-        for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
-            C.reset_status_variables(self, comm=comm)
-
-    def run(self, u0, t0, Tend):
-        """
-        Main driver.
-
-        ParaDiag always runs whole blocks -- every rank participates in every iteration -- so unlike
-        the pipelined controllers there is no communicator splitting as steps finish.
-        """
-        comm = self.comm
-        for hook in self.hooks:
-            hook.reset_stats()
-
-        all_dt = comm.allgather(self.S.dt)
-        block_dt = sum(all_dt)
-        time = t0 + sum(all_dt[: comm.rank])
-        block_start = t0
-
-        if block_start >= Tend - 10 * np.finfo(float).eps:
-            raise ControllerError('Nothing to do, check t0, dt and Tend!')
-
-        if block_start + block_dt > Tend + 10 * np.finfo(float).eps and comm.rank == 0:
-            self.logger.warning(
-                'Warning: This controller will solve past your desired end time until the end of its block!'
-            )
-
-        self.restart_block(time, u0)
-        uend = u0
-
-        for hook in self.hooks:
-            hook.post_setup(step=None, level_number=None)
-        for hook in self.hooks:
-            hook.pre_run(step=self.S, level_number=0)
-
-        while block_start < Tend - 10 * np.finfo(float).eps:
-            while not self.ParaDiag():
-                pass
-
-            uend = self.S.levels[0].uend.bcast(root=comm.size - 1, comm=comm)
-            tend = comm.bcast(self.S.time + self.S.dt, root=comm.size - 1)
-
-            for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
-                C.post_step_processing(self, self.S, comm=comm)
-                C.prepare_next_block(self, self.S, self.S.status.time_size, tend, Tend, comm=comm)
-
-            block_start = tend
-            if block_start < Tend - 10 * np.finfo(float).eps:
-                all_dt = comm.allgather(self.S.dt)
-                time = block_start + sum(all_dt[: comm.rank])
-                self.restart_block(time, uend)
-
-        for hook in self.hooks:
-            hook.post_run(step=self.S, level_number=0)
-        for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
-            C.post_run_processing(self, self.S, comm=comm)
-
-        return uend, self.return_stats()

--- a/pySDC/implementations/controller_classes/controller_ParaDiag_MPI.py
+++ b/pySDC/implementations/controller_classes/controller_ParaDiag_MPI.py
@@ -34,9 +34,11 @@ class controller_ParaDiag_MPI(ParaDiagController):
             comm: MPI communicator, one rank per time step
         """
         comm = MPI.COMM_WORLD if comm is None else comm
-        super().__init__(controller_params=controller_params, description=description, n_steps=comm.size, useMPI=True)
+        self.prepare_ParaDiag_params(controller_params, description)
+        super().__init__(controller_params=controller_params, description=description, useMPI=True)
 
         self.comm = comm
+        self.n_steps = comm.size
         self.sweeper_params = description['sweeper_params']
 
         # each step needs its own G^-1, determined by where it sits in the block

--- a/pySDC/implementations/controller_classes/controller_ParaDiag_nonMPI.py
+++ b/pySDC/implementations/controller_classes/controller_ParaDiag_nonMPI.py
@@ -1,17 +1,19 @@
-import itertools
 import numpy as np
 
 from pySDC.core.controller import ParaDiagController
-from pySDC.core import step as stepclass
-from pySDC.core.errors import ControllerError
-from pySDC.implementations.convergence_controller_classes.basic_restarting import BasicRestarting
 from pySDC.helpers.ParaDiagHelper import get_G_inv_matrix
+from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
 
 
-class controller_ParaDiag_nonMPI(ParaDiagController):
+class controller_ParaDiag_nonMPI(ParaDiagController, controller_nonMPI):
     """
 
     ParaDiag controller, running serialized version.
+
+    This is `controller_nonMPI` with a different iteration: where PFASST sweeps and cascades through
+    the levels, ParaDiag diagonalizes across the steps. Everything around the iteration -- blocks,
+    windowing, restarts, convergence -- is the driver it inherits, which is why the dispatcher it
+    uses is still called `pfasst`.
 
     This controller uses the increment formulation. That is to say, we setup the residual of the all at once problem,
     put it on the right hand side, invert the ParaDiag preconditioner on the left-hand side to compute the increment
@@ -29,68 +31,96 @@ class controller_ParaDiag_nonMPI(ParaDiagController):
            controller_params: parameter set for the controller and the steps
            description: all the parameters to set up the rest (levels, problems, transfer, ...)
         """
-        super().__init__(controller_params, description, useMPI=False, n_steps=num_procs)
+        self.prepare_ParaDiag_params(controller_params, description)
 
-        self.MS = []
         self.sweeper_params = description['sweeper_params']
-        self._G_inv_alpha = self.get_alpha(0)
+        self._G_inv_alpha = self.resolve_alpha(controller_params['alpha'], 0)
 
-        for l in range(num_procs):
-            G_inv = get_G_inv_matrix(l, num_procs, self._G_inv_alpha, description['sweeper_params'])
-            description['sweeper_params']['G_inv'] = G_inv
+        # the steps are copies of the first one, so give that one its own G^-1 before they are built
+        description['sweeper_params']['G_inv'] = get_G_inv_matrix(
+            0, num_procs, self._G_inv_alpha, description['sweeper_params']
+        )
 
-            self.MS.append(stepclass.Step(description))
+        super().__init__(num_procs, controller_params, description)
 
-        self.base_convergence_controllers += [BasicRestarting.get_implementation(useMPI=False)]
-        for convergence_controller in self.base_convergence_controllers:
-            self.add_convergence_controller(convergence_controller, description)
-
-        if self.params.dump_setup:
-            self.dump_setup(step=self.MS[0], controller_params=controller_params, description=description)
+        self.n_steps = num_procs
 
         if len(self.MS[0].levels) > 1:
             raise NotImplementedError('This controller does not support multiple levels')
 
-        for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
-            C.reset_buffers_nonMPI(self)
-            C.setup_status_variables(self, MS=self.MS)
+        # every step but the first still has the first one's G^-1
+        self.set_G_inv(self._G_inv_alpha)
 
-    def ParaDiag(self, local_MS_active):
+    # ------------------------------------------------------------------ what makes this ParaDiag
+
+    def get_stages(self):
         """
-        Main function for ParaDiag
-
-        For the workflow of this controller, see https://arxiv.org/abs/2103.12571
-
-        This method changes self.MS directly by accessing active steps through local_MS_active.
-
-        Args:
-            local_MS_active (list): all active steps
+        ParaDiag has one iteration stage, and no predictor because it has no coarse level.
 
         Returns:
-            boot: Whether all steps are done
+            dict: stage name -> the method that runs it
         """
-
-        # if all stages are the same (or DONE), continue, otherwise abort
-        stages = [S.status.stage for S in local_MS_active if S.status.stage != 'DONE']
-        if stages[1:] == stages[:-1]:
-            stage = stages[0]
-        else:
-            raise ControllerError('not all stages are equal')
-
-        self.logger.debug(stage)
-
-        MS_running = [S for S in local_MS_active if S.status.stage != 'DONE']
-
-        switcher = {
+        return {
             'SPREAD': self.spread,
             'IT_CHECK': self.it_check,
             'IT_PARADIAG': self.it_ParaDiag,
         }
 
-        assert stage in switcher.keys(), f'Got unexpected stage {stage!r}'
-        switcher[stage](MS_running)
+    def next_iteration_stage(self, S):
+        """
+        Args:
+            S (pySDC.Step.step): The current step
 
-        return all(S.status.done for S in local_MS_active)
+        Returns:
+            str: name of the stage to enter
+        """
+        return 'IT_PARADIAG'
+
+    def compute_residual_after_spread(self, S):
+        """
+        ParaDiag's residual is the one of the composite collocation problem, which `it_ParaDiag`
+        computes as part of the iteration. The convergence check runs before the first iteration,
+        so the initial guess needs its residual here.
+
+        Args:
+            S (pySDC.Step.step): The current step
+        """
+        S.levels[0].sweep.compute_residual()
+
+    def update_residual_for_check(self, local_MS_running):
+        """
+        Nothing to do: the residual is already current, and recomputing it the way a sweep-based
+        algorithm does would need the initial conditions this controller has not communicated yet.
+
+        Args:
+            local_MS_running (list): list of currently running steps
+        """
+        pass
+
+    def get_active_steps(self, time, Tend, slots):
+        """
+        ParaDiag diagonalizes across the whole block, so it cannot drop steps out of one. A block
+        that starts before `Tend` is run whole, past `Tend` if need be.
+
+        Args:
+            time (list): starting time of each slot
+            Tend (float): ending time
+            slots (list): all slot numbers
+
+        Returns:
+            list: one bool per slot
+        """
+        active = super().get_active_steps(time, Tend, slots)
+
+        if any(active) and not all(active):
+            self.logger.warning(
+                'Warning: This controller will solve past your desired end time until the end of its block!'
+            )
+            return [True] * len(active)
+
+        return active
+
+    # ------------------------------------------------------------------ the ParaDiag iteration
 
     def apply_matrix(self, mat, quantity):
         """
@@ -156,6 +186,17 @@ class controller_ParaDiag_nonMPI(ParaDiagController):
             # compute residuals locally
             S.levels[0].sweep.compute_residual()
 
+    def set_G_inv(self, alpha):
+        """
+        Give every step the G^-1 that belongs to where it sits in the block.
+
+        Args:
+            alpha (float): the alpha this G^-1 is built from
+        """
+        L = len(self.MS)
+        for l, S in enumerate(self.MS):
+            S.levels[0].sweep.set_G_inv(get_G_inv_matrix(l, L, alpha, self.sweeper_params))
+
     def update_G_inv(self, k=0):
         """
         Rebuild G^-1 on every step if alpha changed with the iteration.
@@ -167,9 +208,7 @@ class controller_ParaDiag_nonMPI(ParaDiagController):
         if alpha == self._G_inv_alpha:
             return
         self._G_inv_alpha = alpha
-        L = len(self.MS)
-        for l, S in enumerate(self.MS):
-            S.levels[0].sweep.set_G_inv(get_G_inv_matrix(l, L, alpha, self.sweeper_params))
+        self.set_G_inv(alpha)
 
     def update_solution(self, local_MS_running):
         """
@@ -251,245 +290,3 @@ class controller_ParaDiag_nonMPI(ParaDiagController):
         # update stage
         for S in local_MS_running:
             S.status.stage = 'IT_CHECK'
-
-    def it_check(self, local_MS_running):
-        """
-        Key routine to check for convergence/termination
-
-        Args:
-            local_MS_running (list): list of currently running steps
-        """
-
-        for S in local_MS_running:
-            if S.status.iter > 0:
-                for hook in self.hooks:
-                    hook.post_iteration(step=S, level_number=0)
-
-            # decide if the step is done, needs to be restarted and other things convergence related
-            for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
-                C.post_iteration_processing(self, S, MS=local_MS_running)
-                C.convergence_control(self, S, MS=local_MS_running)
-
-        for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
-            C.post_iteration_processing_block(self, MS=local_MS_running)
-
-        for S in local_MS_running:
-            if not S.status.first:
-                for hook in self.hooks:
-                    hook.pre_comm(step=S, level_number=0)
-                S.status.prev_done = S.prev.status.done  # "communicate"
-                for hook in self.hooks:
-                    hook.post_comm(step=S, level_number=0, add_to_stats=True)
-                S.status.done = S.status.done and S.status.prev_done
-
-            if self.params.all_to_done:
-                for hook in self.hooks:
-                    hook.pre_comm(step=S, level_number=0)
-                S.status.done = all(T.status.done for T in local_MS_running)
-                for hook in self.hooks:
-                    hook.post_comm(step=S, level_number=0, add_to_stats=True)
-
-            if not S.status.done:
-                # increment iteration count here (and only here)
-                S.status.iter += 1
-                for hook in self.hooks:
-                    hook.pre_iteration(step=S, level_number=0)
-                for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
-                    C.pre_iteration_processing(self, S, MS=local_MS_running)
-
-                # Do another ParaDiag iteration
-                S.status.stage = 'IT_PARADIAG'
-            else:
-                S.levels[0].sweep.compute_end_point()
-                for hook in self.hooks:
-                    hook.post_step(step=S, level_number=0)
-                S.status.stage = 'DONE'
-
-        for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
-            C.reset_buffers_nonMPI(self)
-
-    def spread(self, local_MS_running):
-        """
-        Spreading phase
-
-        Args:
-            local_MS_running (list): list of currently running steps
-        """
-
-        for S in local_MS_running:
-
-            # first stage: spread values
-            for hook in self.hooks:
-                hook.pre_step(step=S, level_number=0)
-
-            # call predictor from sweeper
-            S.levels[0].sweep.predict()
-
-            # compute the residual
-            S.levels[0].sweep.compute_residual()
-
-            # update stage
-            S.status.stage = 'IT_CHECK'
-
-            for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
-                C.post_spread_processing(self, S, MS=local_MS_running)
-
-    def run(self, u0, t0, Tend):
-        """
-        Main driver for running the serial version of ParaDiag
-
-        Args:
-           u0: initial values
-           t0: starting time
-           Tend: ending time
-
-        Returns:
-            end values on the last step
-            stats object containing statistics for each step, each level and each iteration
-        """
-
-        # some initializations and reset of statistics
-        uend = None
-        num_procs = len(self.MS)
-        for hook in self.hooks:
-            hook.reset_stats()
-
-        # initial ordering of the steps: 0,1,...,Np-1
-        slots = list(range(num_procs))
-
-        # initialize time variables of each step
-        time = [t0 + sum(self.MS[j].dt for j in range(p)) for p in slots]
-
-        # determine which steps are still active (time < Tend)
-        active = [time[p] < Tend - 10 * np.finfo(float).eps for p in slots]
-        if not all(active) and any(active):
-            self.logger.warning(
-                'Warning: This controller will solve past your desired end time until the end of its block!'
-            )
-            active = [
-                True,
-            ] * len(active)
-
-        if not any(active):
-            raise ControllerError('Nothing to do, check t0, dt and Tend.')
-
-        # compress slots according to active steps, i.e. remove all steps which have times above Tend
-        active_slots = list(itertools.compress(slots, active))
-
-        # initialize block of steps with u0
-        self.restart_block(active_slots, time, u0)
-
-        for hook in self.hooks:
-            hook.post_setup(step=None, level_number=None)
-
-        # call pre-run hook
-        for S in self.MS:
-            for hook in self.hooks:
-                hook.pre_run(step=S, level_number=0)
-
-        # main loop: as long as at least one step is still active (time < Tend), do something
-        while any(active):
-            MS_active = [self.MS[p] for p in active_slots]
-            done = False
-            while not done:
-                done = self.ParaDiag(MS_active)
-
-            restarts = [S.status.restart for S in MS_active]
-            restart_at = np.where(restarts)[0][0] if True in restarts else len(MS_active)
-            if True in restarts:  # restart part of the block
-                # initial condition to next block is initial condition of step that needs restarting
-                uend = self.MS[restart_at].levels[0].u[0]
-                time[active_slots[0]] = time[restart_at]
-                self.logger.info(f'Starting next block with initial conditions from step {restart_at}')
-
-            else:  # move on to next block
-                # initial condition for next block is last solution of current block
-                uend = self.MS[active_slots[-1]].levels[0].uend
-                time[active_slots[0]] = time[active_slots[-1]] + self.MS[active_slots[-1]].dt
-
-            for S in MS_active[:restart_at]:
-                for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
-                    C.post_step_processing(self, S, MS=MS_active)
-
-            for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
-                [C.prepare_next_block(self, S, len(active_slots), time, Tend, MS=MS_active) for S in self.MS]
-
-            # setup the times of the steps for the next block
-            for i in range(1, len(active_slots)):
-                time[active_slots[i]] = time[active_slots[i] - 1] + self.MS[active_slots[i] - 1].dt
-
-            # determine new set of active steps and compress slots accordingly
-            active = [time[p] < Tend - 10 * np.finfo(float).eps for p in slots]
-            if not all(active) and any(active):
-                self.logger.warning(
-                    'Warning: This controller will solve past your desired end time until the end of its block!'
-                )
-                active = [
-                    True,
-                ] * len(active)
-            active_slots = list(itertools.compress(slots, active))
-
-            # restart active steps (reset all values and pass uend to u0)
-            self.restart_block(active_slots, time, uend)
-
-        # call post-run hook
-        for S in self.MS:
-            for hook in self.hooks:
-                hook.post_run(step=S, level_number=0)
-
-        for S in self.MS:
-            for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
-                C.post_run_processing(self, S, MS=MS_active)
-
-        return uend, self.return_stats()
-
-    def restart_block(self, active_slots, time, u0):
-        """
-        Helper routine to reset/restart block of (active) steps
-
-        Args:
-            active_slots: list of active steps
-            time: list of new times
-            u0: initial value to distribute across the steps
-
-        """
-
-        for j in range(len(active_slots)):
-            # get slot number
-            p = active_slots[j]
-
-            # store current slot number for diagnostics
-            self.MS[p].status.slot = p
-            # store link to previous step
-            self.MS[p].prev = self.MS[active_slots[j - 1]]
-
-            self.MS[p].reset_step()
-
-            # determine whether I am the first and/or last in line
-            self.MS[p].status.first = active_slots.index(p) == 0
-            self.MS[p].status.last = active_slots.index(p) == len(active_slots) - 1
-
-            # initialize step with u0
-            self.MS[p].init_step(u0)
-
-            # setup G^{-1} for new number of active slots
-            # self.MS[j].levels[0].sweep.set_G_inv(get_G_inv_matrix(j, len(active_slots), self.params.alpha, self.description['sweeper_params']))
-
-            # reset some values
-            self.MS[p].status.done = False
-            self.MS[p].status.prev_done = False
-            self.MS[p].status.iter = 0
-            self.MS[p].status.stage = 'SPREAD'
-            self.MS[p].status.force_done = False
-            self.MS[p].status.time_size = len(active_slots)
-
-            for l in self.MS[p].levels:
-                l.tag = None
-                l.status.sweep = 1
-
-        for p in active_slots:
-            for lvl in self.MS[p].levels:
-                lvl.status.time = time[p]
-
-        for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
-            C.reset_status_variables(self, active_slots=active_slots)

--- a/pySDC/implementations/controller_classes/controller_ParaDiag_nonMPI.py
+++ b/pySDC/implementations/controller_classes/controller_ParaDiag_nonMPI.py
@@ -1,11 +1,11 @@
 import numpy as np
 
-from pySDC.core.controller import ParaDiagController
 from pySDC.helpers.ParaDiagHelper import get_G_inv_matrix
+from pySDC.implementations.controller_classes.ParaDiag import ParaDiag
 from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
 
 
-class controller_ParaDiag_nonMPI(ParaDiagController, controller_nonMPI):
+class controller_ParaDiag_nonMPI(ParaDiag, controller_nonMPI):
     """
 
     ParaDiag controller, running serialized version.
@@ -50,75 +50,6 @@ class controller_ParaDiag_nonMPI(ParaDiagController, controller_nonMPI):
 
         # every step but the first still has the first one's G^-1
         self.set_G_inv(self._G_inv_alpha)
-
-    # ------------------------------------------------------------------ what makes this ParaDiag
-
-    def get_stages(self):
-        """
-        ParaDiag has one iteration stage, and no predictor because it has no coarse level.
-
-        Returns:
-            dict: stage name -> the method that runs it
-        """
-        return {
-            'SPREAD': self.spread,
-            'IT_CHECK': self.it_check,
-            'IT_PARADIAG': self.it_ParaDiag,
-        }
-
-    def next_iteration_stage(self, S):
-        """
-        Args:
-            S (pySDC.Step.step): The current step
-
-        Returns:
-            str: name of the stage to enter
-        """
-        return 'IT_PARADIAG'
-
-    def compute_residual_after_spread(self, S):
-        """
-        ParaDiag's residual is the one of the composite collocation problem, which `it_ParaDiag`
-        computes as part of the iteration. The convergence check runs before the first iteration,
-        so the initial guess needs its residual here.
-
-        Args:
-            S (pySDC.Step.step): The current step
-        """
-        S.levels[0].sweep.compute_residual()
-
-    def update_residual_for_check(self, local_MS_running):
-        """
-        Nothing to do: the residual is already current, and recomputing it the way a sweep-based
-        algorithm does would need the initial conditions this controller has not communicated yet.
-
-        Args:
-            local_MS_running (list): list of currently running steps
-        """
-        pass
-
-    def get_active_steps(self, time, Tend, slots):
-        """
-        ParaDiag diagonalizes across the whole block, so it cannot drop steps out of one. A block
-        that starts before `Tend` is run whole, past `Tend` if need be.
-
-        Args:
-            time (list): starting time of each slot
-            Tend (float): ending time
-            slots (list): all slot numbers
-
-        Returns:
-            list: one bool per slot
-        """
-        active = super().get_active_steps(time, Tend, slots)
-
-        if any(active) and not all(active):
-            self.logger.warning(
-                'Warning: This controller will solve past your desired end time until the end of its block!'
-            )
-            return [True] * len(active)
-
-        return active
 
     # ------------------------------------------------------------------ the ParaDiag iteration
 

--- a/pySDC/implementations/controller_classes/controller_nonMPI.py
+++ b/pySDC/implementations/controller_classes/controller_nonMPI.py
@@ -242,27 +242,23 @@ class controller_nonMPI(Controller):
             S: the current step
             level: the level number
             add_to_stats: a flag to end recording data in the hooks (defaults to False)
+
+        Note:
+            Computing the end point is this function's job, not the caller's, exactly as in
+            `controller_MPI.send_full`. It happens whether or not anyone is listening, because the
+            last step has no successor but its `uend` is still the block's result.
         """
-
-        def send(source, tag):
-            """
-            Send function
-
-            Args:
-                source: level which has the new values
-                tag: identifier for this message
-            """
-            # sending here means computing uend ("one-sided communication")
-            source.sweep.compute_end_point()
-            source.tag = cp.deepcopy(tag)
-
         for hook in self.hooks:
             hook.pre_comm(step=S, level_number=level)
+
+        # sending here means computing uend ("one-sided communication")
+        S.levels[level].sweep.compute_end_point()
+
         if not S.status.last:
             self.logger.debug(
                 'Process %2i provides data on level %2i with tag %s' % (S.status.slot, level, S.status.iter)
             )
-            send(S.levels[level], tag=(level, S.status.iter, S.status.slot))
+            S.levels[level].tag = cp.deepcopy((level, S.status.iter, S.status.slot))
 
         for hook in self.hooks:
             hook.post_comm(step=S, level_number=level, add_to_stats=add_to_stats)
@@ -509,7 +505,6 @@ class controller_nonMPI(Controller):
 
                 S.status.stage = self.next_iteration_stage(S)
             else:
-                S.levels[0].sweep.compute_end_point()
                 for hook in self.hooks:
                     hook.post_step(step=S, level_number=0)
                 S.status.stage = 'DONE'

--- a/pySDC/implementations/controller_classes/controller_nonMPI.py
+++ b/pySDC/implementations/controller_classes/controller_nonMPI.py
@@ -120,7 +120,7 @@ class controller_nonMPI(Controller):
         time = [t0 + sum(self.MS[j].dt for j in range(p)) for p in slots]
 
         # determine which steps are still active (time < Tend)
-        active = self.get_active_steps(time, Tend, slots)
+        active = [self.step_is_active(time[p], time[0], Tend) for p in slots]
 
         if not any(active):
             raise ControllerError('Nothing to do, check t0, dt and Tend.')
@@ -171,7 +171,7 @@ class controller_nonMPI(Controller):
                 time[active_slots[i]] = time[active_slots[i] - 1] + self.MS[active_slots[i] - 1].dt
 
             # determine new set of active steps and compress slots accordingly
-            active = self.get_active_steps(time, Tend, slots)
+            active = [self.step_is_active(time[p], time[0], Tend) for p in slots]
             active_slots = list(itertools.compress(slots, active))
 
             # restart active steps (reset all values and pass uend to u0)
@@ -187,23 +187,6 @@ class controller_nonMPI(Controller):
                 C.post_run_processing(self, S, MS=MS_active)
 
         return uend, self.return_stats()
-
-    def get_active_steps(self, time, Tend, slots):
-        """
-        Which steps still have work to do, as a mask over `slots`.
-
-        A step is active while it starts before `Tend`. An algorithm that can only advance whole
-        blocks overrides this and says so.
-
-        Args:
-            time (list): starting time of each slot
-            Tend (float): ending time
-            slots (list): all slot numbers
-
-        Returns:
-            list: one bool per slot
-        """
-        return [time[p] < Tend - 10 * np.finfo(float).eps for p in slots]
 
     def restart_block(self, active_slots, time, u0):
         """
@@ -497,7 +480,7 @@ class controller_nonMPI(Controller):
             local_MS_running (list): list of currently running steps
         """
 
-        self.update_residual_for_check(local_MS_running)
+        self.prepare_convergence_check(local_MS_running)
 
         for S in local_MS_running:
             if S.status.iter > 0:
@@ -548,13 +531,13 @@ class controller_nonMPI(Controller):
         """
         pass
 
-    def update_residual_for_check(self, local_MS_running):
+    def prepare_convergence_check(self, local_MS_running):
         """
-        Refresh the residual that `it_check` is about to look at.
+        Make current what `it_check` is about to read: the end point and the residual.
 
-        For a sweep-based algorithm the residual depends on the initial condition, so the end points
-        have to be exchanged first. An algorithm that computes its residual as part of the iteration
-        overrides this and does nothing here.
+        For a sweep-based algorithm both come out of the exchange with the neighbours, so this is
+        the send and receive plus the residual it enables. An algorithm that gets its residual from
+        the iteration instead overrides this, and still owes the end point.
 
         Args:
             local_MS_running (list): list of currently running steps

--- a/pySDC/implementations/controller_classes/controller_nonMPI.py
+++ b/pySDC/implementations/controller_classes/controller_nonMPI.py
@@ -120,7 +120,7 @@ class controller_nonMPI(Controller):
         time = [t0 + sum(self.MS[j].dt for j in range(p)) for p in slots]
 
         # determine which steps are still active (time < Tend)
-        active = [time[p] < Tend - 10 * np.finfo(float).eps for p in slots]
+        active = self.get_active_steps(time, Tend, slots)
 
         if not any(active):
             raise ControllerError('Nothing to do, check t0, dt and Tend.')
@@ -171,7 +171,7 @@ class controller_nonMPI(Controller):
                 time[active_slots[i]] = time[active_slots[i] - 1] + self.MS[active_slots[i] - 1].dt
 
             # determine new set of active steps and compress slots accordingly
-            active = [time[p] < Tend - 10 * np.finfo(float).eps for p in slots]
+            active = self.get_active_steps(time, Tend, slots)
             active_slots = list(itertools.compress(slots, active))
 
             # restart active steps (reset all values and pass uend to u0)
@@ -187,6 +187,23 @@ class controller_nonMPI(Controller):
                 C.post_run_processing(self, S, MS=MS_active)
 
         return uend, self.return_stats()
+
+    def get_active_steps(self, time, Tend, slots):
+        """
+        Which steps still have work to do, as a mask over `slots`.
+
+        A step is active while it starts before `Tend`. An algorithm that can only advance whole
+        blocks overrides this and says so.
+
+        Args:
+            time (list): starting time of each slot
+            Tend (float): ending time
+            slots (list): all slot numbers
+
+        Returns:
+            list: one bool per slot
+        """
+        return [time[p] < Tend - 10 * np.finfo(float).eps for p in slots]
 
     def restart_block(self, active_slots, time, u0):
         """

--- a/pySDC/implementations/controller_classes/controller_nonMPI.py
+++ b/pySDC/implementations/controller_classes/controller_nonMPI.py
@@ -91,6 +91,8 @@ class controller_nonMPI(Controller):
             C.reset_buffers_nonMPI(self)
             C.setup_status_variables(self, MS=self.MS)
 
+        self.stages = self.get_stages()
+
     def run(self, u0, t0, Tend):
         """
         Main driver for running the serial version of SDC, MSSDC, MLSDC and PFASST (virtual parallelism)
@@ -326,7 +328,22 @@ class controller_nonMPI(Controller):
 
         MS_running = [S for S in local_MS_active if S.status.stage != 'DONE']
 
-        switcher = {
+        self.stages.get(stage, self.default)(MS_running)
+
+        return all(S.status.done for S in local_MS_active)
+
+    def get_stages(self):
+        """
+        The stages this controller can be in, and what to run in each.
+
+        A subclass that iterates differently replaces the iteration stages here and says which one
+        to enter in `next_iteration_stage`; everything around the iteration is the same for any
+        algorithm this controller runs.
+
+        Returns:
+            dict: stage name -> the method that runs it
+        """
+        return {
             'SPREAD': self.spread,
             'PREDICT': self.predict,
             'IT_CHECK': self.it_check,
@@ -336,9 +353,22 @@ class controller_nonMPI(Controller):
             'IT_UP': self.it_up,
         }
 
-        switcher.get(stage, self.default)(MS_running)
+    def next_iteration_stage(self, S):
+        """
+        The stage that starts one iteration of the algorithm.
 
-        return all(S.status.done for S in local_MS_active)
+        Args:
+            S (pySDC.Step.step): The current step
+
+        Returns:
+            str: name of the stage to enter
+        """
+        if len(S.levels) > 1:  # MLSDC or PFASST
+            return 'IT_DOWN'
+        elif S.status.time_size == 1 or self.params.mssdc_jac:  # SDC or parallel MSSDC (Jacobi-like)
+            return 'IT_FINE'
+        else:
+            return 'IT_COARSE'  # serial MSSDC (Gauss-like)
 
     def spread(self, local_MS_running):
         """
@@ -355,6 +385,8 @@ class controller_nonMPI(Controller):
 
             # call predictor from sweeper
             S.levels[0].sweep.predict()
+
+            self.compute_residual_after_spread(S)
 
             # update stage
             if len(S.levels) > 1:  # MLSDC or PFASST with predict
@@ -448,13 +480,7 @@ class controller_nonMPI(Controller):
             local_MS_running (list): list of currently running steps
         """
 
-        for S in local_MS_running:
-            # send updated values forward
-            self.send_full(S, level=0)
-            # receive values
-            self.recv_full(S, level=0)
-            # compute current residual
-            S.levels[0].sweep.compute_residual(stage='IT_CHECK')
+        self.update_residual_for_check(local_MS_running)
 
         for S in local_MS_running:
             if S.status.iter > 0:
@@ -481,13 +507,7 @@ class controller_nonMPI(Controller):
                 for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
                     C.pre_iteration_processing(self, S, MS=local_MS_running)
 
-                if len(S.levels) > 1:  # MLSDC or PFASST
-                    S.status.stage = 'IT_DOWN'
-                else:  # SDC or MSSDC
-                    if len(local_MS_running) == 1 or self.params.mssdc_jac:  # SDC or parallel MSSDC (Jacobi-like)
-                        S.status.stage = 'IT_FINE'
-                    else:
-                        S.status.stage = 'IT_COARSE'  # serial MSSDC (Gauss-like)
+                S.status.stage = self.next_iteration_stage(S)
             else:
                 S.levels[0].sweep.compute_end_point()
                 for hook in self.hooks:
@@ -496,6 +516,39 @@ class controller_nonMPI(Controller):
 
         for C in [self.convergence_controllers[i] for i in self.convergence_controller_order]:
             C.reset_buffers_nonMPI(self)
+
+    def compute_residual_after_spread(self, S):
+        """
+        Make the residual current right after the initial guess, for algorithms that need it there.
+
+        This controller computes the residual at the top of `it_check` instead, so there is nothing
+        to do; an algorithm whose residual is not available at that point overrides this. Called
+        before `post_spread_processing`, because convergence controllers there may still change the
+        initial iterate.
+
+        Args:
+            S (pySDC.Step.step): The current step
+        """
+        pass
+
+    def update_residual_for_check(self, local_MS_running):
+        """
+        Refresh the residual that `it_check` is about to look at.
+
+        For a sweep-based algorithm the residual depends on the initial condition, so the end points
+        have to be exchanged first. An algorithm that computes its residual as part of the iteration
+        overrides this and does nothing here.
+
+        Args:
+            local_MS_running (list): list of currently running steps
+        """
+        for S in local_MS_running:
+            # send updated values forward
+            self.send_full(S, level=0)
+            # receive values
+            self.recv_full(S, level=0)
+            # compute current residual
+            S.levels[0].sweep.compute_residual(stage='IT_CHECK')
 
     def it_fine(self, local_MS_running: list[Step]):
         """

--- a/pySDC/implementations/controller_classes/controller_nonMPI.py
+++ b/pySDC/implementations/controller_classes/controller_nonMPI.py
@@ -385,51 +385,6 @@ class controller_nonMPI(Controller):
             for S in local_MS_running:
                 S.levels[0].sweep.update_nodes()
 
-        # elif self.params.predict_type == 'libpfasst_style':
-        #
-        #     # loop over all steps
-        #     for S in local_MS_running:
-        #
-        #         # restrict to coarsest level
-        #         for l in range(1, len(S.levels)):
-        #             S.transfer(source=S.levels[l - 1], target=S.levels[l])
-        #
-        #     # run in serial on coarse level
-        #     for S in local_MS_running:
-        #
-        #         self.hooks.pre_comm(step=S, level_number=len(S.levels) - 1)
-        #         # receive from previous step (if not first)
-        #         if not S.status.first:
-        #             self.logger.debug('Process %2i receives from %2i on level %2i with tag %s -- PREDICT' %
-        #                               (S.status.slot, S.prev.status.slot, len(S.levels) - 1, 0))
-        #             self.recv(S.levels[-1], S.prev.levels[-1], tag=(len(S.levels), 0, S.prev.status.slot))
-        #         self.hooks.post_comm(step=S, level_number=len(S.levels) - 1)
-        #
-        #         # do the coarse sweep
-        #         S.levels[-1].sweep.update_nodes()
-        #
-        #         self.hooks.pre_comm(step=S, level_number=len(S.levels) - 1)
-        #         # send to succ step
-        #         if not S.status.last:
-        #             self.logger.debug('Process %2i provides data on level %2i with tag %s -- PREDICT'
-        #                               % (S.status.slot, len(S.levels) - 1, 0))
-        #             self.send(S.levels[-1], tag=(len(S.levels), 0, S.status.slot))
-        #         self.hooks.post_comm(step=S, level_number=len(S.levels) - 1, add_to_stats=True)
-        #
-        #     # go back to fine level, sweeping
-        #     for l in range(self.nlevels - 1, 0, -1):
-        #
-        #         for S in local_MS_running:
-        #             # prolong values
-        #             S.transfer(source=S.levels[l], target=S.levels[l - 1])
-        #
-        #             if l - 1 > 0:
-        #                 S.levels[l - 1].sweep.update_nodes()
-        #
-        #     # end with a fine sweep
-        #     for S in local_MS_running:
-        #         S.levels[0].sweep.update_nodes()
-
         elif self.params.predict_type == 'pfasst_burnin':
             # loop over all steps
             for S in local_MS_running:

--- a/pySDC/tests/test_controllers/test_controller_conformance.py
+++ b/pySDC/tests/test_controllers/test_controller_conformance.py
@@ -103,10 +103,16 @@ def get_description(config):
         description['sweeper_params']['num_nodes'] = [3, 2]
         description['space_transfer_class'] = mesh_to_mesh
         description['space_transfer_params'] = {'rorder': 2, 'iorder': 6}
+    if config == 'gauss_seidel':
+        # tuned so the steps converge one after another and the running set drains 4, 3, 2, 1 --
+        # see ``test_gauss_seidel_mssdc_agrees`` for why reaching one matters
+        description['sweeper_params']['num_nodes'] = 2
+        description['level_params'] = {'restol': 1e-10, 'dt': 0.8}
+        description['step_params'] = {'maxiter': 99}
     return description
 
 
-def run(useMPI, config='single_level', probe=False, all_to_done=False, num_procs=NUM_PROCS):
+def run(useMPI, config='single_level', probe=False, all_to_done=False, mssdc_jac=True, num_procs=NUM_PROCS):
     """
     Run one configuration through one of the two transports and return everything the axes compare.
 
@@ -116,7 +122,7 @@ def run(useMPI, config='single_level', probe=False, all_to_done=False, num_procs
     from pySDC.helpers.stats_helper import get_sorted
 
     description = get_description(config)
-    controller_params = {'logger_level': 30, 'all_to_done': all_to_done}
+    controller_params = {'logger_level': 30, 'all_to_done': all_to_done, 'mssdc_jac': mssdc_jac}
     if probe:
         description['convergence_controllers'] = {RecursionProbe: {}}
 
@@ -136,7 +142,8 @@ def run(useMPI, config='single_level', probe=False, all_to_done=False, num_procs
         )
         P = controller.MS[0].levels[0].prob
 
-    uend, stats = controller.run(u0=P.u_exact(0.0), t0=0.0, Tend=num_procs * DT)
+    dt = description['level_params']['dt']
+    uend, stats = controller.run(u0=P.u_exact(0.0), t0=0.0, Tend=num_procs * dt)
 
     probes = [me for me in controller.convergence_controllers if type(me) == RecursionProbe]
     return {
@@ -180,6 +187,7 @@ CASES = {
     'baseline_multi': {'config': 'multi_level'},
     'probe': {'config': 'single_level', 'probe': True},
     'global_convergence': {'config': 'single_level', 'all_to_done': True},
+    'gauss_seidel': {'config': 'gauss_seidel', 'mssdc_jac': False},
 }
 
 
@@ -367,6 +375,54 @@ def test_global_convergence_stays_available(results):
     assert np.array_equal(serial['niter'], mpi['niter']), (
         f'`all_to_done` means different things in the two controllers: '
         f'{serial["niter"][:, 1].tolist()} vs {mpi["niter"][:, 1].tolist()}'
+    )
+
+
+@pytest.mark.mpi4py
+def test_gauss_seidel_mssdc_agrees(results):
+    """
+    Gauss-Seidel MSSDC has to be the same program in both transports too.
+
+    This is the only axis that runs ``mssdc_jac=False``, where a step takes its predecessor's
+    *current* iterate rather than the previous one, so the steps converge strictly in turn and the
+    running set drains one at a time. Nothing else here reaches that path: with Jacobi coupling the
+    block stays whole until the end, so ``it_coarse`` is never the iteration.
+
+    The second assertion is the point, and it is not an equality. When the running set reaches
+    exactly one, the two controllers used to route that last step differently --
+    ``controller_nonMPI`` asked ``len(local_MS_running) == 1``, which is knowledge no single rank
+    has, while ``controller_MPI`` asked ``num_procs == 1`` -- so one went to ``IT_FINE`` and the
+    other to ``IT_COARSE``. Both are now ``S.status.time_size == 1``, the block size either
+    transport can read locally.
+
+    Be clear about what that means for this axis: comparing the two transports would **not** have
+    found that divergence, and does not defend against its return. By the time the set is down to
+    one step, that step has no successor to send to and its predecessor is done, so ``IT_FINE`` and
+    ``IT_COARSE`` both come down to a single ``update_nodes`` -- the two controllers ran different
+    stages and got bit-identical answers. It is the same blind spot the module docstring describes
+    for the pipelining, in a third form: not a property both sides lose at once, but a difference
+    neither side expresses in its output.
+
+    What the axis does buy is the path. ``it_coarse`` as the iteration, and a running set that
+    drains one step at a time, are reached by nothing else in this file, so any *future* divergence
+    there -- one that does change an answer -- now has a test looking at it. The last assertion
+    keeps that true by pinning the configuration rather than the result: if the iteration counts
+    stop ending on a strict increase, the block no longer drains to a single step and this has
+    quietly stopped covering the case it was written for. Retune the problem; do not drop it.
+    """
+    serial, mpi = results['gauss_seidel']
+
+    assert np.array_equal(
+        serial['niter'], mpi['niter']
+    ), f'iteration counts differ: {serial["niter"].tolist()} vs {mpi["niter"].tolist()}'
+    assert np.allclose(
+        serial['uend'], mpi['uend'], atol=ATOL, rtol=RTOL
+    ), f'uend differs by {np.max(np.abs(serial["uend"] - mpi["uend"])):.3e} > {ATOL:.0e}'
+
+    counts = serial['niter'][:, 1]
+    assert counts[-1] > counts[-2], (
+        'the block no longer drains to a single running step, so this axis has stopped covering '
+        f'the routing it was written for -- iteration counts were {counts.tolist()}'
     )
 
 


### PR DESCRIPTION
Collapses the algorithm axis of the controller matrix. ParaDiag stops being a pair of standalone
controllers and becomes a mixin over whichever transport's controller it is used with, so there are
two controllers and not four, and the two ParaDiag ones stop being copies of the PFASST drivers.

```
implementations/controller_classes/ParaDiag.py   class ParaDiag        (no __init__, no base)
    controller_ParaDiag_nonMPI(ParaDiag, controller_nonMPI)
    controller_ParaDiag_MPI  (ParaDiag, controller_MPI)
```

Both inherit `run`, `restart_block`, `spread`, `it_check` and the stage dispatch from their
transport. Each keeps only what depends on where the other steps are -- `apply_matrix`,
`prepare_Jacobians`, `compute_all_at_once_residual`, `update_G_inv`. `ParaDiag` itself holds what is
true of the algorithm whatever the decomposition: the parameter checks, alpha, the weighted
transform, its stages, and its answers to the questions the driver asks.

## Why this axis and not the other one

`controller_ParaDiag_nonMPI` was `controller_nonMPI` with a different iteration and a copy of
everything else: `restart_block` identical line for line, `run` 85%, `spread` 87%. That is where the
duplication was.

The transport axis is not the same shape and is deliberately left alone. Normalise away
`for S in local_MS_running:` and `self.S` -> `S` and the PFASST sweep stages are line-for-line
identical across transports -- but `restart_block` is 14% and `run` 36%. The stage machine is one
program transcribed twice; the driver is two genuinely different programs, and sharing it is a much
larger and riskier change than this one.

## What this is, and is not

Almost all of it is structural. One thing is a defect on master: `controller_ParaDiag_MPI.it_check`
allreduced convergence itself on top of the allreduce `CheckConvergence.communicate_convergence`
already performs -- one redundant collective per ParaDiag iteration at every rank count. Inheriting
`it_check` removes it. Correctness was never affected.

Two latent divergences between the two PFASST controllers are closed, neither of which changes an
answer today:

- the Gauss-Seidel MSSDC routing (`len(local_MS_running) == 1` vs `num_procs == 1`, now
  `S.status.time_size == 1` in both, which is the block size either transport can read locally)
- where the end point gets computed: `controller_MPI` does it in `send_full` and not in
  `it_check`'s done branch, `controller_nonMPI` did the opposite, and the two halves cancelled.
  They no longer have to.

The second one is not academic -- it is what broke ParaDiag under MPI during this work, silently and
only under MPI, because a seam whose contract said "residual" also had to mean "end point".

## Conformance

New axis: Gauss-Seidel MSSDC, four steps, tuned so the block drains 4, 3, 2, 1. Nothing in the suite
ran `mssdc_jac=False` before, so `it_coarse`-as-the-iteration was covered by no axis at all.

The test says plainly that comparing the transports would not have caught the routing divergence it
was written for -- once the set is down to one step both stages reduce to a single `update_nodes`,
so the two controllers ran different code to bit-identical answers. It was verified to pass on
master unchanged. What it buys is the path, plus an assertion on the *configuration* so the axis
cannot quietly stop covering it.

## Verification

- 28 configurations (one and two levels, 1/2/4 steps, Jacobi and Gauss-Seidel MSSDC, one and two
  fine sweeps, both convergence modes, plus ParaDiag) compared against master on `uend`, per-step
  iteration counts, residual history and the shape of the stats emission: **0 changed**, after every
  commit.
- `test_ParaDiag_MPI_matches_nonMPI` still holds the two transports at `rtol=1e-14`, across
  Dahlquist / Dahlquist_IMEX / vdp on 1, 2 and 4 ranks.
- Controllers, tutorials step_6 and step_9, adaptive alpha, ParaDiag sweepers: green.

## Note for anyone importing it

`ParaDiagController` no longer lives in `pySDC.core.controller`; it is `ParaDiag` in
`pySDC.implementations.controller_classes.ParaDiag`. Only the two ParaDiag controllers imported it.
Public controller names, constructor signatures and behaviour are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)