### PR TITLE
The delta-form MLSDC hierarchy

### DIFF
--- a/pySDC/implementations/transfer_classes/BaseTransferDelta.py
+++ b/pySDC/implementations/transfer_classes/BaseTransferDelta.py
@@ -1,0 +1,159 @@
+r"""
+Space-time transfer for the delta-form hierarchy.
+
+:class:`BaseTransfer` makes a coarse level rebuild its own residual from :math:`\mathcal{O}(1)`
+coarse data and recovers the coarse-grid correction as :math:`u_G - u_G^{\mathrm{old}}`. Both have
+exact algebraic replacements -- :math:`\varepsilon_G = R\varepsilon_F`, which is what the FAS
+:math:`\tau` is *for*, and the correction is the sum of the sweep's own increments -- and this
+transfer uses those instead. It is what decides whether a level rebuilds its residual or is handed
+one: the delta-form sweepers do both, and this is what hands one down.
+
+Identical to :class:`BaseTransfer` up to round-off at backend precision, verified for two, three and
+four levels and for PFASST. It is also slightly cheaper, because :math:`\tau` is then never read:
+see :meth:`delta_transfer.restrict`.
+
+What the reformulation buys is that every coarse-level quantity becomes proportional to the fine
+residual rather than to :math:`|u|`. A coarse level is a preconditioner whose returned correction
+tends to zero, so once nothing on it is rebuilt out of :math:`\mathcal{O}(1)` state, its arithmetic
+error is proportional to that correction rather than to the solution -- which is what lets it run
+below backend precision without capping the accuracy of the iteration.
+"""
+
+from pySDC.core.base_transfer import BaseTransfer
+from pySDC.core.errors import UnlockError
+
+
+class delta_transfer(BaseTransfer):
+    """
+    Space-time transfer that passes a residual down and an accumulated correction up.
+
+    Drop-in for :class:`BaseTransfer`, and identical to it up to round-off when every level is at
+    backend precision. Falls back to the stock prolongation when the coarse level has banked no
+    corrections, so a hierarchy mixing delta-form and stock sweepers still runs.
+    """
+
+    def coarse_reads_tau(self):
+        """
+        Whether the coarse level reads the FAS :math:`\\tau` at all.
+
+        The sweep does not -- it is handed the restricted fine residual, which is what :math:`\\tau`
+        exists to produce -- and neither does :meth:`DeltaFormMixin.compute_residual`. The one
+        remaining reader is :meth:`compute_end_point`, and only when the end point comes from the
+        quadrature update rather than a copy of the last node. When nothing reads it, building it is
+        a coarse ``integrate()`` and a restriction spent on a quantity that is then discarded.
+
+        Returns
+        -------
+        bool
+            Whether :math:`\\tau` has to be built.
+        """
+        SG = self.coarse.sweep
+        return not (SG.coll.right_is_node and not SG.params.do_coll_update)
+
+    def restrict_state(self):
+        """
+        Restrict ``u`` and re-evaluate ``f``, which is :meth:`BaseTransfer.restrict` without
+        :math:`\\tau`.
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        UnlockError
+            If the fine level has not been unlocked yet.
+        """
+        F, G = self.fine, self.coarse
+        SF, SG, PG = F.sweep, G.sweep, G.prob
+        if not F.status.unlocked:
+            raise UnlockError('fine level is still locked, cannot use data from there')
+
+        tmp_u = [self.space_transfer.restrict(F.u[m]) for m in range(1, SF.coll.num_nodes + 1)]
+        G.u[0] = self.space_transfer.restrict(F.u[0])
+        for n in range(1, SG.coll.num_nodes + 1):
+            # float(), not the raw np.float64 entry: see DeltaFormMixin._coeff
+            G.u[n] = float(self.Rcoll[n - 1, 0]) * tmp_u[0]
+            for m in range(1, SF.coll.num_nodes):
+                G.u[n] += float(self.Rcoll[n - 1, m]) * tmp_u[m]
+
+        G.f[0] = PG.eval_f(G.u[0], G.time)
+        for m in range(1, SG.coll.num_nodes + 1):
+            G.f[m] = PG.eval_f(G.u[m], G.time + G.dt * SG.coll.nodes[m - 1])
+            G.uold[m] = PG.dtype_u(G.u[m])
+            G.fold[m] = PG.dtype_f(G.f[m])
+
+        G.status.unlocked = True
+        return None
+
+    def restrict(self):
+        """
+        Restrict the state, then hand the coarse level the restricted fine residual.
+
+        Returns
+        -------
+        None
+        """
+        SF, SG = self.fine.sweep, self.coarse.sweep
+        SF._delta_setup()
+        SG._delta_setup()
+        eps_F = SF._residual_nodes()
+        super().restrict() if self.coarse_reads_tau() else self.restrict_state()
+
+        tmp = [self.space_transfer.restrict(eps) for eps in eps_F]
+        eps_G = []
+        for n in range(SG.coll.num_nodes):
+            acc = float(self.Rcoll[n, 0]) * tmp[0]
+            for m in range(1, SF.coll.num_nodes):
+                acc += float(self.Rcoll[n, m]) * tmp[m]
+            eps_G.append(SG._to_work(self.coarse.prob, acc))
+        SG.eps_in = eps_G
+        SG.delta_acc = None
+        # after the rounding, so the reference is the value the level actually holds and a level
+        # that receives nothing shifts its residual by exactly zero
+        self.coarse.u0_reference = self.coarse.prob.dtype_u(self.coarse.u[0])
+        return None
+
+    def prolong(self):
+        """
+        Add the coarse level's accumulated correction to the fine level.
+
+        If the fine level is itself a coarse level of something above it, its residual and its own
+        accumulated correction are advanced by the same update, so neither has to be rebuilt from
+        :math:`\\mathcal{O}(1)` state later in the V-cycle.
+
+        Returns
+        -------
+        None
+        """
+        if self.coarse.sweep.delta_acc is None:
+            return super().prolong()
+
+        F, PF = self.fine, self.fine.prob
+        SF, SG = self.fine.sweep, self.coarse.sweep
+        SF._delta_setup()
+        tmp = [self.space_transfer.prolong(delta) for delta in self.coarse.sweep.delta_acc]
+
+        corr = []
+        for n in range(1, SF.coll.num_nodes + 1):
+            c = float(self.Pcoll[n - 1, 0]) * tmp[0]
+            for m in range(1, SG.coll.num_nodes):
+                c += float(self.Pcoll[n - 1, m]) * tmp[m]
+            # Quantise the correction at the correction precision, then bring it back to backend
+            # units before applying it. `_to_work` alone also divides by the sweep's scale, and
+            # adding *that* to the nodal value would be wrong by a factor of the scale.
+            c = SF._to_backend(PF, SF._to_work(PF, c))
+            corr.append(SF._to_work(PF, c))
+
+            t_node = F.time + F.dt * SF.coll.nodes[n - 1]
+            u_old, f_old = PF.dtype_u(F.u[n]), PF.dtype_f(F.f[n])
+            F.u[n] += c
+            F.f[n] = PF.eval_f(F.u[n], t_node)
+            if SF.eps_in is not None:
+                # records into SF._dfs, which is what advance_residual reads below
+                SF._f_increment(PF, F.f[n], f_old, u_old, c, t_node)
+
+        if SF.eps_in is not None:
+            SF.eps_in = SF.advance_residual(SF.eps_in, corr, SF._dfs)
+            SF.accumulate(corr)
+        return None

