### PR TITLE
Make fenics_grayscott run again, and give it a test

### DIFF
--- a/pySDC/implementations/problem_classes/GrayScott_1D_FEniCS_implicit.py
+++ b/pySDC/implementations/problem_classes/GrayScott_1D_FEniCS_implicit.py
@@ -57,6 +57,14 @@ class fenics_grayscott(Problem):
         Feed rate for :math:`v`.
     B : float, optional
         Overall decay rate for :math:`u`.
+    newton_tol : float, optional
+        Absolute tolerance of the node-local Newton solve. It has to be tighter than the SDC residual
+        tolerance, otherwise the node-local solve, not the SDC iteration, sets the accuracy floor.
+    newton_rtol : float, optional
+        Relative tolerance of the node-local Newton solve. Dolfin stops on whichever bar is met first,
+        so this one has to be lowered alongside ``newton_tol`` to actually tighten the solve.
+    newton_maxiter : int, optional
+        Maximum number of node-local Newton iterations.
 
     Attributes
     ----------
@@ -90,7 +98,21 @@ class fenics_grayscott(Problem):
     dtype_u = fenics_mesh
     dtype_f = fenics_mesh
 
-    def __init__(self, c_nvars=256, t0=0.0, family='CG', order=4, refinements=None, Du=1.0, Dv=0.01, A=0.09, B=0.086):
+    def __init__(
+        self,
+        c_nvars=256,
+        t0=0.0,
+        family='CG',
+        order=4,
+        refinements=None,
+        Du=1.0,
+        Dv=0.01,
+        A=0.09,
+        B=0.086,
+        newton_tol=1e-9,
+        newton_rtol=1e-8,
+        newton_maxiter=100,
+    ):
         """Initialization routine"""
 
         if refinements is None:
@@ -124,6 +146,9 @@ class fenics_grayscott(Problem):
         super(fenics_grayscott, self).__init__(self.V)
         self._makeAttributeAndRegister(
             'c_nvars', 't0', 'family', 'order', 'refinements', 'Du', 'Dv', 'A', 'B', localVars=locals(), readOnly=True
+        )
+        self._makeAttributeAndRegister(
+            'newton_tol', 'newton_rtol', 'newton_maxiter', localVars=locals(), readOnly=False
         )
         # rhs in weak form
         self.w = df.Function(self.V)
@@ -214,9 +239,9 @@ class fenics_grayscott(Problem):
         solver = df.NonlinearVariationalSolver(problem)
 
         prm = solver.parameters
-        prm['newton_solver']['absolute_tolerance'] = 1e-09
-        prm['newton_solver']['relative_tolerance'] = 1e-08
-        prm['newton_solver']['maximum_iterations'] = 100
+        prm['newton_solver']['absolute_tolerance'] = self.newton_tol
+        prm['newton_solver']['relative_tolerance'] = self.newton_rtol
+        prm['newton_solver']['maximum_iterations'] = self.newton_maxiter
         prm['newton_solver']['relaxation_parameter'] = 1.0
 
         solver.solve()

--- a/pySDC/implementations/problem_classes/GrayScott_1D_FEniCS_implicit.py
+++ b/pySDC/implementations/problem_classes/GrayScott_1D_FEniCS_implicit.py
@@ -101,7 +101,7 @@ class fenics_grayscott(Problem):
             return on_boundary
 
         # set logger level for FFC and dolfin
-        df.set_log_level(df.WARNING)
+        df.set_log_level(df.LogLevel.WARNING)
         logging.getLogger('FFC').setLevel(logging.WARNING)
 
         # set solver and form parameters
@@ -113,12 +113,15 @@ class fenics_grayscott(Problem):
         for _ in range(refinements):
             mesh = df.refine(mesh)
 
