### PR TITLE
Support both NumPy majors, and cover both in CI

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -145,6 +145,10 @@ jobs:
           - soft_failure
           - TOMS
           - StroemungsRaum
+        numpy: ['', '=1']
+        # Both NumPy majors here too. No python axis to exclude against: every project environment
+        # allows the whole 3.10-3.13 range, so `numpy=1` simply resolves the newest python that has
+        # NumPy 1 builds for that project's backends.
     defaults:
       run:
         shell: bash -l {0}
@@ -155,6 +159,8 @@ jobs:
         uses: mamba-org/setup-micromamba@v3
         with:
           environment-file: "pySDC/projects/${{ matrix.env }}/environment.yml"
+          create-args: >-
+              numpy${{ matrix.numpy }}
       - name: Install additional packages as needed
         run: |
           micromamba install -y --file etc/environment-tests.yml --freeze-installed

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -75,6 +75,14 @@ jobs:
       matrix:
         env: ['base', 'fenics', 'mpi4py', 'petsc', 'pytorch']
         python: ['3.10', '3.11', '3.12', '3.13']
+        numpy: ['', '=1']
+        # pySDC supports both NumPy majors, so every backend is run against both. NumPy 1 gets one
+        # python rather than four: 1.26 is the last 1.x release, it does not support 3.13 at all,
+        # and 3.12 is the newest python all five backends still have NumPy 1 builds for.
+        exclude:
+          - {numpy: '=1', python: '3.10'}
+          - {numpy: '=1', python: '3.11'}
+          - {numpy: '=1', python: '3.13'}
     defaults:
       run:
         shell: bash -l {0}
@@ -87,6 +95,7 @@ jobs:
           environment-file: "etc/environment-${{ matrix.env }}.yml"
           create-args: >-
               python=${{ matrix.python }}
+              numpy${{ matrix.numpy }}
       - name: Install additional packages as needed
         run: |
           micromamba install -y --file etc/environment-tests.yml --freeze-installed

--- a/pySDC/projects/compression/Docker/install_pySDC.sh
+++ b/pySDC/projects/compression/Docker/install_pySDC.sh
@@ -12,7 +12,11 @@ spack load libpressio
 # install local version of pySDC and other dependencies
 python -m pip install --upgrade pip
 cd /pySDC
-pip install -e .
+# numpy<2 is this image's constraint, not pySDC's: libpressio here is a spack build whose `_pressio`
+# extension is compiled against NumPy 1.x, and it fails to import the moment anything replaces numpy
+# underneath it. Held explicitly rather than relying on the image's preinstalled numpy happening to
+# satisfy the resolver.
+pip install -e . "numpy<2"
 python -m pip install pytest
 python -m pip install coverage
 python -m pip install "mpi4py<4.1.0"

--- a/pySDC/tests/test_helpers/test_spectral_helper.py
+++ b/pySDC/tests/test_helpers/test_spectral_helper.py
@@ -148,7 +148,10 @@ def test_matrix1D(N, base, type):
     helper.add_axis(base=base, N=N)
     helper.setup_fft()
 
-    x = helper.get_grid()
+    # np.asarray, because `get_grid` hands back a list of per-axis grids and NumPy 1's
+    # `Chebyshev.__call__` cannot multiply a list by a scalar. NumPy 2 converts it itself, so this
+    # is what NumPy 2 was already doing, spelled out for both.
+    x = np.asarray(helper.get_grid())
 
     if type == 'diff':
         D = helper.get_differentiation_matrix(axes=(-1,))


### PR DESCRIPTION
Follow-up to the reverted floor bump (253649ada / bd3aa0b1f). Policy here is that pySDC works on **both** NumPy majors, with the libpressio container the one place held at NumPy 1.

## Why the revert happened

The floor bump went green across all 20 matrix jobs and still broke `user_libpressio_tests`. That container ships numpy 1.24.3 and a spack-built libpressio whose `_pressio` extension is compiled against NumPy 1.x; its `pip install -e .` honoured the new floor by replacing numpy underneath it (`_ARRAY_API not found`). It was the only environment still genuinely on NumPy 1, and nothing in CI was watching that axis — which is the real gap this PR closes.

## What is here

**Let the spectral helper's 1D matrix test run on NumPy 1 too.** `get_grid` returns a list of per-axis grids and NumPy 1's `Chebyshev.__call__` cannot multiply a list by an `np.float64`. These four tests were the *only* thing between the suite and a green NumPy 1 run. `np.asarray` is what NumPy 2 does internally, so neither major changes what it computes.

**Hold the libpressio container at NumPy 1.** Explicit `"numpy<2"` instead of relying on the image's preinstalled numpy happening to satisfy the resolver. The constraint is the image's, not pySDC's — the real fix is an image whose libpressio is built against NumPy 2.

**Run every backend against both NumPy majors**, in the framework matrix and the project matrix alike:

| matrix | before | after |
|---|---|---|
| `user_cpu_tests_linux` | 20 | 25 — 20 latest + 5 NumPy 1 (all five backends at 3.12) |
| `project_cpu_tests_linux` | 17 | 34 — all seventeen projects on both |

NumPy 1 gets one python in the framework matrix because 1.26 is the last 1.x, has no 3.13 build, and 3.12 is the newest python all five backends still have NumPy 1 builds for. The project matrix needs no exclusions: every project environment allows the whole 3.10–3.13 range.

The three container jobs are deliberately untouched — their images fix their own numpy.

## Verified locally

| | result |
|---|---|
| base suite, numpy 1.26.4 | **3320 passed, 0 failed** (env has vtk + numba + mpi4py-fft, nothing skipped) |
| base suite, numpy 2.4.6 | 3245 passed; 166 failures all `ModuleNotFoundError` for modules that env lacks |
| `test_matrix1D`, both majors | 4 passed each |
| nine project suites, numpy 1.26.4 | 138 passed; all 52 failures identical under numpy 2.4.6 (50 missing local `mpirun`, 2 pre-existing DAE assertions) |
| `-m "fenics or petsc"`, both majors | identical results |
| `numpy=1` solves, framework | base → numba 0.67.0, mpi4py → mpi4py-fft 2.0.6, petsc → petsc4py 3.21.6, pytorch → 2.13.0 |
| `numpy=1` solves, projects | all seven with backend pins land on numpy 1.26.4 / python 3.12 — SDC_showdown petsc4py 3.21.6, RayleighBenard + Resilience + AllenCahn_Bayreuth mpi4py-fft 2.0.6, Second_orderSDC numba 0.67.0, StroemungsRaum fenics-dolfin 2019.1.0 |

## Cost

Measured from run 34592842553: CI spends **149 machine-min** today. The five framework legs add ~23 (19 of which is the single `mpi4py` job), the seventeen project legs add ~36. Wall clock is set by `user_cpu_tests_linux (mpi4py)` at ~19 min and should not move, since the added project jobs are 0–6 min each.

The container change is the one thing I could not exercise locally — no amd64 spack image here. CI is the check.

## Left alone deliberately

`pyproject.toml` still says `numpy>=1.15.4`. CI will now verify 1.26 and current 2.x, so the lower bound remains a claim nothing tests; tightening it to a tested floor is a separate policy call.

`user_libpressio_tests` now has no NumPy 2 coverage at all, and cannot until that image's libpressio is rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)