--- a/pySDC/implementations/transfer_classes/BaseTransferDelta.py
+++ b/pySDC/implementations/transfer_classes/BaseTransferDelta.py
@@ -8,9 +8,18 @@ exact algebraic replacements -- :math:`\varepsilon_G = R\varepsilon_F`, which is
 transfer uses those instead. It is what decides whether a level rebuilds its residual or is handed
 one: the delta-form sweepers do both, and this is what hands one down.
 
+The FAS :math:`\tau` is **substituted, not discarded**. Writing
+:math:`\tau = R(\Delta t\,Q_F f_F) - \Delta t\,Q_G f_G` and putting it into the coarse residual
+:math:`\Delta t (Q_G f_G) + u_G[0] - u_G[m] + \tau` cancels the :math:`\Delta t\,Q_G f_G` terms
+identically and leaves :math:`R\varepsilon_F`. So a coarse level handed that residual is solving
+precisely the FAS-corrected problem -- and must *not* also add :math:`\tau`, which would count it
+twice. What is skipped is materialising :math:`\tau` as an array, since the quantity it exists to
+produce arrives directly.
+
 Identical to :class:`BaseTransfer` up to round-off at backend precision, verified for two, three and
-four levels and for PFASST. It is also slightly cheaper, because :math:`\tau` is then never read:
-see :meth:`delta_transfer.restrict`.
+four levels and for PFASST -- and against a control with :math:`\tau` genuinely zeroed, which does
+not converge at all. It is also slightly cheaper, because nothing then reads :math:`\tau` except
+:meth:`compute_end_point` in the quadrature-update case: see :meth:`delta_transfer.restrict`.
 
 What the reformulation buys is that every coarse-level quantity becomes proportional to the fine
 residual rather than to :math:`|u|`. A coarse level is a preconditioner whose returned correction

