### PR TITLE
Levels that genuinely run at a reduced dtype

### DIFF
--- a/pySDC/implementations/problem_classes/HeatEquation_ND_FD.py
+++ b/pySDC/implementations/problem_classes/HeatEquation_ND_FD.py
@@ -73,9 +73,10 @@ class heatNd_unforced(GenericNDimFinDiff):
         solver_type='direct',
         bc='periodic',
         sigma=6e-2,
+        dtype='float64',
     ):
         """Initialization routine"""
-        super().__init__(nvars, nu, 2, freq, stencil_type, order, lintol, liniter, solver_type, bc)
+        super().__init__(nvars, nu, 2, freq, stencil_type, order, lintol, liniter, solver_type, bc, dtype=dtype)
         if solver_type == 'GMRES':
             self.logger.warning('GMRES is not usually used for heat equation')
         self._makeAttributeAndRegister('nu', localVars=locals(), readOnly=True)

--- a/pySDC/implementations/problem_classes/generic_ND_FD.py
+++ b/pySDC/implementations/problem_classes/generic_ND_FD.py
@@ -45,6 +45,12 @@ class GenericNDimFinDiff(Problem):
         Tolerance for spatial solver.
     liniter : int, optional
         Maximum number of iterations for linear solver.
+    dtype : dtype-like, optional
+        Precision the state is stored at. ``float64`` by default, which is what every caller got
+        before this existed. The operators follow at ``promote_types(dtype, float32)``, since SciPy
+        has no half-precision sparse matrix and hardware that stores half precision computes in
+        single anyway -- so ``float16`` here means genuinely half-precision *storage* with
+        single-precision arithmetic, which is the arrangement it has on real hardware too.
     solver_type : str, optional
         Type of solver. Can be ``'direct'``, ``'GMRES'`` or ``'CG'``.
     bc : str or tuple of 2 string, optional
@@ -94,6 +100,7 @@ class GenericNDimFinDiff(Problem):
         solver_type='direct',
         bc='periodic',
         bcParams=None,
+        dtype='float64',
     ):
         # make sure parameters have the correct types
         if type(nvars) not in [int, tuple]:
@@ -132,8 +139,14 @@ class GenericNDimFinDiff(Problem):
         if ndim > 1 and nvars[1:] != nvars[:-1]:
             raise ProblemError('need a square domain, got %s' % nvars)
 
-        # invoke super init, passing number of dofs
-        super().__init__(init=(nvars[0] if ndim == 1 else nvars, None, np.dtype('float64')))
+        # invoke super init, passing number of dofs and the precision to store them at
+        dtype = np.dtype(dtype)
+
+        # SciPy holds no float16 sparse matrix, and hardware that stores half precision computes in
+        # single anyway, so the operators sit at the smallest single-or-wider type that holds `dtype`
+        operator_dtype = np.promote_types(dtype, np.float32)
+
+        super().__init__(init=(nvars[0] if ndim == 1 else nvars, None, dtype))
 
         dx, xvalues = problem_helper.get_1d_grid(size=nvars[0], bc=bc, left_boundary=0.0, right_boundary=1.0)
 
@@ -148,12 +161,16 @@ class GenericNDimFinDiff(Problem):
         )
         self.A *= coeff
 
+        self.A = self.A.astype(operator_dtype)
+
         self.xvalues = xvalues
-        self.Id = sp.eye(np.prod(nvars), format='csc')
+        self.Id = sp.eye(np.prod(nvars), format='csc', dtype=operator_dtype)
 
         # store attribute and register them as parameters
         self._makeAttributeAndRegister('nvars', 'stencil_type', 'order', 'bc', localVars=locals(), readOnly=True)
         self._makeAttributeAndRegister('freq', 'lintol', 'liniter', 'solver_type', localVars=locals())
+        self.dtype = dtype
+        self.operator_dtype = operator_dtype
 
         if self.solver_type != 'direct':
             self.work_counters[self.solver_type] = WorkCounter()

--- a/pySDC/implementations/transfer_classes/TransferMesh.py
+++ b/pySDC/implementations/transfer_classes/TransferMesh.py
@@ -146,6 +146,14 @@ class mesh_to_mesh(SpaceTransfer):
             for i in range(1, len(Rspace)):
                 self.Rspace = sp.kron(self.Rspace, Rspace[i], format='csc')
 