-        # define function space for future reference
-        V = df.FunctionSpace(mesh, family, order)
-        self.V = V * V
+        # define mixed function space for future reference. `V * V` was removed in DOLFIN 2019.1,
+        # so the mixed space is built from a MixedElement instead.
+        element = df.FiniteElement(family, mesh.ufl_cell(), order)
+        self.V = df.FunctionSpace(mesh, df.MixedElement([element, element]))
 
-        # invoke super init, passing number of dofs
-        super(fenics_grayscott).__init__(V)
+        # invoke super init, passing number of dofs. Note this used to be
+        # `super(fenics_grayscott).__init__(V)`, which builds an unbound super object and therefore
+        # never ran Problem.__init__ at all.
+        super(fenics_grayscott, self).__init__(self.V)
         self._makeAttributeAndRegister(
             'c_nvars', 't0', 'family', 'order', 'refinements', 'Du', 'Dv', 'A', 'B', localVars=locals(), readOnly=True
         )
@@ -263,11 +266,12 @@ class fenics_grayscott(Problem):
             Exact solution (only at :math:`t_0 = 0.0`).
         """
 
-        class InitialConditions(df.Expression):
-            def __init__(self):
-                # fixme: why do we need this?
+        # subclassing df.Expression was removed in DOLFIN 2018.1; UserExpression is the
+        # replacement and requires the base initialiser to run.
+        class InitialConditions(df.UserExpression):
+            def __init__(self, **kwargs):
                 random.seed(2)
-                pass
+                super().__init__(**kwargs)
 
             def eval(self, values, x):
                 values[0] = 1 - 0.5 * np.power(np.sin(np.pi * x[0] / 100), 100)
@@ -278,7 +282,7 @@ class fenics_grayscott(Problem):
 
         assert t == 0, 'ERROR: u_exact only valid for t=0'
 
-        uinit = InitialConditions()
+        uinit = InitialConditions(degree=self.order)
 
         me = self.dtype_u(self.V)
         me.values = df.interpolate(uinit, self.V)

--- a/pySDC/tests/test_problems/test_GrayScott_1D_FEniCS.py
+++ b/pySDC/tests/test_problems/test_GrayScott_1D_FEniCS.py
@@ -74,9 +74,7 @@ def test_runs_in_sdc():
         'level_params': {'restol': -1, 'dt': 1.0},
         'step_params': {'maxiter': 4},
     }
-    controller = controller_nonMPI(
-        num_procs=1, controller_params={'logger_level': 30}, description=description
-    )
+    controller = controller_nonMPI(num_procs=1, controller_params={'logger_level': 30}, description=description)
     prob = controller.MS[0].levels[0].prob
     u0 = prob.u_exact(0.0)
     uend, _ = controller.run(u0=u0, t0=0.0, Tend=2.0)

--- a/pySDC/tests/test_problems/test_GrayScott_1D_FEniCS.py
+++ b/pySDC/tests/test_problems/test_GrayScott_1D_FEniCS.py
@@ -1,0 +1,85 @@
+"""
+Regression coverage for the FEniCS Gray-Scott problem.
+
+This problem class had no test and had silently rotted against DOLFIN 2019.1.0 -- the version
+``etc/environment-fenics.yml`` pins -- to the point where it could not be constructed at all. These
+tests pin the basics so that cannot happen again.
+"""
+
+import pytest
+
+PARAMS = {
+    'c_nvars': 64,
+    't0': 0.0,
+    'family': 'CG',
+    'order': 2,
+    'refinements': 1,
+    'Du': 1.0,
+    'Dv': 0.01,
+    'A': 0.09,
+    'B': 0.086,
+}
+
+
+@pytest.mark.fenics
+def test_construction_runs_the_base_initialiser():
+    """``Problem.__init__`` must actually run, which an unbound ``super()`` call skipped."""
+    from pySDC.implementations.problem_classes.GrayScott_1D_FEniCS_implicit import fenics_grayscott
+
+    prob = fenics_grayscott(**PARAMS)
+
+    assert hasattr(prob, 'init'), 'Problem.__init__ did not run'
+    assert hasattr(prob, 'logger'), 'Problem.__init__ did not run'
+    assert prob.V.num_sub_spaces() == 2, 'expected a mixed space with two components'
+
+
+@pytest.mark.fenics
+def test_basic_operations():
+    """Initial value, right-hand side and implicit solve must all work."""
+    from pySDC.implementations.problem_classes.GrayScott_1D_FEniCS_implicit import fenics_grayscott
+
+    prob = fenics_grayscott(**PARAMS)
+
+    u = prob.u_exact(0.0)
+    assert abs(u) > 0.0
+
+    f = prob.eval_f(u, 0.0)
+    assert abs(f) > 0.0
+
+    solution = prob.solve_system(u, 0.01, u, 0.0)
+    assert abs(solution) > 0.0
+
+    with pytest.raises(AssertionError):
+        prob.u_exact(1.0)
+
+
+@pytest.mark.fenics
+def test_runs_in_sdc():
+    """A short SDC run must complete and stay bounded."""
+    from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
+    from pySDC.implementations.problem_classes.GrayScott_1D_FEniCS_implicit import fenics_grayscott
+    from pySDC.implementations.sweeper_classes.generic_implicit import generic_implicit
+
+    description = {
+        'problem_class': fenics_grayscott,
+        'problem_params': PARAMS,
+        'sweeper_class': generic_implicit,
+        'sweeper_params': {
+            'quad_type': 'RADAU-RIGHT',
+            'node_type': 'LEGENDRE',
+            'num_nodes': 3,
+            'QI': 'LU',
+            'initial_guess': 'spread',
+        },
+        'level_params': {'restol': -1, 'dt': 1.0},
+        'step_params': {'maxiter': 4},
+    }
+    controller = controller_nonMPI(
+        num_procs=1, controller_params={'logger_level': 30}, description=description
+    )
+    prob = controller.MS[0].levels[0].prob
+    u0 = prob.u_exact(0.0)
+    uend, _ = controller.run(u0=u0, t0=0.0, Tend=2.0)
+
+    assert abs(uend) > 0.0
+    assert abs(uend - u0) < 1.0, 'solution moved implausibly far in two steps'


### PR DESCRIPTION
`fenics_grayscott` has not been constructible for some time. It fails on the first line of
`__init__` against the DOLFIN the project pins (2019.1.0):

```
AttributeError: module 'dolfin' has no attribute 'WARNING'
```

There was no test, which is how it rotted. Four independent breakages, each hiding the next:

| | |
|---|---|
| `df.set_log_level(df.WARNING)` | moved to `df.LogLevel.WARNING` |
| `self.V = V * V` | `*` on function spaces removed in 2019.1; built from a `MixedElement` instead |
| `super(fenics_grayscott).__init__(V)` | builds an *unbound* super object, so `Problem.__init__` never ran at all |
| `class InitialConditions(df.Expression)` | subclassing `Expression` removed in 2018.1; `UserExpression`, whose base initialiser has to run, and `interpolate` needs a `degree` |

The third is the interesting one: the missing `self` meant the problem carried no `init`, no
`params` and no work counters, so even after the API fixes nothing downstream would have worked.

Second commit makes the node-local Newton tolerances parameters rather than hard-coded 1e-9 / 1e-8.
Below that bar the node-local solve, not the outer iteration, sets the accuracy floor — and DOLFIN
stops on whichever tolerance is met first, so the relative one has to come down alongside the
absolute one. Defaults are the previous values, so no caller moves.

## Test

`pySDC/tests/test_problems/test_GrayScott_1D_FEniCS.py`, three `fenics`-marked tests: construction
(including that the base initialiser actually ran and the space really is mixed), the three basic
operations, and a short SDC run. All three fail on master with the `AttributeError` above.

The FEniCS job had 1 test in `pySDC/tests` before this; it has 4 now.

Found while adding FEniCS coverage for a mixed-precision project, where this was the reason the
nonlinear FEniCS route could not be exercised. It stands alone and is otherwise unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)