--- a/pySDC/implementations/transfer_classes/BaseTransferDeltaMPI.py
+++ b/pySDC/implementations/transfer_classes/BaseTransferDeltaMPI.py
@@ -1,0 +1,88 @@
+r"""
+Node-parallel counterpart of :mod:`pySDC.implementations.transfer_classes.BaseTransferDelta`.
+
+Same two identities -- the coarse residual is the restricted fine residual, and the coarse-grid
+correction is the sum of the sweep's own increments -- with every loop over collocation nodes
+written as the reduction the node-parallel layout needs, since one rank holds one node.
+
+One difference from the serial transfer: this one still builds the FAS :math:`\tau`, which the
+delta-form hierarchy then never reads. Skipping it is the saving
+:meth:`BaseTransferDelta.delta_transfer.restrict_state` takes, and it has not been written for the
+node-parallel layout yet.
+"""
+
+from mpi4py import MPI
+
+from pySDC.implementations.transfer_classes.BaseTransferMPI import base_transfer_MPI
+
+
+class delta_transfer_MPI(base_transfer_MPI):
+    """
+    Node-parallel counterpart of
+    :class:`~pySDC.implementations.transfer_classes.BaseTransferDelta.delta_transfer`.
+
+    Same two identities -- the coarse residual is the restricted fine residual, and the coarse-grid
+    correction is the sum of the sweep's own increments -- with the collocation transfer written as
+    a reduction, since each rank holds one node.
+    """
+
+    def restrict(self):
+        """
+        Restrict as usual, then hand the coarse level the restricted fine residual.
+
+        Returns
+        -------
+        None
+        """
+        SF, SG = self.fine.sweep, self.coarse.sweep
+        SF._delta_setup()
+        SG._delta_setup()
+        eps_F = SF._residual_nodes()[0]
+        super().restrict()
+
+        CF, CG, PG = self.comm_fine, self.comm_coarse, self.coarse.prob
+        tmp = self.space_transfer.restrict(eps_F)
+        received = PG.u_init
+        for n in range(SG.coll.num_nodes):
+            CF.Reduce(self.Rcoll[n, CF.rank] * tmp, received if n == CG.rank else None, root=n, op=MPI.SUM)
+
+        SG.eps_in = [SG._to_work(PG, received)]
+        SG.delta_acc = None
+        self.coarse.u0_reference = PG.dtype_u(self.coarse.u[0])
+        return None
+
+    def prolong(self):
+        """
+        Add the coarse level's accumulated correction to the fine level.
+
+        Returns
+        -------
+        None
+        """
+        if self.coarse.sweep.delta_acc is None:
+            return super().prolong()
+
+        F, PF = self.fine, self.fine.prob
+        SF, CF, CG = self.fine.sweep, self.comm_fine, self.comm_coarse
+        SF._delta_setup()
+        tmp = self.space_transfer.prolong(self.coarse.sweep.delta_acc[0])
+
+        correction = PF.u_init
+        for n in range(SF.coll.num_nodes):
+            CG.Reduce(self.Pcoll[n, CG.rank] * tmp, correction if n == CF.rank else None, root=n, op=MPI.SUM)
+        # quantised, then back to backend units before it is applied -- see the serial transfer
+        applied = SF._to_backend(PF, SF._to_work(PF, correction))
+        correction = SF._to_work(PF, applied)
+
+        rank = CF.rank
+        t_node = F.time + F.dt * SF.coll.nodes[rank]
+        u_old, f_old = PF.dtype_u(F.u[rank + 1]), PF.dtype_f(F.f[rank + 1])
+        F.u[rank + 1] += applied
+        F.f[rank + 1] = PF.eval_f(F.u[rank + 1], t_node)
+
+        if SF.eps_in is not None:
+            # records into SF._dfs, which is what advance_residual reads
+            SF._f_increment(PF, F.f[rank + 1], f_old, u_old, applied, t_node)
+            SF.eps_in = SF.advance_residual(SF.eps_in, [correction], SF._dfs)
+            SF.accumulate([correction])
+        return None