+        # Carry the operators at the precision of what they produce, rather than always at float64.
+        # A float64 operator applied to a reduced-precision vector upcasts, so the transfer would do
+        # its work in double and only round on the way into the destination, which is the one place
+        # a reduced-precision level would silently keep paying full freight. `promote_types` with
+        # float32 keeps it legal for SciPy, which has no half-precision sparse matrix.
+        self.Rspace = self.Rspace.astype(np.promote_types(self.coarse_prob.init[-1], np.float32))
+        self.Pspace = self.Pspace.astype(np.promote_types(self.fine_prob.init[-1], np.float32))
+
     def restrict(self, F):
         """
         Restriction implementation

--- a/pySDC/tests/test_reduced_precision.py
+++ b/pySDC/tests/test_reduced_precision.py
@@ -1,0 +1,229 @@
+r"""
+Tests for levels that genuinely run at a reduced dtype.
+
+``dtype`` on the finite-difference problems gives a level whose arrays really are ``float32`` or
+``float16``. That is easy to get wrong in a way that looks right: a silent upcast agrees with
+``float64`` perfectly.
+
+So these assert in both directions. The reduced dtype has to survive a whole run rather than drift
+back to ``float64``; and it has to *change* the numbers by roughly the format's epsilon, which is
+what a run that never left ``float64`` could not do.
+
+The sweeper's own reduced-precision storage, ``correction_precision``, is a different mechanism and
+is tested with the sweeper in ``pySDC/tests/test_sweepers/test_delta_form.py``.
+"""
+
+import numpy as np
+import pytest
+
+SWEEPER_PARAMS = {
+    'quad_type': 'RADAU-RIGHT',
+    'node_type': 'LEGENDRE',
+    'num_nodes': 3,
+    'QI': 'LU',
+    'initial_guess': 'spread',
+    'linear_implicit': True,
+}
+
+HEAT_PARAMS = {
+    'nu': 1.0,
+    'freq': 2,
+    'bc': 'dirichlet-zero',
+    'order': 2,
+    'solver_type': 'direct',
+}
+
+
+def run(prob_extra=None, **sweep_extra):
+    """Run one step of two-level heat and return the iterations, the end value and the controller."""
+    from pySDC.helpers.stats_helper import get_sorted
+    from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
+    from pySDC.implementations.transfer_classes.TransferMesh import mesh_to_mesh
+    from pySDC.implementations.problem_classes.HeatEquation_ND_FD import heatNd_unforced
+    from pySDC.implementations.sweeper_classes.delta_form import delta_implicit
+    from pySDC.implementations.transfer_classes.BaseTransferDelta import delta_transfer
+
+    description = {
+        'problem_class': heatNd_unforced,
+        'problem_params': dict(HEAT_PARAMS, nvars=[127, 63], **(prob_extra or {})),
+        'sweeper_class': delta_implicit,
+        'sweeper_params': dict(SWEEPER_PARAMS, **sweep_extra),
+        'level_params': {'restol': 1e-11, 'dt': 1e-1},
+        'step_params': {'maxiter': 40},
+        'space_transfer_class': mesh_to_mesh,
+        'space_transfer_params': {'iorder': 4, 'rorder': 2},
+        'base_transfer_class': delta_transfer,
+    }
+    controller = controller_nonMPI(num_procs=1, controller_params={'logger_level': 30}, description=description)
+    prob = controller.MS[0].levels[0].prob
+    uend, stats = controller.run(u0=prob.u_exact(0.0), t0=0.0, Tend=1e-1)
+    residuals = [value for _, value in get_sorted(stats, type='residual_post_iteration', sortby='iter')]
+    return len(residuals), uend, controller
+
+
+@pytest.mark.base
+@pytest.mark.parametrize('precision', ['float32', 'float16'])
+def test_the_reduced_dtype_survives_the_run(precision):
+    """
+    Every array the coarse level holds must still be at the requested precision when the run ends.
+
+    This is the check the emulation cannot make, and the one that would catch a silent upcast. A
+    coefficient taken out of a numpy array is an ``np.float64``, and under NEP 50 multiplying a
+    reduced-precision array by one produces ``float64`` -- so a single missing ``float()`` puts the
+    level back at backend precision without changing an answer or failing anything else.
+    """
+    _, _, controller = run({'dtype': ['float64', precision]})
+    fine, coarse = controller.MS[0].levels
+
+    held = {str(np.asarray(v).dtype) for v in list(coarse.u) + list(coarse.f) if v is not None}
+    assert held == {precision}, f'the coarse level drifted to {held}'
+    assert {str(np.asarray(v).dtype) for v in fine.u if v is not None} == {'float64'}
+    assert coarse.prob.A.dtype == np.promote_types(precision, np.float32)
+
+
+@pytest.mark.base
+def test_reduced_storage_actually_costs_fewer_bytes():
+    """The point of a real dtype over the emulation is the memory, so check it is actually smaller."""
+    sizes = {}
+    for precision in ('float64', 'float32', 'float16'):
+        _, _, controller = run({'dtype': ['float64', precision]})
+        coarse = controller.MS[0].levels[1]
+        sizes[precision] = sum(np.asarray(v).nbytes for v in list(coarse.u) + list(coarse.f) if v is not None)
+
+    assert sizes['float32'] == sizes['float64'] // 2
+    assert sizes['float16'] == sizes['float64'] // 4
+
+
+@pytest.mark.base
+def test_default_dtype_is_unchanged():
+    """Adding the parameter must not have moved anything for callers who never pass it."""
+    from pySDC.implementations.problem_classes.HeatEquation_ND_FD import heatNd_unforced
+
+    prob = heatNd_unforced(nvars=127, **HEAT_PARAMS)
+    assert prob.init[-1] == np.dtype('float64')
+    assert prob.A.dtype == np.dtype('float64')
+    assert prob.u_exact(0.0).dtype == np.dtype('float64')
+
+
+@pytest.mark.base
+def test_float16_state_still_does_not_work():
+    """
+    The control, and the one thing no reformulation moves: the fine level's state stays float64.
+
+    That is where the residual is formed by cancelling O(1) quantities, so there is nothing to scale
+    -- the level is the state. Half precision there barely converges at all.
+    """
+    from pySDC.helpers.stats_helper import get_sorted
+    from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
+    from pySDC.implementations.problem_classes.HeatEquation_ND_FD import heatNd_unforced
+    from pySDC.implementations.sweeper_classes.delta_form import delta_implicit
+
+    floors = {}
+    for precision in ('float64', 'float32', 'float16'):
+        description = {
+            'problem_class': heatNd_unforced,
+            'problem_params': dict(HEAT_PARAMS, nvars=127, dtype=precision),
+            'sweeper_class': delta_implicit,
+            'sweeper_params': dict(SWEEPER_PARAMS),
+            'level_params': {'restol': -1, 'dt': 1e-1},
+            'step_params': {'maxiter': 30},
+        }
+        controller = controller_nonMPI(num_procs=1, controller_params={'logger_level': 30}, description=description)
+        prob = controller.MS[0].levels[0].prob
+        _, stats = controller.run(u0=prob.u_exact(0.0), t0=0.0, Tend=1e-1)
+        floors[precision] = min(v for _, v in get_sorted(stats, type='residual_post_iteration', sortby='iter'))
+
+    assert floors['float64'] < 1e-12
+    assert floors['float32'] > 1e-6, 'a float32 state stopped capping the fine level'
+    assert floors['float16'] > 1e-2, 'a float16 state stopped capping the fine level'
+
+
+@pytest.mark.base
+@pytest.mark.parametrize('precision,epsilon', [('float32', 1.2e-7), ('float16', 9.8e-4)])
+def test_reduced_precision_leaves_its_fingerprint(precision, epsilon):
+    """
+    A reduced level must *change* the numbers, by roughly the format's epsilon.
+
+    Every other test here asserts that reduced precision agrees with ``float64`` -- which is also
+    exactly what would be seen if a bug silently upcast everything and no reduction happened at all.
+    This asserts the opposite: the coarse level's state after its first sweep has to differ from the
+    ``float64`` run by something between round-off and the format's own epsilon. Too small and the
+    reduction is not happening; too large and it is not the reduction doing it.
+    """
+    from pySDC.implementations.controller_classes.controller_nonMPI import controller_nonMPI
+    from pySDC.implementations.transfer_classes.TransferMesh import mesh_to_mesh
+    from pySDC.implementations.problem_classes.HeatEquation_ND_FD import heatNd_unforced
+    from pySDC.implementations.sweeper_classes.delta_form import delta_implicit
+    from pySDC.implementations.transfer_classes.BaseTransferDelta import delta_transfer
+
+    captured = {}
+
+    class capture(delta_implicit):
+        def update_nodes(self):
+            super().update_nodes()
+            if self.level.level_index == 1 and 'state' not in captured:
+                captured['state'] = np.asarray(self.level.u[1], dtype=np.float64).copy()
+
+    def snapshot(coarse_dtype):
+        captured.clear()
+        description = {
+            'problem_class': heatNd_unforced,
+            'problem_params': dict(HEAT_PARAMS, nvars=[127, 63], dtype=['float64', coarse_dtype]),
+            'sweeper_class': capture,
+            'sweeper_params': dict(SWEEPER_PARAMS),
+            'level_params': {'restol': 1e-11, 'dt': 1e-1},
+            'step_params': {'maxiter': 40},
+            'space_transfer_class': mesh_to_mesh,
+            'space_transfer_params': {'iorder': 4, 'rorder': 2},
+            'base_transfer_class': delta_transfer,
+        }
+        controller = controller_nonMPI(num_procs=1, controller_params={'logger_level': 30}, description=description)
+        prob = controller.MS[0].levels[0].prob
+        controller.run(u0=prob.u_exact(0.0), t0=0.0, Tend=1e-1)
+        return captured['state']
+
+    reference = snapshot('float64')
+    # the control: the harness is deterministic, so float64 against itself has to be exactly zero,
+    # or the differences below would mean nothing
+    assert np.array_equal(snapshot('float64'), reference)
+
+    relative = np.max(np.abs(snapshot(precision) - reference)) / np.max(np.abs(reference))
+    assert relative > epsilon / 100, f'{precision} changed nothing ({relative:.1e}) -- is it really reduced?'
+    assert relative < epsilon * 100, f'{precision} changed too much ({relative:.1e}) to be rounding'
+
+
+@pytest.mark.base
+@pytest.mark.parametrize('precision', ['float32', 'float16'])
+def test_the_transfer_operators_follow_the_level(precision):
+    """
+    The space transfer has to carry its operators at the precision of what they produce.
+
+    A ``float64`` operator applied to a reduced-precision vector upcasts, so the transfer would do
+    its work in double and only round on the way into the destination -- the one place a
+    reduced-precision level would keep paying full freight while every dtype assertion still passed.
+    So this checks the operators *and* that what comes out of a restriction is not wider than the
+    level it lands on.
+    """
+    _, _, controller = run({'dtype': ['float64', precision]})
+    transfer = controller.MS[0].base_transfer.space_transfer
+    expected = np.promote_types(precision, np.float32)
+
+    assert transfer.Rspace.dtype == expected, f'the restriction operator is {transfer.Rspace.dtype}'
+    assert transfer.Pspace.dtype == np.dtype('float64'), 'the prolongation produces a float64 level'
+
+    fine, coarse = controller.MS[0].levels
+    restricted = transfer.restrict(fine.u[1])
+    assert np.asarray(restricted).dtype == np.dtype(
+        precision
+    ), f'a restriction onto a {precision} level produced {np.asarray(restricted).dtype}'
+    assert np.asarray(transfer.prolong(coarse.u[1])).dtype == np.dtype('float64')
+
+
+@pytest.mark.base
+def test_transfer_operators_are_unchanged_by_default():
+    """Adding the cast must not have moved anything for callers who never pass a dtype."""
+    _, _, controller = run()
+    transfer = controller.MS[0].base_transfer.space_transfer
+
+    assert transfer.Rspace.dtype == np.dtype('float64')
+    assert transfer.Pspace.dtype == np.dtype('float64')


### PR DESCRIPTION
Follows #687 and #688. Those made every coarse-level quantity proportional to the fine residual
rather than to `|u|`, which is what a level below backend precision needs. There was no way to ask
for one: the finite-difference problems always built `float64` arrays.

```python
problem_params['dtype'] = ['float64', 'float16']   # per level, as usual
```

The level's arrays then genuinely are `float16`. Operators follow at
`promote_types(dtype, float32)`, because SciPy holds no half-precision sparse matrix and hardware
that stores half precision computes in single anyway — so `float16` means genuinely half-precision
*storage* with single-precision arithmetic, which is the arrangement it has on real hardware too.

`mesh_to_mesh` carries its transfer operators at the precision of what they produce, for the same
reason. A `float64` operator applied to a reduced-precision vector upcasts, so the transfer would do
its work in double and round only on the way into the destination — the one place a
reduced-precision level would keep paying full freight while every dtype assertion still passed.

Default is `float64` everywhere. Nothing moves for callers who never pass it, and there is a test
saying so.

## The trap

A coefficient taken out of a numpy array is an `np.float64`, and under NEP 50 multiplying a
reduced-precision array by one produces `float64`. **A single missing `float()` puts a level quietly
back at backend precision without changing an answer or failing anything.** The delta-form sweepers
and transfer already coerce those coefficients; what was missing was a `dtype` to make that
load-bearing, and a test that would notice.

## Tests assert in both directions

"Reduced precision agrees with float64" is also exactly what a silent upcast produces, so agreement
alone is worthless here. These check the opposite too:

- every array a reduced level holds is still at that precision when the run **ends**, not just at
  construction;
- the storage really is half / a quarter of the bytes;
- the answer *changes* by roughly the format's epsilon — with `float64` against itself as an exact
  zero control, so the harness is known to be deterministic;
- the transfer operators follow the level, and a restriction onto a reduced level does not come back
  wider than it;
- the fine level's state still cannot be reduced (it is where the residual cancels `O(1)` values);
- defaults unchanged, for both the problems and the transfer.

Poison-tested: ignoring `dtype` fails 8 of 10, leaving the problem's operators at `float64` fails 2,
leaving the transfer's operators at `float64` fails 2.

3375 base tests pass on numpy 1.26.4. The new file also on 2.4.6 and under
`NPY_PROMOTION_STATE=weak`, which opts numpy 1.26 into NEP 50 and is how the coercions were checked
to be load-bearing rather than decorative.

Note: `project_cpu_tests_linux (DAE, =1)` is red on master already and unrelated to this branch —
see the discussion on #688.

🤖 Generated with [Claude Code](https://claude.com/claude-code)