--- a/pySDC/tests/test_transfer_classes/test_BaseTransferDelta.py
+++ b/pySDC/tests/test_transfer_classes/test_BaseTransferDelta.py
@@ -1,0 +1,286 @@
+r"""
+Tests for :mod:`pySDC.implementations.transfer_classes.BaseTransferDelta`.
+
+The hierarchy replaces two cancellations of :math:`\mathcal{O}(1)` quantities with exact
+identities. The first three tests check the identities; the rest check that using them changes no
+answer, at two, three and four levels and under PFASST.
+
+What the rewrite *buys* -- a coarse level below backend precision -- needs controls that must break,
+and is measured separately. What is asserted here is the other half: that using the identities costs
+nothing at backend precision.
+"""
+
+import pytest
+
+SWEEPER_PARAMS = {
+    'quad_type': 'RADAU-RIGHT',
+    'node_type': 'LEGENDRE',
+    'num_nodes': 3,
+    'QI': 'LU',
+    'initial_guess': 'spread',
+}
+
+HEAT_PARAMS = {
+    'nu': 1.0,
+    'freq': 2,
+    'bc': 'dirichlet-zero',
+    'order': 2,
+    'solver_type': 'direct',
+}
+
+
+def sweeper_params(**extra):
+    params = dict(SWEEPER_PARAMS, linear_implicit=True)
+    params.update(extra)
+    return params
+
+
+def build(nvars, sweeper_class, transfer_class, num_procs=1, maxiter=6, dt=1e-1, **extra):
+    """Build a controller on the heat equation with the given hierarchy."""
+    from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
+    from pySDC.implementations.transfer_classes.TransferMesh import mesh_to_mesh
+    from pySDC.implementations.problem_classes.HeatEquation_ND_FD import heatNd_unforced
+
+    description = {
+        'problem_class': heatNd_unforced,
+        'problem_params': dict(HEAT_PARAMS, nvars=nvars),
+        'sweeper_class': sweeper_class,
+        'sweeper_params': sweeper_params(**extra),
+        'level_params': {'restol': -1, 'dt': dt},
+        'step_params': {'maxiter': maxiter},
+        'space_transfer_class': mesh_to_mesh,
+        'space_transfer_params': {'iorder': 4, 'rorder': 2},
+        'base_transfer_class': transfer_class,
+    }
+    return controller_nonMPI(num_procs=num_procs, controller_params={'logger_level': 30}, description=description)
+
+
+def run(*args, nsteps=1, dt=1e-1, **kwargs):
+    """Run and return the end value."""
+    controller = build(*args, dt=dt, **kwargs)
+    prob = controller.MS[0].levels[0].prob
+    uend, _ = controller.run(u0=prob.u_exact(0.0), t0=0.0, Tend=nsteps * dt)
+    return uend
+
+
+def floor(*args, nsteps=1, dt=1e-1, **kwargs):
+    """Run and return the residual floor, which is what a stalling iteration shows."""
+    from pySDC.helpers.stats_helper import get_sorted
+
+    controller = build(*args, dt=dt, **kwargs)
+    prob = controller.MS[0].levels[0].prob
+    _, stats = controller.run(u0=prob.u_exact(0.0), t0=0.0, Tend=nsteps * dt)
+    return min(value for _, value in get_sorted(stats, type='residual_post_iteration', sortby='iter'))
+
+
+def tau_building(transfer_class):
+    """
+    A transfer that builds the FAS tau even though the delta hierarchy does not read it.
+
+    The two identity tests below compare the inherited residual against the one a coarse level would
+    have rebuilt from its own state, and that rebuild needs tau. The lean path deliberately skips
+    building it, so the comparison is made on the path where the quantity exists;
+    :func:`test_lean_restriction_changes_nothing` then checks that skipping it changes no answer.
+    """
+
+    class with_tau(transfer_class):
+        def coarse_reads_tau(self):
+            return True
+
+    return with_tau
+
+
+def nrm(value):
+    import numpy as np
+
+    return float(np.max(np.abs(np.asarray(value))))
+
+
+@pytest.mark.base
+def test_coarse_residual_is_the_restricted_fine_residual():
+    """
+    The identity the coarse level's residual is replaced by.
+
+    Stock MLSDC rebuilds ``eps_G = u_G[0] + tau + dt (Q f_G) - u_G[m]`` from O(1) coarse data;
+    analytically that *is* the restricted fine residual, which is what the FAS tau is for. If this
+    identity did not hold, the hierarchy would be solving a different problem.
+    """
+    from pySDC.implementations.sweeper_classes.delta_form import delta_implicit
+    from pySDC.implementations.transfer_classes.BaseTransferDelta import delta_transfer
+
+    deviations = []
+
+    class checking_transfer(tau_building(delta_transfer)):
+        def restrict(self):
+            super().restrict()
+            # what the coarse level would have computed the stock way, from its own O(1) state
+            rebuilt = delta_implicit._residual_nodes(self.coarse.sweep)
+            inherited = self.coarse.sweep.eps_in
+            deviations.append(max(nrm(a - b) for a, b in zip(rebuilt, inherited)))
+
+    run([127, 63], delta_implicit, checking_transfer)
+
+    assert len(deviations) > 1, 'the transfer never ran'
+    assert max(deviations) < 1e-13, f'the two residuals differ by {max(deviations):.3e}'
+
+
+@pytest.mark.base
+def test_accumulated_correction_is_the_coarse_grid_correction():
+    """
+    The identity the coarse-grid correction is replaced by.
+
+    Stock MLSDC recovers it as ``G.u - G.uold``, a difference of two O(1) states; it is also the sum
+    of the sweep's own increments, which is what the delta transfer prolongs instead.
+    """
+    from pySDC.implementations.sweeper_classes.delta_form import delta_implicit
+    from pySDC.implementations.transfer_classes.BaseTransferDelta import delta_transfer
+
+    deviations = []
+
+    class checking_transfer(delta_transfer):
+        def prolong(self):
+            accumulated = self.coarse.sweep.delta_acc
+            differenced = [self.coarse.u[m + 1] - self.coarse.uold[m + 1] for m in range(len(accumulated))]
+            deviations.append(max(nrm(a - b) for a, b in zip(accumulated, differenced)))
+            super().prolong()
+
+    run([127, 63], delta_implicit, checking_transfer)
+
+    assert len(deviations) > 1, 'the transfer never ran'
+    assert max(deviations) < 1e-13, f'the two corrections differ by {max(deviations):.3e}'
+
+
+@pytest.mark.base
+def test_residual_recursion_tracks_the_real_residual():
+    """
+    ``eps <- eps - delta + dt (Q df)`` must keep agreeing with the residual recomputed from scratch.
+
+    This is what lets a level carry its residual through sweeps and prolongations instead of
+    rebuilding it out of O(1) state, so it has to hold after every one of them.
+    """
+    from pySDC.implementations.sweeper_classes.delta_form import delta_implicit
+    from pySDC.implementations.transfer_classes.BaseTransferDelta import delta_transfer
+
+    deviations = []
+
+    class checking_sweeper(delta_implicit):
+        def update_nodes(self):
+            super().update_nodes()
+            if self.eps_in is not None:
+                rebuilt = delta_implicit._residual_nodes(self)
+                deviations.append(max(nrm(a - b) for a, b in zip(rebuilt, self.eps_in)))
+
+    # three levels, so a middle level is swept, restricted from, prolonged onto and swept again
+    run([127, 63, 31], checking_sweeper, tau_building(delta_transfer))
+
+    assert len(deviations) > 1, 'the recursion never ran'
+    assert max(deviations) < 1e-13, f'the tracked residual drifted by {max(deviations):.3e}'
+
+
+@pytest.mark.base
+@pytest.mark.parametrize('nvars', [[127, 63], [127, 63, 31], [127, 63, 31, 15]])
+def test_matches_stock_mlsdc(nvars):
+    """At backend precision the delta hierarchy is an algebraic rewrite, so it must change nothing."""
+    from pySDC.core.base_transfer import BaseTransfer
+    from pySDC.implementations.sweeper_classes.delta_form import delta_implicit
+    from pySDC.implementations.transfer_classes.BaseTransferDelta import delta_transfer
+
+    stock = run(nvars, delta_implicit, BaseTransfer)
+    delta = run(nvars, delta_implicit, delta_transfer)
+    assert abs(stock - delta) < 1e-13, f'{len(nvars)}-level MLSDC deviates by {abs(stock - delta):.3e}'
+
+
+@pytest.mark.base
+@pytest.mark.parametrize('num_procs', [2, 4])
+def test_pfasst(num_procs):
+    """Multiple levels and multiple steps in a block, which MLSDC alone does not cover."""
+    from pySDC.core.base_transfer import BaseTransfer
+    from pySDC.implementations.sweeper_classes.delta_form import delta_implicit
+    from pySDC.implementations.transfer_classes.BaseTransferDelta import delta_transfer
+
+    stock = run([127, 63], delta_implicit, BaseTransfer, num_procs=num_procs, nsteps=num_procs)
+    delta = run([127, 63], delta_implicit, delta_transfer, num_procs=num_procs, nsteps=num_procs)
+    assert abs(stock - delta) < 1e-13, f'PFASST on {num_procs} steps deviates by {abs(stock - delta):.3e}'
+
+
+@pytest.mark.base
+@pytest.mark.parametrize('nvars', [[127, 63], [127, 63, 31]])
+def test_lean_restriction_changes_nothing(nvars):
+    """
+    Skipping the tau construction is an optimisation, so it has to be invisible in the answer.
+
+    The delta hierarchy reads the restricted fine residual instead, and its own
+    ``compute_residual`` reports the residual it already tracks, so nothing is left that reads tau --
+    except ``compute_end_point`` in the quadrature-update case, which is what the gate is for.
+    """
+    from pySDC.implementations.sweeper_classes.delta_form import delta_implicit
+    from pySDC.implementations.transfer_classes.BaseTransferDelta import delta_transfer
+
+    lean = run(nvars, delta_implicit, delta_transfer)
+    built = run(nvars, delta_implicit, tau_building(delta_transfer))
+    assert abs(lean - built) < 1e-13, f'the lean restriction moved the answer by {abs(lean - built):.3e}'
+
+
+@pytest.mark.base
+def test_coarse_level_reports_the_residual_it_tracks():
+    """
+    A coarse level's reported residual must still be the FAS residual, not a rebuild without tau.
+
+    It is only ever logged, so a wrong value here would not fail anything else -- which is exactly
+    why it is checked. Compared against what the stock hierarchy reports for the same level.
+    """
+    from pySDC.core.base_transfer import BaseTransfer
+    from pySDC.implementations.sweeper_classes.delta_form import delta_implicit
+    from pySDC.implementations.transfer_classes.BaseTransferDelta import delta_transfer
+
+    seen = {}
+
+    def watched(transfer_class, key):
+        class watcher(transfer_class):
+            def prolong(self):
+                seen.setdefault(key, []).append(self.coarse.status.residual)
+                super().prolong()
+
+        return watcher
+
+    stock = build([127, 63], delta_implicit, watched(BaseTransfer, 'stock'))
+    delta = build([127, 63], delta_implicit, watched(delta_transfer, 'delta'))
+    for controller in (stock, delta):
+        prob = controller.MS[0].levels[0].prob
+        controller.run(u0=prob.u_exact(0.0), t0=0.0, Tend=1e-1)
+
+    assert len(seen['stock']) > 2, 'the coarse level never reported a residual'
+    assert len(seen['stock']) == len(seen['delta'])
+    for a, b in zip(seen['stock'], seen['delta']):
+        # The two routes differ by round-off, which stays around 1e-14 absolute while the residual
+        # falls, so the bar has to be absolute as well as relative. It still discriminates: a
+        # residual rebuilt without tau differs by O(tau), i.e. by the coarsening defect.
+        assert abs(a - b) < 1e-9 * abs(a) + 1e-13, f'coarse residual differs: {a:.3e} vs {b:.3e}'
+
+
+@pytest.mark.base
+def test_lean_restriction_is_actually_taken():
+    """
+    The saving is only real if the gate lets it through, so check that tau is never built.
+
+    With a right-sided rule and no collocation update -- pySDC's default, and what every example
+    here uses -- nothing reads tau, and a coarse level that still carries one means the gate has
+    silently stopped opening.
+    """
+    from pySDC.implementations.sweeper_classes.delta_form import delta_implicit
+    from pySDC.implementations.transfer_classes.BaseTransferDelta import delta_transfer
+
+    controller = build([127, 63], delta_implicit, delta_transfer)
+    prob = controller.MS[0].levels[0].prob
+    controller.run(u0=prob.u_exact(0.0), t0=0.0, Tend=1e-1)
+
+    coarse = controller.MS[0].levels[1]
+    assert coarse.status.unlocked, 'the coarse level never ran'
+    assert all(t is None for t in coarse.tau), 'tau was built even though nothing reads it'
+
+    # and the gate closes again when the end point comes from the quadrature update, which is the
+    # one place tau is still read
+    with_update = build([127, 63], delta_implicit, delta_transfer, do_coll_update=True)
+    prob = with_update.MS[0].levels[0].prob
+    with_update.run(u0=prob.u_exact(0.0), t0=0.0, Tend=1e-1)
+    assert any(t is not None for t in with_update.MS[0].levels[1].tau), 'tau is needed here and was skipped'

--- a/pySDC/tests/test_transfer_classes/test_BaseTransferDelta.py
+++ b/pySDC/tests/test_transfer_classes/test_BaseTransferDelta.py
@@ -284,3 +284,52 @@ def test_lean_restriction_is_actually_taken():
     prob = with_update.MS[0].levels[0].prob
     with_update.run(u0=prob.u_exact(0.0), t0=0.0, Tend=1e-1)
     assert any(t is not None for t in with_update.MS[0].levels[1].tau), 'tau is needed here and was skipped'
+
+
+@pytest.mark.base
+def test_tau_is_substituted_not_discarded():
+    r"""
+    The control for :func:`test_matches_stock_mlsdc`, and the one that says what is going on.
+
+    This hierarchy never builds the FAS :math:`\tau`, which reads like MLSDC's defining term being
+    thrown away. It is not: :math:`\tau = R(\Delta t\,Q_F f_F) - \Delta t\,Q_G f_G` put into the
+    coarse residual cancels the :math:`\Delta t\,Q_G f_G` terms identically and leaves
+    :math:`R\varepsilon_F`, so a level handed that residual is solving the FAS-corrected problem and
+    would double-count if it added :math:`\tau` as well.
+
+    Agreeing with stock MLSDC proves that only if :math:`\tau` matters on this configuration, so the
+    third row throws it away for real. It does not converge at all.
+    """
+    import numpy as np
+    from pySDC.core.base_transfer import BaseTransfer
+    from pySDC.implementations.sweeper_classes.delta_form import delta_implicit
+    from pySDC.implementations.transfer_classes.BaseTransferDelta import delta_transfer
+
+    sizes = []
+
+    class measuring(BaseTransfer):
+        def restrict(self):
+            super().restrict()
+            sizes.append(max(nrm(t) for t in self.coarse.tau))
+
+    class tau_zeroed(BaseTransfer):
+        """Stock MLSDC with the FAS correction discarded rather than substituted."""
+
+        def restrict(self):
+            super().restrict()
+            for m in range(len(self.coarse.tau)):
+                self.coarse.tau[m] *= 0.0
+
+    stock = floor([127, 63], delta_implicit, measuring, maxiter=25)
+    delta = floor([127, 63], delta_implicit, delta_transfer, maxiter=25)
+    zeroed = floor([127, 63], delta_implicit, tau_zeroed, maxiter=25)
+
+    reference = run([127, 63], delta_implicit, BaseTransfer, maxiter=25)
+    rewritten = run([127, 63], delta_implicit, delta_transfer, maxiter=25)
+
+    # tau is a real correction here, not a rounding-level one
+    assert max(sizes) > 1e-4, f'tau is only {max(sizes):.2e}, so discarding it would prove nothing'
+    assert stock < 1e-12 and delta < 1e-12, f'the converging rows did not converge: {stock:.2e}, {delta:.2e}'
+    assert abs(rewritten - reference) < 1e-13, f'the rewrite moved the answer by {abs(rewritten - reference):.3e}'
+    assert zeroed > 1e-8, f'discarding tau floored at {zeroed:.2e}, so this controls nothing'
+    assert not np.isclose(zeroed, delta), 'discarding tau and substituting it cannot be the same thing'

--- a/pySDC/tests/test_transfer_classes/test_BaseTransferDelta_MPI.py
+++ b/pySDC/tests/test_transfer_classes/test_BaseTransferDelta_MPI.py
@@ -1,0 +1,118 @@
+r"""
+Tests for :mod:`pySDC.implementations.transfer_classes.BaseTransferDeltaMPI`.
+
+One collocation node per rank, so the node-parallel hierarchy has to reproduce the serial one. Both
+identities it rests on become reductions here -- the restricted fine residual and the accumulated
+coarse correction each couple all nodes -- which is the part that can be got wrong without changing
+any answer at backend precision on a single rank.
+
+Follows the launch pattern of ``test_MPI_sweeper.py``: pytest re-executes this module under
+``mpirun``, and the ``__main__`` block below runs the comparison inside it.
+"""
+
+import pytest
+
+SWEEPER_PARAMS = {
+    'quad_type': 'RADAU-RIGHT',
+    'node_type': 'LEGENDRE',
+    'QI': 'MIN-SR-S',  # the node-parallel layout uses only the diagonal of QI, so it has to be one
+    'initial_guess': 'spread',
+    'linear_implicit': True,
+}
+
+HEAT_PARAMS = {
+    'nu': 1.0,
+    'freq': 2,
+    'bc': 'dirichlet-zero',
+    'order': 2,
+    'solver_type': 'direct',
+}
+
+NVARS = [63, 31]
+
+
+def run(use_MPI, num_nodes, stock_hierarchy):
+    """Run a two-level V-cycle and return the end value."""
+    from pySDC.core.base_transfer import BaseTransfer
+    from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
+    from pySDC.implementations.problem_classes.HeatEquation_ND_FD import heatNd_unforced
+    from pySDC.implementations.transfer_classes.TransferMesh import mesh_to_mesh
+
+    sweeper_params = dict(SWEEPER_PARAMS, num_nodes=num_nodes)
+
+    if use_MPI:
+        from mpi4py import MPI
+        from pySDC.implementations.sweeper_classes.delta_form_MPI import delta_implicit_MPI as sweeper_class
+        from pySDC.implementations.transfer_classes.BaseTransferMPI import base_transfer_MPI
+        from pySDC.implementations.transfer_classes.BaseTransferDeltaMPI import delta_transfer_MPI
+
+        sweeper_params['comm'] = MPI.COMM_WORLD
+        transfer_class = base_transfer_MPI if stock_hierarchy else delta_transfer_MPI
+    else:
+        from pySDC.implementations.sweeper_classes.delta_form import delta_implicit as sweeper_class
+        from pySDC.implementations.transfer_classes.BaseTransferDelta import delta_transfer
+
+        transfer_class = BaseTransfer if stock_hierarchy else delta_transfer
+
+    description = {
+        'problem_class': heatNd_unforced,
+        'problem_params': dict(HEAT_PARAMS, nvars=NVARS),
+        'sweeper_class': sweeper_class,
+        'sweeper_params': sweeper_params,
+        'level_params': {'restol': -1, 'dt': 1e-2},
+        'step_params': {'maxiter': 6},
+        'space_transfer_class': mesh_to_mesh,
+        'space_transfer_params': {'iorder': 4, 'rorder': 2},
+        'base_transfer_class': transfer_class,
+    }
+    controller = controller_nonMPI(num_procs=1, controller_params={'logger_level': 30}, description=description)
+    prob = controller.MS[0].levels[0].prob
+    uend, _ = controller.run(u0=prob.u_exact(0.0), t0=0.0, Tend=2e-2)
+    return uend
+
+
+def individual_test(num_nodes, launch=False):
+    """Compare the node-parallel delta hierarchy against the serial one, or launch mpirun to do so."""
+    if launch:
+        import os
+        import subprocess
+
+        my_env = os.environ.copy()
+        my_env['PYTHONPATH'] = '../../..:.'
+        my_env['COVERAGE_PROCESS_START'] = 'pyproject.toml'
+
+        cmd = f'mpirun -np {num_nodes} python {__file__} --num_nodes={num_nodes}'
+        p = subprocess.Popen(cmd.split(), env=my_env, cwd='.')
+        p.wait()
+        assert p.returncode == 0, f'got return code {p.returncode} with {num_nodes} processes'
+        return
+
+    parallel = run(True, num_nodes, stock_hierarchy=False)
+    serial = run(False, num_nodes, stock_hierarchy=False)
+    stock = run(True, num_nodes, stock_hierarchy=True)
+
+    assert (
+        abs(parallel - serial) < 1e-13
+    ), f'node-parallel and serial delta hierarchy disagree by {abs(parallel - serial):.3e}'
+    # and against the stock node-parallel hierarchy, which is what says the two identities hold
+    # in their reduced form rather than merely agreeing with each other
+    assert abs(parallel - stock) < 1e-13, f'the delta hierarchy moved the answer by {abs(parallel - stock):.3e}'
+
+
+@pytest.mark.mpi4py
+@pytest.mark.parametrize('num_nodes', [2, 3])
+def test_matches_the_serial_and_the_stock_hierarchy(num_nodes):
+    """
+    The reduced identities have to give what the serial loops give, and what stock MLSDC gives.
+
+    Comparing only against the serial delta hierarchy would pass if both were wrong the same way,
+    which is why the stock node-parallel hierarchy is the third leg.
+    """
+    individual_test(num_nodes, launch=True)
+
+
+if __name__ == '__main__':
+    import sys
+
+    kwargs = dict(arg.removeprefix('--').split('=') for arg in sys.argv[1:])
+    individual_test(num_nodes=int(kwargs['num_nodes']))


### PR DESCRIPTION
Follows #687, which put the sweep in delta form. This does the same to the **hierarchy**.

`BaseTransfer` makes a coarse level rebuild its own residual out of `O(1)` coarse data,

```
eps_G = dt(Q_G f_G) + u_G[0] - u_G[m] + tau
```

and recovers the coarse-grid correction as `u_G - u_G_old`. Both are differences of `O(1)`
quantities. Both have exact algebraic replacements:

```
eps_G = R eps_F                    u_G - u_G_old = sum over sweeps of delta_G
```

## The FAS tau is substituted, not discarded

This is the part worth reading carefully, because "tau is never built" sounds like MLSDC's defining
term being thrown away. With `tau = R(dt Q_F f_F) - dt Q_G f_G`, substituting into the coarse
residual cancels the `dt Q_G f_G` terms **identically**:

```
eps_G[m] = dt(Q_G f_G)_m + R u_F[0] - R u_F[m+1] + R(dt Q_F f_F)_m - dt(Q_G f_G)_m
         = R( u_F[0] + dt(Q_F f_F)_m - u_F[m+1] )
         = R eps_F[m]
```

So a coarse level handed `R eps_F` is solving precisely the FAS-corrected problem — and must *not*
also add `tau`, which would count it twice. What is skipped is materialising `tau` as an array,
since the quantity it exists to produce arrives directly. That is what makes the restriction cheaper.

`test_tau_is_substituted_not_discarded` holds this to the standard: agreeing with stock MLSDC only
means something if `tau` matters here, so it measures it and adds a row that discards it for real.

| | iterations | vs stock |
|---|---|---|
| stock MLSDC, `tau` built and used | 7 | — |
| delta hierarchy, `tau` never built | 7 | **2.6e-16** |
| CONTROL: stock MLSDC, `tau` zeroed | **50** (maxiter) | **3.1e-06 wrong** |

`tau` is 2.4e-03 against a solution of ~0.02 — about 12% of `u`. Discarding it collapses MLSDC.

The one genuine remaining reader is `compute_end_point` when `do_coll_update=True`, which is a
*different* use — the quadrature update for `uend`, not the residual — and no identity removes it.
That is what `coarse_reads_tau()` gates, tested in both directions.

## The rest

The residual travels with the level: a sweep advances it by `eps <- eps - delta + dt (Q df)`, and so
does a prolongation, with `delta` the interpolated coarse correction. Both combine only small
quantities — which is what lets a middle level be swept again on the way up without rebuilding an
`O(1)` residual.

**No sweeper changes.** `delta_form` already does both; which one happens is decided by the transfer
it is given. `BaseTransfer` hands nothing down and every level rebuilds its own residual, as today.

And every coarse-level quantity becomes proportional to the fine residual rather than to `|u|`, so a
coarse level can run below backend precision without capping accuracy. That needs controls that must
break, so it is measured separately, not here.

## Tests

The first three check the identities against the quantities they replace — the inherited residual
against one rebuilt the stock way, the accumulated correction against `u_G - u_G_old`, and the
recursion against a residual recomputed from scratch after every sweep *and* every prolongation. The
rest check that using them changes no answer: against `BaseTransfer` at two, three and four levels
and under PFASST on 2 and 4 steps, that the coarse level still reports the FAS residual it tracks
(only ever logged, so nothing else would catch it), and that `tau` really is skipped.

Four more under `mpirun` for the node-parallel counterpart, where both identities become reductions
over ranks — the part that can be wrong without changing any answer on a single rank. Poison-tested:
a wrong reduce root in either direction, a scaled handed-down residual and a dropped prolonged
correction are all caught.

3364 base tests pass. New files verified on numpy 1.26.4 and 2.4.6. Purely additive — no existing
file is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)